### PR TITLE
feat: Add One-Class RSLVQ with Neural Gas cooperation

### DIFF
--- a/examples/oc_lmrslvq_iris.py
+++ b/examples/oc_lmrslvq_iris.py
@@ -1,0 +1,67 @@
+"""
+One-Class Localized Matrix RSLVQ (OC-LMRSLVQ) example using Iris Data with JAX.
+
+This example demonstrates:
+- One-class classification with per-prototype Omega matrices
+- Probabilistic soft-weighting of all prototypes via Gaussian mixture
+- Local metric adaptation for novelty detection
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.models import OCLMRSLVQ
+
+# Load data — treat class 0 as target, rest as outliers
+dataset = load_iris_jax()
+X, y_raw = dataset.input_data, dataset.labels
+y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+print(f"Dataset: {X.shape}")
+print(f"Target (class 0): {int(jnp.sum(y == 0))}, Outlier: {int(jnp.sum(y == 1))}")
+
+# Setup OC-LMRSLVQ model
+model = OCLMRSLVQ(
+    sigma=1.0,
+    n_prototypes=3,
+    max_iter=100,
+    lr=0.01,
+    target_label=0,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining OC-LMRSLVQ...")
+model.fit(X, y)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Loss decreased: {model.loss_history_[0]:.4f} -> {model.loss_history_[-1]:.4f}")
+
+# Predictions
+preds = model.predict(X)
+target_acc = float(jnp.mean(preds[y == 0] == 0))
+outlier_acc = float(jnp.mean(preds[y == 1] == 1))
+overall_acc = float(jnp.mean(preds == y))
+
+print(f"\nTarget accuracy:  {target_acc:.2%}")
+print(f"Outlier accuracy: {outlier_acc:.2%}")
+print(f"Overall accuracy: {overall_acc:.2%}")
+
+# Decision scores
+scores = model.decision_function(X)
+mean_target = float(jnp.mean(scores[y == 0]))
+mean_outlier = float(jnp.mean(scores[y == 1]))
+print(f"\nMean target score:  {mean_target:.4f}")
+print(f"Mean outlier score: {mean_outlier:.4f}")
+
+# Per-prototype Omega matrices
+print(f"\nLocal omegas shape: {model.omegas_.shape}")
+print(f"Thetas: {model.thetas_}")
+
+# Predict with reject option
+preds_reject = model.predict_with_reject(X, upper=0.7, lower=0.3)
+n_accepted = int(jnp.sum(preds_reject == 0))
+n_rejected = int(jnp.sum(preds_reject == 1))
+n_uncertain = int(jnp.sum(preds_reject == -1))
+print(f"\nWith reject option: accepted={n_accepted}, rejected={n_rejected}, uncertain={n_uncertain}")

--- a/examples/oc_lmrslvq_ng_iris.py
+++ b/examples/oc_lmrslvq_ng_iris.py
@@ -1,0 +1,65 @@
+"""
+One-Class Local Matrix RSLVQ with Neural Gas (OC-LMRSLVQ-NG) example using Iris Data.
+
+This example demonstrates:
+- One-class classification with per-prototype Omega_k metric adaptation
+- Combined Gaussian soft-assignment and NG rank-based cooperation
+- Independently learned projection matrices per prototype
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.models import OCLMRSLVQ_NG
+
+# Load data — treat class 0 as target, rest as outliers
+dataset = load_iris_jax()
+X, y_raw = dataset.input_data, dataset.labels
+y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+print(f"Dataset: {X.shape}")
+print(f"Target (class 0): {int(jnp.sum(y == 0))}, Outlier: {int(jnp.sum(y == 1))}")
+
+# Setup OC-LMRSLVQ-NG model
+model = OCLMRSLVQ_NG(
+    sigma=1.0,
+    latent_dim=2,
+    n_prototypes=3,
+    max_iter=100,
+    lr=0.01,
+    target_label=0,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining OC-LMRSLVQ-NG...")
+model.fit(X, y)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+print(f"Omegas shape: {model.omegas_.shape}")
+
+# Predictions
+preds = model.predict(X)
+target_acc = float(jnp.mean(preds[y == 0] == 0))
+outlier_acc = float(jnp.mean(preds[y == 1] == 1))
+overall_acc = float(jnp.mean(preds == y))
+
+print(f"\nTarget accuracy:  {target_acc:.2%}")
+print(f"Outlier accuracy: {outlier_acc:.2%}")
+print(f"Overall accuracy: {overall_acc:.2%}")
+
+# Decision scores
+scores = model.decision_function(X)
+mean_target = float(jnp.mean(scores[y == 0]))
+mean_outlier = float(jnp.mean(scores[y == 1]))
+print(f"\nMean target score:  {mean_target:.4f}")
+print(f"Mean outlier score: {mean_outlier:.4f}")
+
+# Predict with reject option
+preds_reject = model.predict_with_reject(X, upper=0.7, lower=0.3)
+n_accepted = int(jnp.sum(preds_reject == 0))
+n_rejected = int(jnp.sum(preds_reject == 1))
+n_uncertain = int(jnp.sum(preds_reject == -1))
+print(f"\nWith reject option: accepted={n_accepted}, rejected={n_rejected}, uncertain={n_uncertain}")

--- a/examples/oc_mrslvq_iris.py
+++ b/examples/oc_mrslvq_iris.py
@@ -1,0 +1,67 @@
+"""
+One-Class Matrix RSLVQ (OC-MRSLVQ) example using Iris Data with JAX.
+
+This example demonstrates:
+- One-class classification with learned Omega metric adaptation
+- Probabilistic soft-weighting of all prototypes via Gaussian mixture
+- Threshold-based novelty detection with omega-projected distances
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.models import OCMRSLVQ
+
+# Load data — treat class 0 as target, rest as outliers
+dataset = load_iris_jax()
+X, y_raw = dataset.input_data, dataset.labels
+y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+print(f"Dataset: {X.shape}")
+print(f"Target (class 0): {int(jnp.sum(y == 0))}, Outlier: {int(jnp.sum(y == 1))}")
+
+# Setup OC-MRSLVQ model
+model = OCMRSLVQ(
+    sigma=1.0,
+    n_prototypes=3,
+    max_iter=100,
+    lr=0.01,
+    target_label=0,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining OC-MRSLVQ...")
+model.fit(X, y)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Loss decreased: {model.loss_history_[0]:.4f} -> {model.loss_history_[-1]:.4f}")
+
+# Predictions
+preds = model.predict(X)
+target_acc = float(jnp.mean(preds[y == 0] == 0))
+outlier_acc = float(jnp.mean(preds[y == 1] == 1))
+overall_acc = float(jnp.mean(preds == y))
+
+print(f"\nTarget accuracy:  {target_acc:.2%}")
+print(f"Outlier accuracy: {outlier_acc:.2%}")
+print(f"Overall accuracy: {overall_acc:.2%}")
+
+# Decision scores
+scores = model.decision_function(X)
+mean_target = float(jnp.mean(scores[y == 0]))
+mean_outlier = float(jnp.mean(scores[y == 1]))
+print(f"\nMean target score:  {mean_target:.4f}")
+print(f"Mean outlier score: {mean_outlier:.4f}")
+
+# Omega matrix
+print(f"\nOmega shape: {model.omega_matrix.shape}")
+print(f"Lambda (relevance matrix):\n{model.lambda_matrix}")
+
+# Predict with reject option
+preds_reject = model.predict_with_reject(X, upper=0.7, lower=0.3)
+n_accepted = int(jnp.sum(preds_reject == 0))
+n_rejected = int(jnp.sum(preds_reject == 1))
+n_uncertain = int(jnp.sum(preds_reject == -1))
+print(f"\nWith reject option: accepted={n_accepted}, rejected={n_rejected}, uncertain={n_uncertain}")

--- a/examples/oc_mrslvq_ng_iris.py
+++ b/examples/oc_mrslvq_ng_iris.py
@@ -1,0 +1,66 @@
+"""
+One-Class Matrix RSLVQ with Neural Gas (OC-MRSLVQ-NG) example using Iris Data.
+
+This example demonstrates:
+- One-class classification with global Omega metric adaptation
+- Combined Gaussian soft-assignment and NG rank-based cooperation
+- Learned projection matrix for adaptive distance metric
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.models import OCMRSLVQ_NG
+
+# Load data — treat class 0 as target, rest as outliers
+dataset = load_iris_jax()
+X, y_raw = dataset.input_data, dataset.labels
+y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+print(f"Dataset: {X.shape}")
+print(f"Target (class 0): {int(jnp.sum(y == 0))}, Outlier: {int(jnp.sum(y == 1))}")
+
+# Setup OC-MRSLVQ-NG model
+model = OCMRSLVQ_NG(
+    sigma=1.0,
+    latent_dim=2,
+    n_prototypes=3,
+    max_iter=100,
+    lr=0.01,
+    target_label=0,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining OC-MRSLVQ-NG...")
+model.fit(X, y)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+print(f"Omega shape: {model.omega_matrix.shape}")
+print(f"Lambda shape: {model.lambda_matrix.shape}")
+
+# Predictions
+preds = model.predict(X)
+target_acc = float(jnp.mean(preds[y == 0] == 0))
+outlier_acc = float(jnp.mean(preds[y == 1] == 1))
+overall_acc = float(jnp.mean(preds == y))
+
+print(f"\nTarget accuracy:  {target_acc:.2%}")
+print(f"Outlier accuracy: {outlier_acc:.2%}")
+print(f"Overall accuracy: {overall_acc:.2%}")
+
+# Decision scores
+scores = model.decision_function(X)
+mean_target = float(jnp.mean(scores[y == 0]))
+mean_outlier = float(jnp.mean(scores[y == 1]))
+print(f"\nMean target score:  {mean_target:.4f}")
+print(f"Mean outlier score: {mean_outlier:.4f}")
+
+# Predict with reject option
+preds_reject = model.predict_with_reject(X, upper=0.7, lower=0.3)
+n_accepted = int(jnp.sum(preds_reject == 0))
+n_rejected = int(jnp.sum(preds_reject == 1))
+n_uncertain = int(jnp.sum(preds_reject == -1))
+print(f"\nWith reject option: accepted={n_accepted}, rejected={n_rejected}, uncertain={n_uncertain}")

--- a/examples/oc_rslvq_iris.py
+++ b/examples/oc_rslvq_iris.py
@@ -1,0 +1,63 @@
+"""
+One-Class Robust Soft LVQ (OC-RSLVQ) example using Iris Data with JAX.
+
+This example demonstrates:
+- One-class classification with soft Gaussian mixture responsibilities
+- Euclidean distance with probabilistic weighting of all prototypes
+- Threshold-based novelty detection without metric adaptation
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.models import OCRSLVQ
+
+# Load data — treat class 0 as target, rest as outliers
+dataset = load_iris_jax()
+X, y_raw = dataset.input_data, dataset.labels
+y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+print(f"Dataset: {X.shape}")
+print(f"Target (class 0): {int(jnp.sum(y == 0))}, Outlier: {int(jnp.sum(y == 1))}")
+
+# Setup OC-RSLVQ model
+model = OCRSLVQ(
+    sigma=1.0,
+    n_prototypes=3,
+    max_iter=100,
+    lr=0.01,
+    target_label=0,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining OC-RSLVQ...")
+model.fit(X, y)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Loss decreased: {model.loss_history_[0]:.4f} -> {model.loss_history_[-1]:.4f}")
+
+# Predictions
+preds = model.predict(X)
+target_acc = float(jnp.mean(preds[y == 0] == 0))
+outlier_acc = float(jnp.mean(preds[y == 1] == 1))
+overall_acc = float(jnp.mean(preds == y))
+
+print(f"\nTarget accuracy:  {target_acc:.2%}")
+print(f"Outlier accuracy: {outlier_acc:.2%}")
+print(f"Overall accuracy: {overall_acc:.2%}")
+
+# Decision scores
+scores = model.decision_function(X)
+mean_target = float(jnp.mean(scores[y == 0]))
+mean_outlier = float(jnp.mean(scores[y == 1]))
+print(f"\nMean target score:  {mean_target:.4f}")
+print(f"Mean outlier score: {mean_outlier:.4f}")
+
+# Predict with reject option
+preds_reject = model.predict_with_reject(X, upper=0.7, lower=0.3)
+n_accepted = int(jnp.sum(preds_reject == 0))
+n_rejected = int(jnp.sum(preds_reject == 1))
+n_uncertain = int(jnp.sum(preds_reject == -1))
+print(f"\nWith reject option: accepted={n_accepted}, rejected={n_rejected}, uncertain={n_uncertain}")

--- a/examples/oc_rslvq_ng_iris.py
+++ b/examples/oc_rslvq_ng_iris.py
@@ -1,0 +1,65 @@
+"""
+One-Class RSLVQ with Neural Gas (OC-RSLVQ-NG) example using Iris Data.
+
+This example demonstrates:
+- One-class classification with combined Gaussian soft-assignment and
+  Neural Gas rank-based neighborhood cooperation
+- Euclidean distance with probabilistic + topological weighting
+- Gamma decay from broad to sharp neighborhood during training
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.models import OCRSLVQ_NG
+
+# Load data — treat class 0 as target, rest as outliers
+dataset = load_iris_jax()
+X, y_raw = dataset.input_data, dataset.labels
+y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+print(f"Dataset: {X.shape}")
+print(f"Target (class 0): {int(jnp.sum(y == 0))}, Outlier: {int(jnp.sum(y == 1))}")
+
+# Setup OC-RSLVQ-NG model
+model = OCRSLVQ_NG(
+    sigma=1.0,
+    n_prototypes=3,
+    max_iter=100,
+    lr=0.01,
+    target_label=0,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining OC-RSLVQ-NG...")
+model.fit(X, y)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+print(f"Loss: {model.loss_history_[0]:.4f} -> {model.loss_history_[-1]:.4f}")
+
+# Predictions
+preds = model.predict(X)
+target_acc = float(jnp.mean(preds[y == 0] == 0))
+outlier_acc = float(jnp.mean(preds[y == 1] == 1))
+overall_acc = float(jnp.mean(preds == y))
+
+print(f"\nTarget accuracy:  {target_acc:.2%}")
+print(f"Outlier accuracy: {outlier_acc:.2%}")
+print(f"Overall accuracy: {overall_acc:.2%}")
+
+# Decision scores
+scores = model.decision_function(X)
+mean_target = float(jnp.mean(scores[y == 0]))
+mean_outlier = float(jnp.mean(scores[y == 1]))
+print(f"\nMean target score:  {mean_target:.4f}")
+print(f"Mean outlier score: {mean_outlier:.4f}")
+
+# Predict with reject option
+preds_reject = model.predict_with_reject(X, upper=0.7, lower=0.3)
+n_accepted = int(jnp.sum(preds_reject == 0))
+n_rejected = int(jnp.sum(preds_reject == 1))
+n_uncertain = int(jnp.sum(preds_reject == -1))
+print(f"\nWith reject option: accepted={n_accepted}, rejected={n_rejected}, uncertain={n_uncertain}")

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -48,6 +48,12 @@ try:
     from .image_lvq import ImageGLVQ, ImageGMLVQ, ImageGTLVQ
     from .image_cbc import ImageCBC
 
+    # One-class RSLVQ models
+    from .oc_rslvq import OCRSLVQ
+    from .oc_mrslvq import OCMRSLVQ, OCLMRSLVQ
+    from .oc_rslvq_ng import OCRSLVQ_NG
+    from .oc_mrslvq_ng import OCMRSLVQ_NG, OCLMRSLVQ_NG
+
     # Unsupervised topology models
     from .neural_gas import NeuralGas
     from .growing_neural_gas import GrowingNeuralGas
@@ -73,6 +79,10 @@ try:
         'SiameseGTLVQ': SiameseGTLVQ,
         'ImageGLVQ': ImageGLVQ, 'ImageGMLVQ': ImageGMLVQ,
         'ImageGTLVQ': ImageGTLVQ, 'ImageCBC': ImageCBC,
+        # One-class RSLVQ
+        'OCRSLVQ': OCRSLVQ, 'OCMRSLVQ': OCMRSLVQ, 'OCLMRSLVQ': OCLMRSLVQ,
+        'OCRSLVQ_NG': OCRSLVQ_NG, 'OCMRSLVQ_NG': OCMRSLVQ_NG,
+        'OCLMRSLVQ_NG': OCLMRSLVQ_NG,
         # Unsupervised topology
         'NeuralGas': NeuralGas, 'GrowingNeuralGas': GrowingNeuralGas,
         'KohonenSOM': KohonenSOM, 'HeskesSOM': HeskesSOM,
@@ -108,6 +118,9 @@ __all__ = [
     'LVQMLN', 'PLVQ',
     'SiameseGLVQ', 'SiameseGMLVQ', 'SiameseGTLVQ',
     'ImageGLVQ', 'ImageGMLVQ', 'ImageGTLVQ', 'ImageCBC',
+    # One-class RSLVQ
+    'OCRSLVQ', 'OCMRSLVQ', 'OCLMRSLVQ',
+    'OCRSLVQ_NG', 'OCMRSLVQ_NG', 'OCLMRSLVQ_NG',
     # Unsupervised topology
     'NeuralGas', 'GrowingNeuralGas', 'KohonenSOM', 'HeskesSOM',
     # Status

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -48,11 +48,26 @@ try:
     from .image_lvq import ImageGLVQ, ImageGMLVQ, ImageGTLVQ
     from .image_cbc import ImageCBC
 
-    # One-class RSLVQ models
+    # One-class models
+    from .oc_glvq import OCGLVQ
+    from .oc_grlvq import OCGRLVQ
+    from .oc_gmlvq import OCGMLVQ
+    from .oc_lgmlvq import OCLGMLVQ
+    from .oc_gtlvq import OCGTLVQ
+    from .oc_glvq_ng import OCGLVQ_NG
+    from .oc_grlvq_ng import OCGRLVQ_NG
+    from .oc_gmlvq_ng import OCGMLVQ_NG
+    from .oc_lgmlvq_ng import OCLGMLVQ_NG
+    from .oc_gtlvq_ng import OCGTLVQ_NG
     from .oc_rslvq import OCRSLVQ
     from .oc_mrslvq import OCMRSLVQ, OCLMRSLVQ
     from .oc_rslvq_ng import OCRSLVQ_NG
     from .oc_mrslvq_ng import OCMRSLVQ_NG, OCLMRSLVQ_NG
+    from .svq_occ import SVQOCC
+    from .svq_occ_r import SVQOCC_R
+    from .svq_occ_m import SVQOCC_M
+    from .svq_occ_lm import SVQOCC_LM
+    from .svq_occ_t import SVQOCC_T
 
     # Unsupervised topology models
     from .neural_gas import NeuralGas
@@ -79,10 +94,19 @@ try:
         'SiameseGTLVQ': SiameseGTLVQ,
         'ImageGLVQ': ImageGLVQ, 'ImageGMLVQ': ImageGMLVQ,
         'ImageGTLVQ': ImageGTLVQ, 'ImageCBC': ImageCBC,
+        # One-class GLVQ
+        'OCGLVQ': OCGLVQ, 'OCGRLVQ': OCGRLVQ, 'OCGMLVQ': OCGMLVQ,
+        'OCLGMLVQ': OCLGMLVQ, 'OCGTLVQ': OCGTLVQ,
+        'OCGLVQ_NG': OCGLVQ_NG, 'OCGRLVQ_NG': OCGRLVQ_NG,
+        'OCGMLVQ_NG': OCGMLVQ_NG, 'OCLGMLVQ_NG': OCLGMLVQ_NG,
+        'OCGTLVQ_NG': OCGTLVQ_NG,
         # One-class RSLVQ
         'OCRSLVQ': OCRSLVQ, 'OCMRSLVQ': OCMRSLVQ, 'OCLMRSLVQ': OCLMRSLVQ,
         'OCRSLVQ_NG': OCRSLVQ_NG, 'OCMRSLVQ_NG': OCMRSLVQ_NG,
         'OCLMRSLVQ_NG': OCLMRSLVQ_NG,
+        # One-class SVQ-OCC
+        'SVQOCC': SVQOCC, 'SVQOCC_R': SVQOCC_R, 'SVQOCC_M': SVQOCC_M,
+        'SVQOCC_LM': SVQOCC_LM, 'SVQOCC_T': SVQOCC_T,
         # Unsupervised topology
         'NeuralGas': NeuralGas, 'GrowingNeuralGas': GrowingNeuralGas,
         'KohonenSOM': KohonenSOM, 'HeskesSOM': HeskesSOM,
@@ -118,9 +142,14 @@ __all__ = [
     'LVQMLN', 'PLVQ',
     'SiameseGLVQ', 'SiameseGMLVQ', 'SiameseGTLVQ',
     'ImageGLVQ', 'ImageGMLVQ', 'ImageGTLVQ', 'ImageCBC',
+    # One-class GLVQ
+    'OCGLVQ', 'OCGRLVQ', 'OCGMLVQ', 'OCLGMLVQ', 'OCGTLVQ',
+    'OCGLVQ_NG', 'OCGRLVQ_NG', 'OCGMLVQ_NG', 'OCLGMLVQ_NG', 'OCGTLVQ_NG',
     # One-class RSLVQ
     'OCRSLVQ', 'OCMRSLVQ', 'OCLMRSLVQ',
     'OCRSLVQ_NG', 'OCMRSLVQ_NG', 'OCLMRSLVQ_NG',
+    # One-class SVQ-OCC
+    'SVQOCC', 'SVQOCC_R', 'SVQOCC_M', 'SVQOCC_LM', 'SVQOCC_T',
     # Unsupervised topology
     'NeuralGas', 'GrowingNeuralGas', 'KohonenSOM', 'HeskesSOM',
     # Status

--- a/prosemble/models/oc_mrslvq.py
+++ b/prosemble/models/oc_mrslvq.py
@@ -1,0 +1,359 @@
+"""
+One-Class Matrix RSLVQ (OC-MRSLVQ) and One-Class Local Matrix RSLVQ (OC-LMRSLVQ).
+
+Extends OC-GLVQ with:
+- Omega metric adaptation (global or per-prototype)
+- Probabilistic soft-weighting of all prototypes via Gaussian mixture
+
+Instead of using only the nearest prototype (hard argmin like OC-GMLVQ),
+all prototypes contribute to the loss via Gaussian proximity weights:
+
+    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)
+    μ_k = s · (d_k - θ_k) / (d_k + θ_k)
+    loss = mean(Σ_k p(k|x) · sigmoid(μ_k + margin, β))
+
+References
+----------
+.. [1] Schneider, P., Biehl, M., & Hammer, B. (2009). Adaptive
+       Relevance Matrices in Learning Vector Quantization. Neural
+       Computation.
+.. [2] Seo, S., & Obermayer, K. (2007). Soft Nearest Prototype
+       Classification. IEEE Trans. Neural Networks.
+.. [3] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IEEE WSOM+ 2022.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.oc_glvq import OCGLVQ
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.activations import sigmoid_beta
+
+
+class OCMRSLVQ(OCGLVQ):
+    """One-Class Matrix Robust Soft LVQ.
+
+    Combines one-class threshold detection with a learned global Omega
+    projection matrix and probabilistic soft-weighting of all prototypes.
+
+    All prototypes contribute to the one-class decision via Gaussian
+    proximity weights, with distances computed in the Omega-projected space.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture for prototype weighting.
+    latent_dim : int, optional
+        Dimensionality of the projected space. Default: n_features.
+    n_prototypes : int
+        Number of prototypes for the target class. Default: 3.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+
+    Attributes
+    ----------
+    omega_ : array of shape (n_features, latent_dim)
+        Learned projection matrix.
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds.
+    """
+
+    def __init__(self, sigma=1.0, latent_dim=None, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.latent_dim = latent_dim
+        self.omega_ = None
+
+    def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
+        params['omega'] = self.omega_
+        return params
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim if self.latent_dim is not None else n_features
+        params['omega'] = identity_omega_init(n_features, latent_dim)
+
+        # Reinitialize thetas using omega-projected distances
+        target_mask = (y == self._target_label)
+        X_target = X[target_mask]
+        prototypes = params['prototypes']
+        omega = params['omega']
+        diff = X_target[:, None, :] - prototypes[None, :, :]
+        projected = jnp.einsum('nkd,dl->nkl', diff, omega)
+        dists = jnp.sum(projected ** 2, axis=2)
+        params['thetas'] = jnp.sqrt(jnp.mean(dists, axis=0) + 1e-10)
+
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        thetas = params['thetas']
+        omega = params['omega']
+
+        # Omega-projected squared distances: (n, K)
+        diff = X[:, None, :] - prototypes[None, :, :]
+        projected = jnp.einsum('nkd,dl->nkl', diff, omega)
+        distances = jnp.sum(projected ** 2, axis=2)
+
+        # Gaussian weights: p(k|x) for all prototypes
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        weights = jnp.exp(log_probs - log_norm)
+        weights = weights / jnp.sum(weights, axis=1, keepdims=True)
+
+        # Per-prototype OC mu
+        s = jnp.where(y == self._target_label, 1.0, -1.0)
+        mu = s[:, None] * (distances - thetas[None, :]) / (
+            distances + thetas[None, :] + 1e-10
+        )
+
+        # Weighted sigmoid loss
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+        return jnp.mean(jnp.sum(weights * cost, axis=1))
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omega_ = params['omega']
+
+    def decision_function(self, X):
+        """Compute target-likeness scores using soft-weighted Omega distances.
+
+        Scores near 1.0 indicate target class, near 0.0 indicate outlier.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        scores : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        projected = jnp.einsum('nkd,dl->nkl', diff, self.omega_)
+        distances = jnp.sum(projected ** 2, axis=2)
+
+        # Gaussian weights
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        weights = jnp.exp(log_probs - log_norm)
+        weights = weights / jnp.sum(weights, axis=1, keepdims=True)
+
+        # Per-prototype mu (from target perspective, no sign flip)
+        mu = (distances - self.thetas_[None, :]) / (
+            distances + self.thetas_[None, :] + 1e-10
+        )
+        # Weighted score
+        weighted_mu = jnp.sum(weights * mu, axis=1)
+        return 1.0 - jax.nn.sigmoid(self.beta * weighted_mu)
+
+    @property
+    def omega_matrix(self):
+        """Return the learned projection matrix Omega."""
+        if self.omega_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_
+
+    @property
+    def lambda_matrix(self):
+        """Return the implicit metric Lambda = Omega^T Omega."""
+        return self.omega_matrix.T @ self.omega_matrix
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omega_ is not None:
+            attrs.append('omega_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_ is not None:
+            arrays['omega_'] = np.asarray(self.omega_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_' in arrays:
+            self.omega_ = jnp.asarray(arrays['omega_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['latent_dim'] = self.latent_dim
+        return hp
+
+
+class OCLMRSLVQ(OCGLVQ):
+    """One-Class Localized Matrix Robust Soft LVQ.
+
+    Each prototype k has its own Omega_k matrix for local metric
+    adaptation, combined with probabilistic soft-weighting and
+    one-class threshold detection.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture for prototype weighting.
+    latent_dim : int, optional
+        Latent space dimensionality per prototype. Default: n_features.
+    n_prototypes : int
+        Number of prototypes for the target class. Default: 3.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+
+    Attributes
+    ----------
+    omegas_ : array of shape (n_prototypes, n_features, latent_dim)
+        Learned per-prototype projection matrices.
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds.
+    """
+
+    def __init__(self, sigma=1.0, latent_dim=None, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.latent_dim = latent_dim
+        self.omegas_ = None
+
+    def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
+        params['omegas'] = self.omegas_
+        return params
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim if self.latent_dim is not None else n_features
+        n_protos = params['prototypes'].shape[0]
+        omega_single = identity_omega_init(n_features, latent_dim)
+        params['omegas'] = jnp.tile(omega_single[None, :, :], (n_protos, 1, 1))
+
+        # Reinitialize thetas using local-omega-projected distances
+        target_mask = (y == self._target_label)
+        X_target = X[target_mask]
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        diff = X_target[:, None, :] - prototypes[None, :, :]
+        projected = jnp.einsum('nkd,kdl->nkl', diff, omegas)
+        dists = jnp.sum(projected ** 2, axis=2)
+        params['thetas'] = jnp.sqrt(jnp.mean(dists, axis=0) + 1e-10)
+
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        thetas = params['thetas']
+        omegas = params['omegas']  # (K, d, l)
+
+        # Local omega-projected squared distances: (n, K)
+        diff = X[:, None, :] - prototypes[None, :, :]
+        projected = jnp.einsum('nkd,kdl->nkl', diff, omegas)
+        distances = jnp.sum(projected ** 2, axis=2)
+
+        # Gaussian weights
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        weights = jnp.exp(log_probs - log_norm)
+        weights = weights / jnp.sum(weights, axis=1, keepdims=True)
+
+        # Per-prototype OC mu
+        s = jnp.where(y == self._target_label, 1.0, -1.0)
+        mu = s[:, None] * (distances - thetas[None, :]) / (
+            distances + thetas[None, :] + 1e-10
+        )
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+        return jnp.mean(jnp.sum(weights * cost, axis=1))
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omegas_ = params['omegas']
+
+    def decision_function(self, X):
+        """Compute target-likeness scores using local Omega distances.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        scores : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        projected = jnp.einsum('nkd,kdl->nkl', diff, self.omegas_)
+        distances = jnp.sum(projected ** 2, axis=2)
+
+        # Gaussian weights
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        weights = jnp.exp(log_probs - log_norm)
+        weights = weights / jnp.sum(weights, axis=1, keepdims=True)
+
+        mu = (distances - self.thetas_[None, :]) / (
+            distances + self.thetas_[None, :] + 1e-10
+        )
+        weighted_mu = jnp.sum(weights * mu, axis=1)
+        return 1.0 - jax.nn.sigmoid(self.beta * weighted_mu)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omegas_ is not None:
+            attrs.append('omegas_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omegas_ is not None:
+            arrays['omegas_'] = np.asarray(self.omegas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omegas_' in arrays:
+            self.omegas_ = jnp.asarray(arrays['omegas_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['latent_dim'] = self.latent_dim
+        return hp

--- a/prosemble/models/oc_mrslvq_ng.py
+++ b/prosemble/models/oc_mrslvq_ng.py
@@ -1,0 +1,123 @@
+"""
+One-Class Matrix RSLVQ with Neural Gas cooperation (OC-MRSLVQ-NG)
+and One-Class Local Matrix RSLVQ with NG (OC-LMRSLVQ-NG).
+
+Combines OC-MRSLVQ/OC-LMRSLVQ's Omega metric adaptation and Gaussian
+soft-weighting with Neural Gas rank-based neighborhood cooperation:
+
+    p(k|x) = exp(-d_Ω_k / 2σ²) / Σ_j exp(-d_Ω_j / 2σ²)
+    h_k = exp(-rank_k / γ)
+    w_k = p(k|x) · h_k / Σ_j p(j|x) · h_j
+    loss = mean(Σ_k w_k · sigmoid(μ_k + margin, β))
+
+OC-MRSLVQ-NG: global Omega projection matrix (same for all prototypes).
+OC-LMRSLVQ-NG: per-prototype Omega_k matrices (local metric adaptation).
+
+References
+----------
+.. [1] Schneider, P., Biehl, M., & Hammer, B. (2009). Adaptive
+       Relevance Matrices in Learning Vector Quantization. Neural
+       Computation.
+.. [2] Seo, S., & Obermayer, K. (2007). Soft Learning Vector
+       Quantization. Neural Computation, 19(6):1589-1604.
+.. [3] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+       Neural Gas with General Similarity Measure. Neural Processing
+       Letters.
+"""
+
+import jax.numpy as jnp
+
+from prosemble.models.oc_rslvq_ng_mixin import OCRSLVQNGMixin
+from prosemble.models.oc_mrslvq import OCMRSLVQ, OCLMRSLVQ
+
+
+class OCMRSLVQ_NG(OCRSLVQNGMixin, OCMRSLVQ):
+    """One-Class Matrix RSLVQ with Neural Gas neighborhood cooperation.
+
+    Learns a global Omega projection with combined Gaussian + NG
+    rank-weighted loss for one-class classification.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture for prototype weighting.
+    latent_dim : int, optional
+        Dimensionality of the projected space. Default: n_features.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+
+    Attributes
+    ----------
+    omega_ : array of shape (n_features, latent_dim)
+        Learned projection matrix.
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype acceptance thresholds.
+    gamma_ : float
+        Final gamma value after training.
+    """
+
+    def _compute_distances(self, params, X):
+        diff = X[:, None, :] - params['prototypes'][None, :, :]
+        projected = jnp.einsum('nkd,dl->nkl', diff, params['omega'])
+        return jnp.sum(projected ** 2, axis=2)
+
+    def _inference_distances(self, X):
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        projected = jnp.einsum('nkd,dl->nkl', diff, self.omega_)
+        return jnp.sum(projected ** 2, axis=2)
+
+
+class OCLMRSLVQ_NG(OCRSLVQNGMixin, OCLMRSLVQ):
+    """One-Class Local Matrix RSLVQ with Neural Gas neighborhood cooperation.
+
+    Learns per-prototype Omega_k projection matrices with combined
+    Gaussian + NG rank-weighted loss for one-class classification.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture for prototype weighting.
+    latent_dim : int, optional
+        Latent space dimensionality per prototype. Default: n_features.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+
+    Attributes
+    ----------
+    omegas_ : array of shape (n_prototypes, n_features, latent_dim)
+        Learned per-prototype projection matrices.
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype acceptance thresholds.
+    gamma_ : float
+        Final gamma value after training.
+    """
+
+    def _compute_distances(self, params, X):
+        diff = X[:, None, :] - params['prototypes'][None, :, :]
+        projected = jnp.einsum('nkd,kdl->nkl', diff, params['omegas'])
+        return jnp.sum(projected ** 2, axis=2)
+
+    def _inference_distances(self, X):
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        projected = jnp.einsum('nkd,kdl->nkl', diff, self.omegas_)
+        return jnp.sum(projected ** 2, axis=2)

--- a/prosemble/models/oc_rslvq.py
+++ b/prosemble/models/oc_rslvq.py
@@ -1,0 +1,122 @@
+"""
+One-Class Robust Soft LVQ (OC-RSLVQ).
+
+Extends OC-GLVQ by replacing hard nearest-prototype assignment with
+probabilistic soft-weighting via Gaussian mixture responsibilities:
+
+    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)
+    μ_k = s · (d_k - θ_k) / (d_k + θ_k)
+    loss = mean(Σ_k p(k|x) · sigmoid(μ_k + margin, β))
+
+Unlike OC-GLVQ which uses only the nearest prototype for each sample,
+OC-RSLVQ distributes evidence across all prototypes weighted by Gaussian
+proximity. This provides smoother decision boundaries and natural
+uncertainty quantification.
+
+References
+----------
+.. [1] Seo, S., & Obermayer, K. (2003). Soft Nearest Prototype
+       Classification. IEEE Trans. Neural Networks, 15(7):1589-1604.
+.. [2] Seo, S., & Obermayer, K. (2007). Soft Learning Vector
+       Quantization. Neural Computation, 19(6):1589-1604.
+.. [3] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IJCNN 2022.
+"""
+
+import jax
+import jax.numpy as jnp
+
+from prosemble.models.oc_glvq import OCGLVQ
+from prosemble.core.activations import sigmoid_beta
+
+
+class OCRSLVQ(OCGLVQ):
+    """One-Class Robust Soft LVQ.
+
+    Combines one-class threshold detection with probabilistic soft-weighting
+    of all prototypes via Gaussian mixture responsibilities.
+
+    All prototypes contribute to the one-class decision via Gaussian
+    proximity weights, with standard Euclidean distances.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture for prototype weighting.
+    n_prototypes : int
+        Number of prototypes for the target class. Default: 3.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype acceptance thresholds.
+    """
+
+    def __init__(self, sigma=1.0, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        thetas = params['thetas']
+
+        # Squared Euclidean distances: (n, K)
+        distances = self.distance_fn(X, prototypes)
+
+        # Gaussian weights: p(k|x) for all prototypes
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        weights = jnp.exp(log_probs - log_norm)
+        weights = weights / jnp.sum(weights, axis=1, keepdims=True)
+
+        # Per-prototype OC mu
+        s = jnp.where(y == self._target_label, 1.0, -1.0)
+        mu = s[:, None] * (distances - thetas[None, :]) / (
+            distances + thetas[None, :] + 1e-10
+        )
+
+        # Weighted sigmoid loss
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+        return jnp.mean(jnp.sum(weights * cost, axis=1))
+
+    def decision_function(self, X):
+        """Compute target-likeness scores using soft-weighted distances.
+
+        Scores near 1.0 indicate target class, near 0.0 indicate outlier.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        scores : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+
+        distances = self.distance_fn(X, self.prototypes_)
+
+        # Gaussian weights
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        weights = jnp.exp(log_probs - log_norm)
+        weights = weights / jnp.sum(weights, axis=1, keepdims=True)
+
+        # Per-prototype mu (from target perspective)
+        mu = (distances - self.thetas_[None, :]) / (
+            distances + self.thetas_[None, :] + 1e-10
+        )
+        # Weighted score
+        weighted_mu = jnp.sum(weights * mu, axis=1)
+        return 1.0 - jax.nn.sigmoid(self.beta * weighted_mu)
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        return hp

--- a/prosemble/models/oc_rslvq_ng.py
+++ b/prosemble/models/oc_rslvq_ng.py
@@ -1,0 +1,62 @@
+"""
+One-Class RSLVQ with Neural Gas cooperation (OC-RSLVQ-NG).
+
+Combines OC-RSLVQ's probabilistic soft-weighting with Neural Gas
+rank-based neighborhood cooperation. Gaussian mixture responsibilities
+are modulated by NG neighborhood weights:
+
+    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)
+    h_k = exp(-rank_k / γ)
+    w_k = p(k|x) · h_k / Σ_j p(j|x) · h_j
+    loss = mean(Σ_k w_k · sigmoid(μ_k + margin, β))
+
+Uses standard Euclidean distance (no metric adaptation).
+
+References
+----------
+.. [1] Seo, S., & Obermayer, K. (2003). Soft Nearest Prototype
+       Classification. IEEE Trans. Neural Networks, 15(7):1589-1604.
+.. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+       Neural Gas with General Similarity Measure. Neural Processing
+       Letters.
+.. [3] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IJCNN 2022.
+"""
+
+from prosemble.models.oc_rslvq_ng_mixin import OCRSLVQNGMixin
+from prosemble.models.oc_rslvq import OCRSLVQ
+
+
+class OCRSLVQ_NG(OCRSLVQNGMixin, OCRSLVQ):
+    """One-Class RSLVQ with Neural Gas neighborhood cooperation.
+
+    Combines soft Gaussian mixture responsibilities with NG rank-based
+    cooperation. Uses standard Euclidean distances.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture for prototype weighting.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype acceptance thresholds.
+    gamma_ : float
+        Final gamma value after training.
+    """
+
+    def _compute_distances(self, params, X):
+        return self.distance_fn(X, params['prototypes'])

--- a/prosemble/models/oc_rslvq_ng_mixin.py
+++ b/prosemble/models/oc_rslvq_ng_mixin.py
@@ -1,0 +1,218 @@
+"""
+Neural Gas Cooperation Mixin for OC-RSLVQ variants.
+
+Combines OC-RSLVQ's Gaussian soft-assignment with Neural Gas rank-based
+neighborhood cooperation. Unlike the OC-GLVQ-NG mixin (which replaces
+hard nearest-prototype with NG ranking), this mixin modulates the
+existing Gaussian responsibilities with NG neighborhood weights:
+
+    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)   [Gaussian]
+    h_k = exp(-rank_k / γ)                              [NG neighborhood]
+    w_k = p(k|x) · h_k / Σ_j p(j|x) · h_j             [combined]
+
+When γ → ∞, h_k ≈ const for all k → recovers OC-RSLVQ (pure Gaussian).
+When γ → 0, only the nearest prototype has h_k > 0 → sharpened assignment.
+
+Subclasses override `_compute_distances(params, X)` to define the
+metric-specific distance (Euclidean, global Ω, local Ω_k).
+"""
+
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.core.activations import sigmoid_beta
+
+
+class OCRSLVQNGMixin:
+    """Mixin that adds Neural Gas cooperation to OC-RSLVQ variants.
+
+    Provides gamma scheduling, combined Gaussian+NG weighting, and
+    the corresponding loss computation.
+
+    Subclasses must override `_compute_distances(params, X)` to return
+    a (n_samples, n_prototypes) distance matrix.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture for prototype weighting.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    """
+
+    def __init__(self, sigma=1.0, gamma_init=None, gamma_final=0.01,
+                 gamma_decay=None, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.gamma_ = None
+
+        # Freeze gamma from optimizer
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual')
+            else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        gamma_init = (self.gamma_init if self.gamma_init is not None
+                      else self.n_prototypes / 2.0)
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (
+                self.gamma_final / gamma_init
+            ) ** (1.0 / self.max_iter)
+
+        params['gamma'] = jnp.array(gamma_init, dtype=jnp.float32)
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_distances(self, params, X):
+        """Compute distance matrix (n_samples, n_prototypes).
+
+        Must be overridden by subclasses to define metric-specific distance.
+        """
+        raise NotImplementedError
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        thetas = params['thetas']
+        gamma = params['gamma']
+
+        distances = self._compute_distances(params, X)
+
+        # 1. Gaussian mixture probabilities
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        gauss = jnp.exp(log_probs - log_norm)
+        gauss = gauss / (jnp.sum(gauss, axis=1, keepdims=True) + 1e-10)
+
+        # 2. NG rank-based neighborhood
+        order = jnp.argsort(distances, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h_norm = h / (jnp.sum(h, axis=1, keepdims=True) + 1e-10)
+
+        # 3. Combined weights (renormalized)
+        combined = gauss * h_norm
+        combined = combined / (jnp.sum(combined, axis=1, keepdims=True)
+                               + 1e-10)
+
+        # 4. Per-prototype OC mu
+        s = jnp.where(y == self._target_label, 1.0, -1.0)
+        mu = s[:, None] * (distances - thetas[None, :]) / (
+            distances + thetas[None, :] + 1e-10
+        )
+
+        # 5. Weighted sigmoid loss
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+        return jnp.mean(jnp.sum(combined * cost, axis=1))
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {**params, 'gamma': new_gamma}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.gamma_ = float(params['gamma'])
+
+    def decision_function(self, X):
+        """Compute target-likeness scores using combined Gaussian+NG weights.
+
+        Uses final (converged) gamma for NG modulation at inference time.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        scores : array of shape (n_samples,)
+            Scores near 1.0 indicate target class, near 0.0 indicate outlier.
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        import jax
+
+        distances = self._inference_distances(X)
+
+        # Gaussian weights
+        log_probs = -distances / (2.0 * self.sigma ** 2)
+        log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+        gauss = jnp.exp(log_probs - log_norm)
+        gauss = gauss / (jnp.sum(gauss, axis=1, keepdims=True) + 1e-10)
+
+        # NG rank weights (using final gamma)
+        order = jnp.argsort(distances, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+        h = jnp.exp(-ranks / (self.gamma_ + 1e-10))
+        h_norm = h / (jnp.sum(h, axis=1, keepdims=True) + 1e-10)
+
+        # Combined
+        combined = gauss * h_norm
+        combined = combined / (jnp.sum(combined, axis=1, keepdims=True)
+                               + 1e-10)
+
+        # Per-prototype mu (from target perspective)
+        mu = (distances - self.thetas_[None, :]) / (
+            distances + self.thetas_[None, :] + 1e-10
+        )
+        weighted_mu = jnp.sum(combined * mu, axis=1)
+        return 1.0 - jax.nn.sigmoid(self.beta * weighted_mu)
+
+    def _inference_distances(self, X):
+        """Compute distances for inference. Override for metric variants."""
+        return self.distance_fn(X, self.prototypes_)
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        return hp

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -114,6 +114,52 @@ Supervised Neural Gas
    :members: fit, predict, predict_proba
    :undoc-members:
 
+One-Class GLVQ
+--------------
+
+.. autoclass:: prosemble.models.OCGLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCGRLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCGMLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCLGMLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCGTLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+One-Class GLVQ with Neural Gas
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: prosemble.models.OCGLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCGRLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCGMLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCLGMLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCGTLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
 One-Class RSLVQ
 ---------------
 
@@ -129,6 +175,9 @@ One-Class RSLVQ
    :members: fit, predict, decision_function, predict_with_reject
    :undoc-members:
 
+One-Class RSLVQ with Neural Gas
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 .. autoclass:: prosemble.models.OCRSLVQ_NG
    :members: fit, predict, decision_function, predict_with_reject
    :undoc-members:
@@ -138,6 +187,29 @@ One-Class RSLVQ
    :undoc-members:
 
 .. autoclass:: prosemble.models.OCLMRSLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+SVQ-OCC
+-------
+
+.. autoclass:: prosemble.models.SVQOCC
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.SVQOCC_R
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.SVQOCC_M
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.SVQOCC_LM
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.SVQOCC_T
    :members: fit, predict, decision_function, predict_with_reject
    :undoc-members:
 

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -114,6 +114,33 @@ Supervised Neural Gas
    :members: fit, predict, predict_proba
    :undoc-members:
 
+One-Class RSLVQ
+---------------
+
+.. autoclass:: prosemble.models.OCRSLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCMRSLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCLMRSLVQ
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCRSLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCMRSLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCLMRSLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject
+   :undoc-members:
+
 Fuzzy Clustering
 ----------------
 

--- a/sphinx-docs/guides/one_class.rst
+++ b/sphinx-docs/guides/one_class.rst
@@ -1,14 +1,473 @@
 One-Class Classification
 ========================
 
-.. note::
+Prosemble provides 21 one-class classification models across three families,
+all implemented in JAX with JIT compilation and ``lax.scan`` training loops.
+Every model follows the same ``fit`` / ``predict`` / ``decision_function`` /
+``predict_with_reject`` API.
 
-   One-class classification models (OC-GLVQ and SVQ-OCC families) are
-   planned for **v1.1**. This includes:
+All one-class models learn per-prototype **visibility thresholds**
+:math:`\theta_k` that define the boundary between target (normal) and
+non-target (outlier) samples.
 
-   - **OC-GLVQ family**: OCGLVQ, OCGRLVQ, OCGMLVQ, OCLGMLVQ, OCGTLVQ
-   - **OC-GLVQ-NG family**: All OC-GLVQ variants with Neural Gas cooperation
-   - **SVQ-OCC family**: SVQOCC, SVQOCC_R, SVQOCC_M, SVQOCC_LM, SVQOCC_T
+OC-GLVQ — Baseline
+-------------------
 
-   These models are fully implemented and tested but will be released in the
-   next version. See :doc:`supervised` for currently available models.
+One-Class Generalized Learning Vector Quantization. Replaces the standard
+GLVQ competing distance :math:`d^-` with learned per-prototype visibility
+thresholds :math:`\theta_k`. Only the nearest prototype contributes to
+the loss.
+
+.. code-block:: python
+
+   import jax.numpy as jnp
+   from prosemble.datasets import load_iris_jax
+   from prosemble.models import OCGLVQ
+
+   # Load data — treat class 0 as target, rest as outliers
+   dataset = load_iris_jax()
+   X, y_raw = dataset.input_data, dataset.labels
+   y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+   model = OCGLVQ(
+       n_prototypes=3,
+       target_label=0,          # target (normal) class label
+       beta=10.0,               # sigmoid steepness
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   # Hard labels
+   preds = model.predict(X)
+
+   # Decision scores in [0, 1] — higher = more target-like
+   scores = model.decision_function(X)
+
+   # Predict with reject option
+   preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+   # Returns: 0 (target), 1 (outlier), -1 (uncertain/rejected)
+
+   # Learned thresholds
+   print(model.thetas_)           # (n_prototypes,)
+   print(model.visibility_radii)  # same as thetas_
+
+OCGRLVQ — Feature Relevances
+-----------------------------
+
+Adds per-feature relevance weights :math:`\lambda_j` that reveal which
+features matter for target-vs-outlier separation.
+
+.. code-block:: python
+
+   from prosemble.models import OCGRLVQ
+
+   model = OCGRLVQ(
+       n_prototypes=3,
+       target_label=0,
+       max_iter=100,
+       lr=0.01,
+   )
+   model.fit(X, y)
+
+   # Inspect learned relevances
+   print(model.relevances_)  # shape: (n_features,), sums to 1
+
+OCGMLVQ — Matrix Metric Learning
+---------------------------------
+
+Learns a global linear transformation :math:`\Omega` such that distance
+is :math:`d(x, w) = \|\Omega(x - w)\|^2`. Captures feature correlations.
+
+.. code-block:: python
+
+   from prosemble.models import OCGMLVQ
+
+   model = OCGMLVQ(
+       n_prototypes=3,
+       latent_dim=2,            # project to 2D
+       target_label=0,
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X, y)
+
+   print(model.omega_matrix.shape)   # (n_features, latent_dim)
+   print(model.lambda_matrix.shape)  # Omega^T @ Omega
+
+OCLGMLVQ — Local Metrics
+-------------------------
+
+Each prototype gets its own :math:`\Omega_k` matrix, allowing different
+regions of the feature space to use different metrics.
+
+.. code-block:: python
+
+   from prosemble.models import OCLGMLVQ
+
+   model = OCLGMLVQ(
+       n_prototypes=3,
+       latent_dim=2,
+       target_label=0,
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X, y)
+
+   print(model.omegas_.shape)  # (n_prototypes, n_features, latent_dim)
+
+OCGTLVQ — Tangent Distance
+---------------------------
+
+Learns per-prototype invariance subspaces. The tangent distance measures
+distance only in directions orthogonal to the invariance subspace:
+:math:`d(x, w_k) = \|(I - \Omega_k \Omega_k^T)(x - w_k)\|^2`.
+
+.. code-block:: python
+
+   from prosemble.models import OCGTLVQ
+
+   model = OCGTLVQ(
+       n_prototypes=3,
+       subspace_dim=2,          # tangent subspace dimension
+       target_label=0,
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X, y)
+
+OC-GLVQ with Neural Gas
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Neural Gas variants replace hard nearest-prototype selection with
+rank-based neighborhood cooperation. All prototypes contribute, weighted
+by :math:`h_k = \exp(-\text{rank}_k / \gamma)`. Gamma decays from broad
+to sharp during training.
+
+.. code-block:: python
+
+   from prosemble.models import OCGLVQ_NG
+
+   model = OCGLVQ_NG(
+       n_prototypes=3,
+       target_label=0,
+       gamma_init=5.0,          # initial neighborhood range
+       gamma_final=0.01,        # final (narrower)
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   print(f"Final gamma: {model.gamma_:.4f}")
+
+All five OC-GLVQ metric variants have NG counterparts:
+
+.. list-table:: OC-GLVQ Neural Gas Variants
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Model
+     - Base
+     - Metric
+   * - ``OCGLVQ_NG``
+     - OCGLVQ
+     - Euclidean
+   * - ``OCGRLVQ_NG``
+     - OCGRLVQ
+     - Per-feature relevance
+   * - ``OCGMLVQ_NG``
+     - OCGMLVQ
+     - Global :math:`\Omega`
+   * - ``OCLGMLVQ_NG``
+     - OCLGMLVQ
+     - Per-prototype :math:`\Omega_k`
+   * - ``OCGTLVQ_NG``
+     - OCGTLVQ
+     - Tangent subspace
+
+OC-RSLVQ — Probabilistic One-Class
+-----------------------------------
+
+One-Class Robust Soft LVQ. Replaces hard nearest-prototype selection with
+soft Gaussian mixture responsibilities. All prototypes contribute,
+weighted by proximity: :math:`p(k|x) = \text{softmax}(-d_k / 2\sigma^2)`.
+
+.. code-block:: python
+
+   from prosemble.models import OCRSLVQ
+
+   model = OCRSLVQ(
+       sigma=1.0,               # Gaussian bandwidth
+       n_prototypes=3,
+       target_label=0,
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   # Decision scores
+   scores = model.decision_function(X)
+   mean_target = float(jnp.mean(scores[y == 0]))
+   mean_outlier = float(jnp.mean(scores[y == 1]))
+   print(f"Mean target score:  {mean_target:.4f}")
+   print(f"Mean outlier score: {mean_outlier:.4f}")
+
+   # Predict with reject option
+   preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+
+OCMRSLVQ — Matrix Metric
+-------------------------
+
+Combines OC-RSLVQ's soft Gaussian weighting with a global :math:`\Omega`
+projection matrix.
+
+.. code-block:: python
+
+   from prosemble.models import OCMRSLVQ
+
+   model = OCMRSLVQ(
+       sigma=1.0,
+       n_prototypes=3,
+       target_label=0,
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   print(f"Omega shape: {model.omega_matrix.shape}")
+   print(f"Lambda (relevance matrix):\n{model.lambda_matrix}")
+
+OCLMRSLVQ — Local Matrix Metric
+--------------------------------
+
+Per-prototype :math:`\Omega_k` matrices with soft Gaussian weighting.
+
+.. code-block:: python
+
+   from prosemble.models import OCLMRSLVQ
+
+   model = OCLMRSLVQ(
+       sigma=1.0,
+       n_prototypes=3,
+       latent_dim=2,
+       target_label=0,
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   print(model.omegas_.shape)  # (n_prototypes, n_features, latent_dim)
+
+OC-RSLVQ with Neural Gas
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Combines soft Gaussian mixture with Neural Gas rank-based cooperation.
+Prototype weights are the product of Gaussian responsibility and NG rank:
+:math:`w_k = p(k|x) \cdot h_k / \sum_j p(j|x) \cdot h_j`.
+
+.. code-block:: python
+
+   from prosemble.models import OCRSLVQ_NG
+
+   model = OCRSLVQ_NG(
+       sigma=1.0,
+       n_prototypes=3,
+       target_label=0,
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   print(f"Final loss: {model.loss_:.4f}")
+   print(f"Final gamma: {model.gamma_:.4f}")
+
+.. list-table:: OC-RSLVQ Neural Gas Variants
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Model
+     - Base
+     - Metric
+   * - ``OCRSLVQ_NG``
+     - OCRSLVQ
+     - Euclidean
+   * - ``OCMRSLVQ_NG``
+     - OCMRSLVQ
+     - Global :math:`\Omega`
+   * - ``OCLMRSLVQ_NG``
+     - OCLMRSLVQ
+     - Per-prototype :math:`\Omega_k`
+
+Matrix NG variants add ``latent_dim``:
+
+.. code-block:: python
+
+   from prosemble.models import OCMRSLVQ_NG, OCLMRSLVQ_NG
+
+   # Global omega + Gaussian + NG
+   model = OCMRSLVQ_NG(
+       sigma=1.0,
+       latent_dim=2,
+       n_prototypes=3,
+       target_label=0,
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   print(f"Omega shape: {model.omega_matrix.shape}")
+   print(f"Final gamma: {model.gamma_:.4f}")
+
+SVQ-OCC — Dual-Objective One-Class
+-----------------------------------
+
+Supervised Vector Quantization One-Class Classification. Balances two
+objectives:
+
+- **R cost**: Neural Gas representation learning on target data
+- **C cost**: Classification cost via per-prototype responsibilities
+
+Total loss: :math:`E = \alpha \cdot R + (1 - \alpha) \cdot C`
+
+.. code-block:: python
+
+   from prosemble.models import SVQOCC
+
+   model = SVQOCC(
+       n_prototypes=3,
+       target_label=0,
+       alpha=0.5,               # balance: R vs C cost
+       cost_function='contrastive',
+       response_type='gaussian',
+       sigma=0.1,               # Heaviside sigmoid sharpness
+       gamma_resp=1.0,          # response bandwidth
+       lambda_init=5.0,         # initial NG lambda
+       lambda_final=0.01,       # final NG lambda
+       max_iter=100,
+       lr=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   scores = model.decision_function(X)
+   preds = model.predict(X)
+
+**Cost functions** (``cost_function``):
+
+- ``'contrastive'`` — contrastive score (default)
+- ``'brier'`` — Brier score
+- ``'cross_entropy'`` — cross-entropy loss
+
+**Response types** (``response_type``):
+
+- ``'gaussian'`` — :math:`p_k = \text{softmax}(-\gamma \cdot d_k)` (default)
+- ``'student_t'`` — :math:`p_k \propto (1 + d_k / \nu)^{-(\nu+1)/2}`
+- ``'uniform'`` — :math:`p_k = 1/K`
+
+SVQ-OCC Metric Variants
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Like the OC-GLVQ family, SVQ-OCC has metric-adapted variants:
+
+.. list-table:: SVQ-OCC Variants
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Model
+     - Metric
+     - Key Parameter
+   * - ``SVQOCC``
+     - Euclidean
+     - —
+   * - ``SVQOCC_R``
+     - Per-feature relevance
+     - ``relevances_``
+   * - ``SVQOCC_M``
+     - Global :math:`\Omega`
+     - ``latent_dim``
+   * - ``SVQOCC_LM``
+     - Per-prototype :math:`\Omega_k`
+     - ``latent_dim``
+   * - ``SVQOCC_T``
+     - Tangent subspace
+     - ``subspace_dim``
+
+.. code-block:: python
+
+   from prosemble.models import SVQOCC_R, SVQOCC_M, SVQOCC_LM, SVQOCC_T
+
+   # Relevance variant
+   model = SVQOCC_R(n_prototypes=3, target_label=0, max_iter=100, lr=0.01)
+   model.fit(X, y)
+   print(model.relevances_)      # (n_features,)
+
+   # Matrix variant
+   model = SVQOCC_M(n_prototypes=3, target_label=0, latent_dim=2,
+                     max_iter=100, lr=0.01)
+   model.fit(X, y)
+   print(model.omega_matrix.shape)
+
+Common Patterns
+---------------
+
+**Data preparation** — one-class models expect binary labels (target=0,
+outlier=1):
+
+.. code-block:: python
+
+   import jax.numpy as jnp
+   from prosemble.datasets import load_iris_jax
+
+   dataset = load_iris_jax()
+   X, y_raw = dataset.input_data, dataset.labels
+   y = jnp.where(y_raw == 0, 0, 1).astype(jnp.int32)
+
+**Decision function** — all models return scores in [0, 1]:
+
+.. code-block:: python
+
+   scores = model.decision_function(X)
+   # Higher score = more target-like
+   # Lower score = more outlier-like
+
+**Reject option** — three-way classification:
+
+.. code-block:: python
+
+   preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+   # 0: accepted (target)
+   # 1: rejected (outlier)
+   # -1: uncertain (between lower and upper)
+
+**Resume training:**
+
+.. code-block:: python
+
+   model.fit(X, y, max_iter=50)
+   model.fit(X, y, resume=True)  # continue from last state
+
+**Fitted attributes** (after ``fit``):
+
+- ``model.prototypes_`` — prototype positions
+- ``model.thetas_`` — per-prototype visibility thresholds
+- ``model.n_iter_`` — number of iterations run
+- ``model.loss_`` — final loss value
+- ``model.loss_history_`` — loss per iteration
+- ``model.visibility_radii`` — same as ``thetas_``
+
+**NG-specific attributes** (OC-*-NG and SVQ-OCC models):
+
+- ``model.gamma_`` — final gamma / lambda value after training
+
+**Matrix-specific attributes** (M / LM variants):
+
+- ``model.omega_matrix`` — learned :math:`\Omega` projection
+- ``model.lambda_matrix`` — :math:`\Omega^T \Omega` (feature importance)
+- ``model.omegas_`` — per-prototype :math:`\Omega_k` (local variants)

--- a/tests/test_oc_mrslvq.py
+++ b/tests/test_oc_mrslvq.py
@@ -1,0 +1,215 @@
+"""Tests for OC-MRSLVQ and OC-LMRSLVQ."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tempfile
+import os
+
+from prosemble.models.oc_mrslvq import OCMRSLVQ, OCLMRSLVQ
+
+
+@pytest.fixture
+def occ_2d():
+    """Simple 2D one-class dataset."""
+    key = jax.random.PRNGKey(42)
+    k1, k2 = jax.random.split(key)
+    X_target = jax.random.normal(k1, (40, 2)) * 0.3
+    X_outlier = jax.random.normal(k2, (20, 2)) * 0.3 + 3.0
+    X = jnp.concatenate([X_target, X_outlier])
+    y = jnp.concatenate([jnp.zeros(40, dtype=jnp.int32),
+                         jnp.ones(20, dtype=jnp.int32)])
+    return X, y
+
+
+@pytest.fixture
+def iris_binary():
+    """Iris binary OCC dataset."""
+    from sklearn.datasets import load_iris
+    data = load_iris()
+    X = jnp.array(data.data, dtype=jnp.float32)
+    y = jnp.where(jnp.array(data.target) == 0, 0, 1).astype(jnp.int32)
+    return X, y
+
+
+class TestOCMRSLVQ:
+    def test_fit_predict(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        target_acc = float(jnp.mean(preds[:40] == 0))
+        assert target_acc >= 0.70
+
+    def test_loss_decreases(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_thetas_positive(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_omega_shape(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=30, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert model.omega_matrix.shape == (2, 2)
+
+    def test_lambda_matrix(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=30, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        lam = model.lambda_matrix
+        assert lam.shape == (2, 2)
+        np.testing.assert_allclose(lam, lam.T, atol=1e-5)
+
+    def test_latent_dim(self, iris_binary):
+        X, y = iris_binary
+        model = OCMRSLVQ(
+            sigma=1.0, latent_dim=2, n_prototypes=3, max_iter=30, lr=0.01,
+            target_label=0,
+        )
+        model.fit(X, y)
+        assert model.omega_matrix.shape == (4, 2)
+
+    def test_target_higher_scores(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=100, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:40]))
+        mean_outlier = float(jnp.mean(scores[40:]))
+        assert mean_target > mean_outlier
+
+    def test_scores_range(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_reject_option(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (60,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_save_load(self, occ_2d):
+        X, y = occ_2d
+        model = OCMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "oc_mrslvq")
+            model.save(path)
+            loaded = OCMRSLVQ.load(path)
+            preds_after = loaded.predict(X)
+            np.testing.assert_array_equal(preds_before, preds_after)
+
+
+class TestOCLMRSLVQ:
+    def test_fit_predict(self, occ_2d):
+        X, y = occ_2d
+        model = OCLMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        target_acc = float(jnp.mean(preds[:40] == 0))
+        assert target_acc >= 0.70
+
+    def test_loss_decreases(self, occ_2d):
+        X, y = occ_2d
+        model = OCLMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_thetas_positive(self, occ_2d):
+        X, y = occ_2d
+        model = OCLMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_local_omegas_shape(self, occ_2d):
+        X, y = occ_2d
+        model = OCLMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=30, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert model.omegas_.shape == (3, 2, 2)  # 3 protos, 2x2 omegas
+
+    def test_latent_dim(self, iris_binary):
+        X, y = iris_binary
+        model = OCLMRSLVQ(
+            sigma=1.0, latent_dim=2, n_prototypes=3, max_iter=30, lr=0.01,
+            target_label=0,
+        )
+        model.fit(X, y)
+        assert model.omegas_.shape == (3, 4, 2)
+
+    def test_target_higher_scores(self, occ_2d):
+        X, y = occ_2d
+        model = OCLMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=100, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:40]))
+        mean_outlier = float(jnp.mean(scores[40:]))
+        assert mean_target > mean_outlier
+
+    def test_scores_range(self, occ_2d):
+        X, y = occ_2d
+        model = OCLMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_save_load(self, occ_2d):
+        X, y = occ_2d
+        model = OCLMRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "oc_lmrslvq")
+            model.save(path)
+            loaded = OCLMRSLVQ.load(path)
+            preds_after = loaded.predict(X)
+            np.testing.assert_array_equal(preds_before, preds_after)

--- a/tests/test_oc_rslvq.py
+++ b/tests/test_oc_rslvq.py
@@ -1,0 +1,128 @@
+"""Tests for OC-RSLVQ."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tempfile
+import os
+
+from prosemble.models.oc_rslvq import OCRSLVQ
+
+
+@pytest.fixture
+def occ_2d():
+    """Simple 2D one-class dataset."""
+    key = jax.random.PRNGKey(42)
+    k1, k2 = jax.random.split(key)
+    X_target = jax.random.normal(k1, (40, 2)) * 0.3
+    X_outlier = jax.random.normal(k2, (20, 2)) * 0.3 + 3.0
+    X = jnp.concatenate([X_target, X_outlier])
+    y = jnp.concatenate([jnp.zeros(40, dtype=jnp.int32),
+                         jnp.ones(20, dtype=jnp.int32)])
+    return X, y
+
+
+@pytest.fixture
+def iris_binary():
+    """Iris binary OCC dataset."""
+    from sklearn.datasets import load_iris
+    data = load_iris()
+    X = jnp.array(data.data, dtype=jnp.float32)
+    y = jnp.where(jnp.array(data.target) == 0, 0, 1).astype(jnp.int32)
+    return X, y
+
+
+class TestOCRSLVQ:
+    def test_fit_predict(self, occ_2d):
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        target_acc = float(jnp.mean(preds[:40] == 0))
+        assert target_acc >= 0.70
+
+    def test_loss_decreases(self, occ_2d):
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_thetas_positive(self, occ_2d):
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_no_omega(self, occ_2d):
+        """OC-RSLVQ has no omega matrix — pure Euclidean."""
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=30, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        assert not hasattr(model, 'omega_') or model.__dict__.get('omega_') is None
+        assert not hasattr(model, 'omegas_') or model.__dict__.get('omegas_') is None
+
+    def test_target_higher_scores(self, occ_2d):
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=100, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:40]))
+        mean_outlier = float(jnp.mean(scores[40:]))
+        assert mean_target > mean_outlier
+
+    def test_scores_range(self, occ_2d):
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_reject_option(self, occ_2d):
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (60,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_save_load(self, occ_2d):
+        X, y = occ_2d
+        model = OCRSLVQ(
+            sigma=0.5, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "oc_rslvq")
+            model.save(path)
+            loaded = OCRSLVQ.load(path)
+            preds_after = loaded.predict(X)
+            np.testing.assert_array_equal(preds_before, preds_after)
+
+    def test_iris(self, iris_binary):
+        X, y = iris_binary
+        model = OCRSLVQ(
+            sigma=1.0, n_prototypes=3, max_iter=50, lr=0.01, target_label=0,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (150,)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)

--- a/tests/test_oc_rslvq_ng.py
+++ b/tests/test_oc_rslvq_ng.py
@@ -1,0 +1,348 @@
+"""Tests for OC-RSLVQ Neural Gas variants."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from prosemble.models import OCRSLVQ_NG, OCMRSLVQ_NG, OCLMRSLVQ_NG
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def binary_data():
+    """Binary one-class dataset."""
+    key = jax.random.PRNGKey(42)
+    k1, k2 = jax.random.split(key)
+    X_target = jax.random.normal(k1, (60, 4)) * 0.5
+    X_outlier = jax.random.normal(k2, (40, 4)) * 0.5 + 3.0
+    X = jnp.concatenate([X_target, X_outlier])
+    y = jnp.concatenate([jnp.zeros(60, dtype=jnp.int32),
+                         jnp.ones(40, dtype=jnp.int32)])
+    return X, y
+
+
+# ===========================================================================
+# OCRSLVQ_NG
+# ===========================================================================
+
+class TestOCRSLVQ_NGBasic:
+    def test_fit_predict(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (100,)
+        acc = float(jnp.mean(preds == y))
+        assert acc > 0.6
+
+    def test_gamma_decay(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.gamma_ is not None
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_gamma_bounded(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            gamma_init=5.0, gamma_final=0.5,
+            max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.gamma_ >= 0.5
+        assert model.gamma_ < 5.0
+
+    def test_custom_gamma_decay(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            gamma_init=3.0, gamma_decay=0.95,
+            max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.gamma_ is not None
+
+    def test_decision_function(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (100,)
+        assert jnp.all((scores >= 0) & (scores <= 1))
+
+    def test_target_higher_scores(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=100, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:60]))
+        mean_outlier = float(jnp.mean(scores[60:]))
+        assert mean_target > mean_outlier
+
+    def test_loss_decreases(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=100, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] != model.loss_history_[-1]
+
+    def test_no_omega(self, binary_data):
+        """OCRSLVQ_NG has no omega matrix — pure Euclidean."""
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=30, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert not hasattr(model, 'omega_') or model.__dict__.get('omega_') is None
+        assert not hasattr(model, 'omegas_') or model.__dict__.get('omegas_') is None
+
+    def test_thetas_positive(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+
+class TestOCRSLVQ_NGSaveLoad:
+    def test_save_load_roundtrip(self, binary_data, tmp_path):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        path = str(tmp_path / "oc_rslvq_ng.npz")
+        model.save(path)
+        loaded = OCRSLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+        assert loaded.gamma_ == pytest.approx(model.gamma_, rel=1e-4)
+
+
+class TestOCRSLVQ_NGResume:
+    def test_resume_training(self, binary_data):
+        X, y = binary_data
+        model = OCRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            max_iter=30, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        loss_before = model.loss_
+        model.fit(X, y, resume=True)
+        assert model.loss_ < abs(loss_before) * 2.0
+
+
+# ===========================================================================
+# OCMRSLVQ_NG
+# ===========================================================================
+
+class TestOCMRSLVQ_NGBasic:
+    def test_fit_predict(self, binary_data):
+        X, y = binary_data
+        model = OCMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (100,)
+        acc = float(jnp.mean(preds == y))
+        assert acc > 0.6
+
+    def test_omega_learned(self, binary_data):
+        X, y = binary_data
+        model = OCMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.omega_matrix.shape == (4, 2)
+        assert model.lambda_matrix.shape == (2, 2)
+
+    def test_gamma_decay(self, binary_data):
+        X, y = binary_data
+        model = OCMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_decision_function(self, binary_data):
+        X, y = binary_data
+        model = OCMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (100,)
+        assert jnp.all((scores >= 0) & (scores <= 1))
+
+    def test_thetas_positive(self, binary_data):
+        X, y = binary_data
+        model = OCMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+
+class TestOCMRSLVQ_NGSaveLoad:
+    def test_save_load_roundtrip(self, binary_data, tmp_path):
+        X, y = binary_data
+        model = OCMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        path = str(tmp_path / "oc_mrslvq_ng.npz")
+        model.save(path)
+        loaded = OCMRSLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+
+
+class TestOCMRSLVQ_NGResume:
+    def test_resume_training(self, binary_data):
+        X, y = binary_data
+        model = OCMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=30, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        loss_before = model.loss_
+        model.fit(X, y, resume=True)
+        assert model.loss_ < abs(loss_before) * 2.0
+
+
+# ===========================================================================
+# OCLMRSLVQ_NG
+# ===========================================================================
+
+class TestOCLMRSLVQ_NGBasic:
+    def test_fit_predict(self, binary_data):
+        X, y = binary_data
+        model = OCLMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (100,)
+        acc = float(jnp.mean(preds == y))
+        assert acc > 0.6
+
+    def test_omegas_shape(self, binary_data):
+        X, y = binary_data
+        model = OCLMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.omegas_.shape == (3, 4, 2)
+
+    def test_gamma_decay(self, binary_data):
+        X, y = binary_data
+        model = OCLMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_decision_function(self, binary_data):
+        X, y = binary_data
+        model = OCLMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (100,)
+        assert jnp.all((scores >= 0) & (scores <= 1))
+
+    def test_thetas_positive(self, binary_data):
+        X, y = binary_data
+        model = OCLMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+
+class TestOCLMRSLVQ_NGSaveLoad:
+    def test_save_load_roundtrip(self, binary_data, tmp_path):
+        X, y = binary_data
+        model = OCLMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=50, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        path = str(tmp_path / "oc_lmrslvq_ng.npz")
+        model.save(path)
+        loaded = OCLMRSLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+
+
+class TestOCLMRSLVQ_NGResume:
+    def test_resume_training(self, binary_data):
+        X, y = binary_data
+        model = OCLMRSLVQ_NG(
+            sigma=0.5, n_prototypes=3, target_label=0,
+            latent_dim=2, max_iter=30, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        loss_before = model.loss_
+        model.fit(X, y, resume=True)
+        assert model.loss_ < abs(loss_before) * 2.0
+
+
+# ===========================================================================
+# Reject option (parametrized across all 3 models)
+# ===========================================================================
+
+@pytest.mark.parametrize("ModelClass,kwargs", [
+    (OCRSLVQ_NG, {'sigma': 0.5}),
+    (OCMRSLVQ_NG, {'sigma': 0.5, 'latent_dim': 2}),
+    (OCLMRSLVQ_NG, {'sigma': 0.5, 'latent_dim': 2}),
+])
+class TestRejectOption:
+    def test_predict_with_reject(self, ModelClass, kwargs, binary_data):
+        X, y = binary_data
+        model = ModelClass(
+            n_prototypes=3, target_label=0,
+            max_iter=50, lr=0.01, random_seed=42, **kwargs,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.6, lower=0.4)
+        assert set(np.unique(preds).tolist()).issubset({-1, 0, 1})


### PR DESCRIPTION
## Summary
- Add 6 one-class probabilistic LVQ models: OCRSLVQ, OCMRSLVQ, OCLMRSLVQ (base) and OCRSLVQ_NG, OCMRSLVQ_NG, OCLMRSLVQ_NG (with Neural Gas cooperation)
- Threshold-based one-class detection + Gaussian soft-assignment over all prototypes
- NG variants add rank-based neighborhood cooperation with gamma decay scheduling
- OCRSLVQNGMixin consolidates shared NG logic across Euclidean, global omega, and local omega metric variants

## Test plan
- [x] 55 tests passing across 3 test files (test_oc_rslvq.py, test_oc_mrslvq.py, test_oc_rslvq_ng.py)
- [x] 6 examples running successfully on Iris dataset
- [x] No regressions in existing test suite (987 passed, 7 skipped)
- [x] Save/load, resume training, rejection classification all verified