### PR TITLE
feat: Add Matrix RSLVQ models (MRSLVQ, LMRSLVQ)

### DIFF
--- a/examples/lmrslvq_iris.py
+++ b/examples/lmrslvq_iris.py
@@ -1,0 +1,61 @@
+"""
+Localized Matrix Robust Soft LVQ (LMRSLVQ) example using Iris Data with JAX.
+
+This example demonstrates:
+- RSLVQ with per-prototype Omega matrices for local metric adaptation
+- Each prototype learns its own feature transformation
+- Probabilistic loss with locally-adapted distances
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import LMRSLVQ
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape}")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup LMRSLVQ model
+model = LMRSLVQ(
+    sigma=1.0,
+    latent_dim=2,
+    n_prototypes_per_class=1,
+    max_iter=100,
+    lr=0.01,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining LMRSLVQ...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Per-prototype Omega matrices
+print(f"\nLocal omegas shape: {model.omegas_.shape}")
+print(f"Prototype labels: {model.prototype_labels_}")
+
+# Class probabilities
+proba = model.predict_proba(X_test[:5])
+print(f"\nClass probabilities (first 5 samples):\n{proba}")

--- a/examples/mrslvq_iris.py
+++ b/examples/mrslvq_iris.py
@@ -1,0 +1,62 @@
+"""
+Matrix Robust Soft LVQ (MRSLVQ) example using Iris Data with JAX.
+
+This example demonstrates:
+- RSLVQ with a learned global Omega matrix for metric adaptation
+- Probabilistic loss: -log(P(correct|x) / P(all|x))
+- Omega-projected distances: d(x, w) = (x-w)^T Omega^T Omega (x-w)
+- Dimensionality reduction via latent_dim
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import MRSLVQ
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape}")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup MRSLVQ model with latent_dim for dimensionality reduction
+model = MRSLVQ(
+    sigma=1.0,
+    latent_dim=2,
+    n_prototypes_per_class=2,
+    max_iter=100,
+    lr=0.01,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining MRSLVQ...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Omega matrix
+print(f"\nOmega shape: {model.omega_matrix.shape}")
+print(f"Lambda (relevance matrix):\n{model.lambda_matrix}")
+
+# Class probabilities
+proba = model.predict_proba(X_test[:5])
+print(f"\nClass probabilities (first 5 samples):\n{proba}")

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -45,6 +45,7 @@ try:
     from .lvq21 import LVQ21
     from .median_lvq import MedianLVQ
     from .probabilistic_lvq import SLVQ, RSLVQ
+    from .matrix_rslvq import MRSLVQ, LMRSLVQ
     from .cbc import CBC
     from .lvqmln import LVQMLN
     from .plvq import PLVQ
@@ -93,6 +94,7 @@ try:
         'MCELVQ_NG': MCELVQ_NG, 'LCELVQ_NG': LCELVQ_NG, 'TCELVQ_NG': TCELVQ_NG,
         'LVQ1': LVQ1, 'LVQ21': LVQ21, 'MedianLVQ': MedianLVQ,
         'SLVQ': SLVQ, 'RSLVQ': RSLVQ,
+        'MRSLVQ': MRSLVQ, 'LMRSLVQ': LMRSLVQ,
         'CBC': CBC,
         'LVQMLN': LVQMLN, 'PLVQ': PLVQ,
         'SiameseGLVQ': SiameseGLVQ, 'SiameseGMLVQ': SiameseGMLVQ,
@@ -142,7 +144,7 @@ __all__ = [
     'GMLVQ', 'LGMLVQ', 'GTLVQ',
     'CELVQ', 'CELVQ_NG', 'MCELVQ_NG', 'LCELVQ_NG', 'TCELVQ_NG',
     'LVQ1', 'LVQ21', 'MedianLVQ',
-    'SLVQ', 'RSLVQ',
+    'SLVQ', 'RSLVQ', 'MRSLVQ', 'LMRSLVQ',
     'CBC',
     'LVQMLN', 'PLVQ',
     'SiameseGLVQ', 'SiameseGMLVQ', 'SiameseGTLVQ',

--- a/prosemble/models/matrix_rslvq.py
+++ b/prosemble/models/matrix_rslvq.py
@@ -1,0 +1,381 @@
+"""
+Matrix Robust Soft LVQ (MRSLVQ) and Localized Matrix RSLVQ (LMRSLVQ).
+
+RSLVQ with learned linear transformation(s) Omega for metric adaptation.
+MRSLVQ uses a single global Omega; LMRSLVQ uses per-prototype Omega_k.
+
+Distance: d(x, w_k) = (x - w_k)^T Omega^T Omega (x - w_k)
+Loss: -log(P(correct_class|x) / P(all|x))  [RSLVQ objective]
+
+References
+----------
+.. [1] Schneider, P., Biehl, M., & Hammer, B. (2009). Adaptive
+       Relevance Matrices in Learning Vector Quantization. Neural
+       Computation.
+.. [2] Seo, S., & Obermayer, K. (2007). Soft Nearest Prototype
+       Classification. IEEE Trans. Neural Networks.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import jit
+from functools import partial
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.core.competitions import wtac
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.losses import rslvq_loss
+from prosemble.core.pooling import stratified_min_pooling
+
+
+@jit
+def _predict_mrslvq_jit(X, prototypes, omega, proto_labels):
+    """JIT-compiled MRSLVQ prediction with learned Omega metric."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,dl->npl', diff, omega)
+    distances = jnp.sum(projected ** 2, axis=2)
+    return wtac(distances, proto_labels)
+
+
+@partial(jit, static_argnums=(4,))
+def _predict_proba_mrslvq_jit(X, prototypes, omega, proto_labels, n_classes):
+    """JIT-compiled MRSLVQ probability prediction."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,dl->npl', diff, omega)
+    distances = jnp.sum(projected ** 2, axis=2)
+    class_dists = stratified_min_pooling(distances, proto_labels, n_classes)
+    return jax.nn.softmax(-class_dists, axis=1)
+
+
+@jit
+def _predict_lmrslvq_jit(X, prototypes, omegas, proto_labels):
+    """JIT-compiled LMRSLVQ prediction with per-prototype Omega metrics."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,pdl->npl', diff, omegas)
+    distances = jnp.sum(projected ** 2, axis=2)
+    return wtac(distances, proto_labels)
+
+
+@partial(jit, static_argnums=(4,))
+def _predict_proba_lmrslvq_jit(X, prototypes, omegas, proto_labels, n_classes):
+    """JIT-compiled LMRSLVQ probability prediction."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,pdl->npl', diff, omegas)
+    distances = jnp.sum(projected ** 2, axis=2)
+    class_dists = stratified_min_pooling(distances, proto_labels, n_classes)
+    return jax.nn.softmax(-class_dists, axis=1)
+
+
+class MRSLVQ(SupervisedPrototypeModel):
+    """Matrix Robust Soft Learning Vector Quantization.
+
+    Combines the RSLVQ probabilistic loss with a learned global linear
+    mapping Omega (d x latent_dim) for metric adaptation:
+        d(x, w) = (x - w)^T Omega^T Omega (x - w)
+
+    The relevance matrix Lambda = Omega^T Omega captures feature
+    correlations in the probabilistic framework.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture.
+    latent_dim : int, optional
+        Dimensionality of the latent space. If None, uses input dim.
+    rejection_confidence : float, optional
+        Minimum class probability for a confident prediction (0 to 1).
+        Samples below this threshold are rejected (labeled -1) when using
+        ``predict_with_rejection()``. Default is None (no rejection).
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    """
+
+    def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.latent_dim = latent_dim
+        self.rejection_confidence = rejection_confidence
+        self.omega_ = None
+
+    def _get_resume_params(self, params):
+        params['omega'] = self.omega_
+        return params
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim or n_features
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+        omega = identity_omega_init(n_features, latent_dim)
+
+        params = {'prototypes': prototypes, 'omega': omega}
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omega = params['omega']
+        diff = X[:, None, :] - prototypes[None, :, :]  # (n, p, d)
+        projected = jnp.einsum('npd,dl->npl', diff, omega)  # (n, p, l)
+        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+        return rslvq_loss(distances, y, proto_labels, sigma=self.sigma)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omega_ = params['omega']
+
+    @property
+    def omega_matrix(self):
+        """Return the learned Omega matrix."""
+        if self.omega_ is None:
+            raise ValueError("Model not fitted.")
+        return self.omega_
+
+    @property
+    def lambda_matrix(self):
+        """Return Lambda = Omega^T Omega (relevance matrix)."""
+        if self.omega_ is None:
+            raise ValueError("Model not fitted.")
+        return self.omega_.T @ self.omega_
+
+    def predict(self, X):
+        """Predict using learned Omega distance."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_mrslvq_jit(
+            X, self.prototypes_, self.omega_, self.prototype_labels_
+        )
+
+    def predict_proba(self, X):
+        """Predict class probabilities using Omega-projected distances."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_proba_mrslvq_jit(
+            X, self.prototypes_, self.omega_, self.prototype_labels_,
+            self.n_classes_
+        )
+
+    def predict_with_rejection(self, X, confidence=None):
+        """Predict with rejection option.
+
+        Samples whose maximum class probability is below the confidence
+        threshold are assigned label -1 (rejected / "I don't know").
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+        confidence : float, optional
+            Override the model's rejection_confidence for this call.
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+            Predicted labels, or -1 for rejected samples.
+        """
+        self._check_fitted()
+        threshold = (confidence if confidence is not None
+                     else self.rejection_confidence)
+        if threshold is None:
+            return self.predict(X)
+
+        X = jnp.asarray(X, dtype=jnp.float32)
+        proba = self.predict_proba(X)
+        max_proba = jnp.max(proba, axis=1)
+        preds = jnp.argmax(proba, axis=1)
+        return jnp.where(max_proba >= threshold, preds, -1)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omega_ is not None:
+            attrs.append('omega_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_ is not None:
+            arrays['omega_'] = np.asarray(self.omega_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_' in arrays:
+            self.omega_ = jnp.asarray(arrays['omega_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['rejection_confidence'] = self.rejection_confidence
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp
+
+
+class LMRSLVQ(SupervisedPrototypeModel):
+    """Localized Matrix Robust Soft Learning Vector Quantization.
+
+    Each prototype k has its own Omega_k matrix. The distance from
+    sample x to prototype w_k is:
+        d(x, w_k) = (x - w_k)^T Omega_k^T Omega_k (x - w_k)
+
+    Combined with the RSLVQ probabilistic loss for metric-adaptive
+    soft classification with local relevance learning.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture.
+    latent_dim : int, optional
+        Latent space dimensionality per prototype. If None, uses input dim.
+    rejection_confidence : float, optional
+        Minimum class probability for a confident prediction (0 to 1).
+        Samples below this threshold are rejected (labeled -1) when using
+        ``predict_with_rejection()``. Default is None (no rejection).
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    """
+
+    def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.latent_dim = latent_dim
+        self.rejection_confidence = rejection_confidence
+        self.omegas_ = None
+
+    def _get_resume_params(self, params):
+        params['omegas'] = self.omegas_
+        return params
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim or n_features
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+        n_protos = prototypes.shape[0]
+        omega_single = identity_omega_init(n_features, latent_dim)
+        omegas = jnp.tile(omega_single[None, :, :], (n_protos, 1, 1))
+
+        params = {'prototypes': prototypes, 'omegas': omegas}
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']  # (p, d, l)
+        diff = X[:, None, :] - prototypes[None, :, :]  # (n, p, d)
+        projected = jnp.einsum('npd,pdl->npl', diff, omegas)  # (n, p, l)
+        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+        return rslvq_loss(distances, y, proto_labels, sigma=self.sigma)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omegas_ = params['omegas']
+
+    def predict(self, X):
+        """Predict using local Omega distances."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_lmrslvq_jit(
+            X, self.prototypes_, self.omegas_, self.prototype_labels_
+        )
+
+    def predict_proba(self, X):
+        """Predict class probabilities using local Omega-projected distances."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_proba_lmrslvq_jit(
+            X, self.prototypes_, self.omegas_, self.prototype_labels_,
+            self.n_classes_
+        )
+
+    def predict_with_rejection(self, X, confidence=None):
+        """Predict with rejection option.
+
+        Samples whose maximum class probability is below the confidence
+        threshold are assigned label -1 (rejected / "I don't know").
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+        confidence : float, optional
+            Override the model's rejection_confidence for this call.
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+            Predicted labels, or -1 for rejected samples.
+        """
+        self._check_fitted()
+        threshold = (confidence if confidence is not None
+                     else self.rejection_confidence)
+        if threshold is None:
+            return self.predict(X)
+
+        X = jnp.asarray(X, dtype=jnp.float32)
+        proba = self.predict_proba(X)
+        max_proba = jnp.max(proba, axis=1)
+        preds = jnp.argmax(proba, axis=1)
+        return jnp.where(max_proba >= threshold, preds, -1)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omegas_ is not None:
+            attrs.append('omegas_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omegas_ is not None:
+            arrays['omegas_'] = np.asarray(self.omegas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omegas_' in arrays:
+            self.omegas_ = jnp.asarray(arrays['omegas_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['rejection_confidence'] = self.rejection_confidence
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -50,6 +50,14 @@ Supervised LVQ
    :members: fit, predict, predict_proba
    :undoc-members:
 
+.. autoclass:: prosemble.models.MRSLVQ
+   :members: fit, predict, predict_proba
+   :undoc-members:
+
+.. autoclass:: prosemble.models.LMRSLVQ
+   :members: fit, predict, predict_proba
+   :undoc-members:
+
 .. autoclass:: prosemble.models.GLVQ1
    :members: fit, predict
    :undoc-members:

--- a/sphinx-docs/guides/supervised.rst
+++ b/sphinx-docs/guides/supervised.rst
@@ -203,6 +203,38 @@ log-likelihood training with confidence-based rejection.
    )
    model.fit(X_train, y_train)
 
+**MRSLVQ** — Matrix RSLVQ with global Omega metric learning:
+
+.. code-block:: python
+
+   from prosemble.models import MRSLVQ
+
+   model = MRSLVQ(
+       n_prototypes_per_class=1,
+       latent_dim=2,
+       sigma=1.0,
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X_train, y_train)
+   print(model.omega_matrix.shape)   # (n_features, latent_dim)
+   print(model.lambda_matrix)        # Omega^T @ Omega
+
+**LMRSLVQ** — Local Matrix RSLVQ with per-prototype Omega matrices:
+
+.. code-block:: python
+
+   from prosemble.models import LMRSLVQ
+
+   model = LMRSLVQ(
+       n_prototypes_per_class=1,
+       latent_dim=2,
+       sigma=1.0,
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X_train, y_train)
+
 Median LVQ
 ----------
 

--- a/tests/test_matrix_rslvq.py
+++ b/tests/test_matrix_rslvq.py
@@ -1,0 +1,181 @@
+"""Tests for MRSLVQ and LMRSLVQ."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from prosemble.models.matrix_rslvq import MRSLVQ, LMRSLVQ
+
+
+@pytest.fixture
+def separable_2d():
+    X = jnp.array([
+        [0.0, 0.0], [0.1, 0.1], [0.2, 0.0], [-0.1, 0.2],
+        [1.0, 1.0], [1.1, 1.1], [1.2, 1.0], [0.9, 1.2],
+    ])
+    y = jnp.array([0, 0, 0, 0, 1, 1, 1, 1])
+    return X, y
+
+
+@pytest.fixture
+def iris_data():
+    from sklearn.datasets import load_iris
+    data = load_iris()
+    return jnp.array(data.data, dtype=jnp.float32), jnp.array(data.target, dtype=jnp.int32)
+
+
+class TestMRSLVQ:
+    def test_fit_predict(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (8,)
+
+    def test_loss_decreases(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_omega_matrix(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=30, lr=0.05)
+        model.fit(X, y)
+        omega = model.omega_matrix
+        assert omega.shape == (2, 2)
+
+    def test_lambda_matrix(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=30, lr=0.05)
+        model.fit(X, y)
+        lam = model.lambda_matrix
+        assert lam.shape == (2, 2)
+        np.testing.assert_allclose(lam, lam.T, atol=1e-5)
+
+    def test_latent_dim(self, iris_data):
+        X, y = iris_data
+        model = MRSLVQ(
+            sigma=1.0, latent_dim=2, n_prototypes_per_class=1,
+            max_iter=30, lr=0.01,
+        )
+        model.fit(X, y)
+        assert model.omega_matrix.shape == (4, 2)
+
+    def test_accuracy(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=100, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy >= 0.75
+
+    def test_predict_proba(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        proba = model.predict_proba(X)
+        assert proba.shape == (8, 2)
+        np.testing.assert_allclose(jnp.sum(proba, axis=1), 1.0, atol=1e-5)
+
+    def test_rejection(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ(
+            sigma=0.5, rejection_confidence=0.99,
+            n_prototypes_per_class=1, max_iter=50, lr=0.05,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_rejection(X)
+        assert preds.shape == (8,)
+        # With high threshold, some samples may be rejected
+        assert jnp.any(preds == -1) or jnp.all(preds >= 0)
+
+    def test_save_load(self, separable_2d, tmp_path):
+        X, y = separable_2d
+        model = MRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        path = str(tmp_path / "mrslvq.npz")
+        model.save(path)
+        loaded = MRSLVQ.load(path)
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+    def test_iris_accuracy(self, iris_data):
+        X, y = iris_data
+        model = MRSLVQ(
+            sigma=1.0, n_prototypes_per_class=2, max_iter=100, lr=0.01,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy > 0.6
+
+
+class TestLMRSLVQ:
+    def test_fit_predict(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (8,)
+
+    def test_loss_decreases(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_local_omegas(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=20, lr=0.05)
+        model.fit(X, y)
+        assert model.omegas_.shape == (2, 2, 2)  # 2 protos, 2x2 omegas
+
+    def test_latent_dim(self, iris_data):
+        X, y = iris_data
+        model = LMRSLVQ(
+            sigma=1.0, latent_dim=2, n_prototypes_per_class=1,
+            max_iter=20, lr=0.01,
+        )
+        model.fit(X, y)
+        assert model.omegas_.shape == (3, 4, 2)  # 3 protos, 4x2 omegas
+
+    def test_accuracy(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=100, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy >= 0.75
+
+    def test_predict_proba(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        proba = model.predict_proba(X)
+        assert proba.shape == (8, 2)
+        np.testing.assert_allclose(jnp.sum(proba, axis=1), 1.0, atol=1e-5)
+
+    def test_rejection(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ(
+            sigma=0.5, rejection_confidence=0.99,
+            n_prototypes_per_class=1, max_iter=50, lr=0.05,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_rejection(X)
+        assert preds.shape == (8,)
+
+    def test_save_load(self, separable_2d, tmp_path):
+        X, y = separable_2d
+        model = LMRSLVQ(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        path = str(tmp_path / "lmrslvq.npz")
+        model.save(path)
+        loaded = LMRSLVQ.load(path)
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)


### PR DESCRIPTION
## Summary
- Add MRSLVQ: Matrix RSLVQ with global Omega projection for metric learning
- Add LMRSLVQ: Local Matrix RSLVQ with per-prototype Omega matrices
- Includes tests (18 total), examples, and Sphinx API + guide documentation

## Test plan
- [x] 10 tests for MRSLVQ (fit/predict, loss, omega/lambda matrices, latent_dim, accuracy, proba, rejection, save/load, iris)
- [x] 8 tests for LMRSLVQ (fit/predict, loss, local omegas, latent_dim, accuracy, proba, rejection, save/load)
- [x] MRSLVQ example: 96.67% test accuracy
- [x] LMRSLVQ example: 96.67% test accuracy
- [x] Sphinx docs build with no warnings