### PR TITLE
refactor: Extract CELVQNGMixin to deduplicate CELVQ-NG family

### DIFF
--- a/prosemble/models/celvq_ng.py
+++ b/prosemble/models/celvq_ng.py
@@ -20,14 +20,11 @@ References
        Letters.
 """
 
-import jax
-import jax.numpy as jnp
-import numpy as np
-
-from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.models.celvq_ng_mixin import CELVQNGMixin
+from prosemble.models.crossentropy_lvq import CELVQ
 
 
-class CELVQ_NG(SupervisedPrototypeModel):
+class CELVQ_NG(CELVQNGMixin, CELVQ):
     """Cross-Entropy LVQ with Neural Gas neighborhood cooperation.
 
     For each class, prototypes are ranked by distance and weighted
@@ -56,133 +53,5 @@ class CELVQ_NG(SupervisedPrototypeModel):
         Final gamma value after training.
     """
 
-    def __init__(self, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
-        self.gamma_init = gamma_init
-        self.gamma_final = gamma_final
-        self.gamma_decay = gamma_decay
-        self.gamma_ = None
-
-        # Ensure gamma is frozen from optimizer (not trainable)
-        if self.freeze_params is None:
-            self.freeze_params = ['gamma']
-        elif 'gamma' not in self.freeze_params:
-            self.freeze_params = list(self.freeze_params) + ['gamma']
-
-    def _get_resume_params(self, params):
-        gamma = self.gamma_ if self.gamma_ is not None else (
-            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
-        )
-        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
-        return params
-
-    def _init_state(self, X, y, key):
-        key1, key2 = jax.random.split(key)
-        prototypes, proto_labels = self._init_prototypes(
-            X, y, self.n_prototypes_per_class, key1
-        )
-
-        # Compute gamma_init from prototype count if not set
-        if isinstance(self.n_prototypes_per_class, int):
-            max_per_class = self.n_prototypes_per_class
-        elif isinstance(self.n_prototypes_per_class, dict):
-            max_per_class = max(self.n_prototypes_per_class.values())
-        else:
-            max_per_class = max(self.n_prototypes_per_class)
-        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
-        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
-        self._gamma_init_actual = gamma_init
-
-        # Compute decay factor
-        if self.gamma_decay is not None:
-            self._gamma_decay = self.gamma_decay
-        else:
-            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
-
-        params = {
-            'prototypes': prototypes,
-            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
-        }
-        opt_state = self._optimizer.init(params)
-        from prosemble.models.prototype_base import SupervisedState
-        state = SupervisedState(
-            prototypes=prototypes,
-            opt_state=opt_state,
-            loss=jnp.array(float('inf')),
-            iteration=0,
-            converged=False,
-        )
-        return state, params, proto_labels
-
-    def _compute_loss(self, params, X, y, proto_labels):
-        prototypes = params['prototypes']
-        gamma = params['gamma']
-        n_classes = self.n_classes_
-
-        # 1. Compute distances (n, p)
-        distances = self.distance_fn(X, prototypes)
-
-        # 2. NG-weighted per-class distance pooling
-        INF = jnp.finfo(distances.dtype).max
-        class_dists_list = []
-
-        for c in range(n_classes):
-            # Mask: which prototypes belong to class c
-            class_mask = (proto_labels == c)  # (p,)
-
-            # Distances to class c prototypes (INF for non-class)
-            d_class = jnp.where(class_mask[None, :], distances, INF)  # (n, p)
-
-            # Rank within class c (double argsort)
-            order = jnp.argsort(d_class, axis=1)
-            ranks = jnp.argsort(order, axis=1).astype(jnp.float32)  # (n, p)
-
-            # NG neighborhood function
-            h = jnp.exp(-ranks / (gamma + 1e-10))  # (n, p)
-            h = jnp.where(class_mask[None, :], h, 0.0)  # zero non-class
-
-            # Normalize within class
-            C = jnp.sum(h, axis=1, keepdims=True)  # (n, 1)
-            h_normalized = h / (C + 1e-10)  # (n, p)
-
-            # NG-weighted class distance
-            weighted_dist = jnp.sum(h_normalized * distances, axis=1)  # (n,)
-            class_dists_list.append(weighted_dist)
-
-        # 3. Stack into (n, n_classes)
-        class_dists = jnp.stack(class_dists_list, axis=1)  # (n, n_classes)
-
-        # 4. Cross-entropy loss
-        logits = -class_dists  # negate: smaller distance = larger logit
-        log_probs = jax.nn.log_softmax(logits, axis=1)
-        target_one_hot = jax.nn.one_hot(y, n_classes)
-        return -jnp.mean(jnp.sum(target_one_hot * log_probs, axis=1))
-
-    def _post_update(self, params):
-        # Decay gamma (neighborhood range) each step
-        new_gamma = params['gamma'] * self._gamma_decay
-        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
-        return {**params, 'gamma': new_gamma}
-
-    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
-        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
-        self.gamma_ = float(params['gamma'])
-
-    def _get_fitted_arrays(self):
-        arrays = super()._get_fitted_arrays()
-        if self.gamma_ is not None:
-            arrays['gamma_'] = np.asarray(self.gamma_)
-        return arrays
-
-    def _set_fitted_arrays(self, arrays):
-        super()._set_fitted_arrays(arrays)
-        if 'gamma_' in arrays:
-            self.gamma_ = float(arrays['gamma_'])
-
-    def _get_hyperparams(self):
-        hp = super()._get_hyperparams()
-        hp['gamma_init'] = self.gamma_init
-        hp['gamma_final'] = self.gamma_final
-        hp['gamma_decay'] = self.gamma_decay
-        return hp
+    def _compute_distances(self, params, X):
+        return self.distance_fn(X, params['prototypes'])

--- a/prosemble/models/celvq_ng_mixin.py
+++ b/prosemble/models/celvq_ng_mixin.py
@@ -1,0 +1,192 @@
+"""
+Cross-Entropy Neural Gas Cooperation Mixin for CELVQ-NG variants.
+
+Provides shared gamma scheduling, NG rank-weighted per-class distance
+pooling, and cross-entropy loss computation. Subclasses override
+`_compute_distances` to define the metric-specific distance.
+
+This mixin consolidates the identical logic shared by CELVQ_NG,
+MCELVQ_NG, LCELVQ_NG, and TCELVQ_NG.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+class CELVQNGMixin:
+    """Mixin that adds Neural Gas cooperation to Cross-Entropy LVQ variants.
+
+    For each class, prototypes are ranked by distance and weighted by
+    exp(-rank / gamma). The NG-weighted class distances become logits
+    for cross-entropy loss over all classes simultaneously.
+
+    gamma decays from gamma_init -> gamma_final during training.
+
+    Subclasses must override `_compute_distances(params, X)` to return
+    a (n_samples, n_prototypes) distance matrix.
+
+    Parameters
+    ----------
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    """
+
+    def __init__(self, gamma_init=None, gamma_final=0.01,
+                 gamma_decay=None, **kwargs):
+        super().__init__(**kwargs)
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.gamma_ = None
+
+        # Freeze gamma from optimizer (not trainable)
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _compute_gamma_init(self):
+        """Compute gamma_init from prototype count if not set."""
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        # Compute decay factor
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
+
+        return gamma_init
+
+    def _init_state(self, X, y, key):
+        key1, key2 = jax.random.split(key)
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+
+        gamma_init = self._compute_gamma_init()
+
+        params = {
+            'prototypes': prototypes,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+
+        # Allow subclasses to add metric params (omega, omegas, etc.)
+        params = self._init_metric_params(params, X, prototypes, key2)
+
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _init_metric_params(self, params, X, prototypes, key):
+        """Override to add metric-specific params (omega, omegas, etc.)."""
+        return params
+
+    def _compute_distances(self, params, X):
+        """Compute distance matrix (n_samples, n_prototypes).
+
+        Must be overridden by subclasses to define metric-specific distance.
+        """
+        raise NotImplementedError
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        gamma = params['gamma']
+        n_classes = self.n_classes_
+
+        # 1. Compute distances (n, p)
+        distances = self._compute_distances(params, X)
+
+        # 2. NG-weighted per-class distance pooling
+        INF = jnp.finfo(distances.dtype).max
+        class_dists_list = []
+
+        for c in range(n_classes):
+            # Mask: which prototypes belong to class c
+            class_mask = (proto_labels == c)  # (p,)
+
+            # Distances to class c prototypes (INF for non-class)
+            d_class = jnp.where(class_mask[None, :], distances, INF)  # (n, p)
+
+            # Rank within class c (double argsort)
+            order = jnp.argsort(d_class, axis=1)
+            ranks = jnp.argsort(order, axis=1).astype(jnp.float32)  # (n, p)
+
+            # NG neighborhood function
+            h = jnp.exp(-ranks / (gamma + 1e-10))  # (n, p)
+            h = jnp.where(class_mask[None, :], h, 0.0)  # zero non-class
+
+            # Normalize within class
+            C = jnp.sum(h, axis=1, keepdims=True)  # (n, 1)
+            h_normalized = h / (C + 1e-10)  # (n, p)
+
+            # NG-weighted class distance
+            weighted_dist = jnp.sum(h_normalized * distances, axis=1)  # (n,)
+            class_dists_list.append(weighted_dist)
+
+        # 3. Stack into (n, n_classes)
+        class_dists = jnp.stack(class_dists_list, axis=1)  # (n, n_classes)
+
+        # 4. Cross-entropy loss
+        logits = -class_dists  # negate: smaller distance = larger logit
+        log_probs = jax.nn.log_softmax(logits, axis=1)
+        target_one_hot = jax.nn.one_hot(y, n_classes)
+        return -jnp.mean(jnp.sum(target_one_hot * log_probs, axis=1))
+
+    def _post_update(self, params):
+        # Decay gamma (neighborhood range) each step
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {**params, 'gamma': new_gamma}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.gamma_ = float(params['gamma'])
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        return hp

--- a/prosemble/models/lcelvq_ng.py
+++ b/prosemble/models/lcelvq_ng.py
@@ -30,7 +30,8 @@ import jax.numpy as jnp
 import numpy as np
 from jax import jit
 
-from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.models.celvq_ng_mixin import CELVQNGMixin
+from prosemble.models.crossentropy_lvq import CELVQ
 from prosemble.core.competitions import wtac
 from prosemble.core.initializers import identity_omega_init
 
@@ -44,7 +45,7 @@ def _predict_lcelvq_ng_jit(X, prototypes, omegas, proto_labels):
     return wtac(distances, proto_labels)
 
 
-class LCELVQ_NG(SupervisedPrototypeModel):
+class LCELVQ_NG(CELVQNGMixin, CELVQ):
     """Localized Matrix Cross-Entropy LVQ with Neural Gas cooperation.
 
     Combines three key ideas:
@@ -84,133 +85,33 @@ class LCELVQ_NG(SupervisedPrototypeModel):
         Final gamma value after training.
     """
 
-    def __init__(self, latent_dim=None, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
+    def __init__(self, latent_dim=None, **kwargs):
         super().__init__(**kwargs)
         self.latent_dim = latent_dim
-        self.gamma_init = gamma_init
-        self.gamma_final = gamma_final
-        self.gamma_decay = gamma_decay
         self.omegas_ = None
-        self.gamma_ = None
-
-        # Ensure gamma is frozen from optimizer (not trainable)
-        if self.freeze_params is None:
-            self.freeze_params = ['gamma']
-        elif 'gamma' not in self.freeze_params:
-            self.freeze_params = list(self.freeze_params) + ['gamma']
 
     def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
         params['omegas'] = self.omegas_
-        gamma = self.gamma_ if self.gamma_ is not None else (
-            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
-        )
-        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
         return params
 
-    def _init_state(self, X, y, key):
+    def _init_metric_params(self, params, X, prototypes, key):
         n_features = X.shape[1]
         latent_dim = self.latent_dim or n_features
-        key1, key2 = jax.random.split(key)
-
-        prototypes, proto_labels = self._init_prototypes(
-            X, y, self.n_prototypes_per_class, key1
-        )
         n_protos = prototypes.shape[0]
-        # Each prototype gets its own Omega
         omega_single = identity_omega_init(n_features, latent_dim)
         omegas = jnp.tile(omega_single[None, :, :], (n_protos, 1, 1))
+        params['omegas'] = omegas
+        return params
 
-        # Compute gamma_init from prototype count if not set
-        if isinstance(self.n_prototypes_per_class, int):
-            max_per_class = self.n_prototypes_per_class
-        elif isinstance(self.n_prototypes_per_class, dict):
-            max_per_class = max(self.n_prototypes_per_class.values())
-        else:
-            max_per_class = max(self.n_prototypes_per_class)
-        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
-        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
-        self._gamma_init_actual = gamma_init
-
-        # Compute decay factor
-        if self.gamma_decay is not None:
-            self._gamma_decay = self.gamma_decay
-        else:
-            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
-
-        params = {
-            'prototypes': prototypes,
-            'omegas': omegas,
-            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
-        }
-        opt_state = self._optimizer.init(params)
-        from prosemble.models.prototype_base import SupervisedState
-        state = SupervisedState(
-            prototypes=prototypes,
-            opt_state=opt_state,
-            loss=jnp.array(float('inf')),
-            iteration=0,
-            converged=False,
-        )
-        return state, params, proto_labels
-
-    def _compute_loss(self, params, X, y, proto_labels):
-        prototypes = params['prototypes']
-        omegas = params['omegas']  # (p, d, l)
-        gamma = params['gamma']
-        n_classes = self.n_classes_
-
-        # 1. Per-prototype Omega distance: d(x, w_k) = ||Omega_k(x - w_k)||^2
-        diff = X[:, None, :] - prototypes[None, :, :]  # (n, p, d)
-        projected = jnp.einsum('npd,pdl->npl', diff, omegas)  # (n, p, l)
-        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
-
-        # 2. NG-weighted per-class distance pooling
-        INF = jnp.finfo(distances.dtype).max
-        class_dists_list = []
-
-        for c in range(n_classes):
-            # Mask: which prototypes belong to class c
-            class_mask = (proto_labels == c)  # (p,)
-
-            # Distances to class c prototypes (INF for non-class)
-            d_class = jnp.where(class_mask[None, :], distances, INF)  # (n, p)
-
-            # Rank within class c (double argsort)
-            order = jnp.argsort(d_class, axis=1)
-            ranks = jnp.argsort(order, axis=1).astype(jnp.float32)  # (n, p)
-
-            # NG neighborhood function
-            h = jnp.exp(-ranks / (gamma + 1e-10))  # (n, p)
-            h = jnp.where(class_mask[None, :], h, 0.0)  # zero non-class
-
-            # Normalize within class
-            C = jnp.sum(h, axis=1, keepdims=True)  # (n, 1)
-            h_normalized = h / (C + 1e-10)  # (n, p)
-
-            # NG-weighted class distance
-            weighted_dist = jnp.sum(h_normalized * distances, axis=1)  # (n,)
-            class_dists_list.append(weighted_dist)
-
-        # 3. Stack into (n, n_classes)
-        class_dists = jnp.stack(class_dists_list, axis=1)  # (n, n_classes)
-
-        # 4. Cross-entropy loss
-        logits = -class_dists  # negate: smaller distance = larger logit
-        log_probs = jax.nn.log_softmax(logits, axis=1)
-        target_one_hot = jax.nn.one_hot(y, n_classes)
-        return -jnp.mean(jnp.sum(target_one_hot * log_probs, axis=1))
-
-    def _post_update(self, params):
-        # Decay gamma (neighborhood range) each step
-        new_gamma = params['gamma'] * self._gamma_decay
-        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
-        return {**params, 'gamma': new_gamma}
+    def _compute_distances(self, params, X):
+        diff = X[:, None, :] - params['prototypes'][None, :, :]  # (n, p, d)
+        projected = jnp.einsum('npd,pdl->npl', diff, params['omegas'])  # (n, p, l)
+        return jnp.sum(projected ** 2, axis=2)  # (n, p)
 
     def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
         super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
         self.omegas_ = params['omegas']
-        self.gamma_ = float(params['gamma'])
 
     def predict(self, X):
         """Predict using per-prototype Omega distances."""
@@ -259,22 +160,15 @@ class LCELVQ_NG(SupervisedPrototypeModel):
         arrays = super()._get_fitted_arrays()
         if self.omegas_ is not None:
             arrays['omegas_'] = np.asarray(self.omegas_)
-        if self.gamma_ is not None:
-            arrays['gamma_'] = np.asarray(self.gamma_)
         return arrays
 
     def _set_fitted_arrays(self, arrays):
         super()._set_fitted_arrays(arrays)
         if 'omegas_' in arrays:
             self.omegas_ = jnp.asarray(arrays['omegas_'])
-        if 'gamma_' in arrays:
-            self.gamma_ = float(arrays['gamma_'])
 
     def _get_hyperparams(self):
         hp = super()._get_hyperparams()
-        hp['gamma_init'] = self.gamma_init
-        hp['gamma_final'] = self.gamma_final
-        hp['gamma_decay'] = self.gamma_decay
         if self.latent_dim is not None:
             hp['latent_dim'] = self.latent_dim
         return hp

--- a/prosemble/models/mcelvq_ng.py
+++ b/prosemble/models/mcelvq_ng.py
@@ -29,7 +29,8 @@ import jax.numpy as jnp
 import numpy as np
 from jax import jit
 
-from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.models.celvq_ng_mixin import CELVQNGMixin
+from prosemble.models.crossentropy_lvq import CELVQ
 from prosemble.core.competitions import wtac
 from prosemble.core.initializers import identity_omega_init
 
@@ -43,7 +44,7 @@ def _predict_mcelvq_ng_jit(X, prototypes, omega, proto_labels):
     return wtac(distances, proto_labels)
 
 
-class MCELVQ_NG(SupervisedPrototypeModel):
+class MCELVQ_NG(CELVQNGMixin, CELVQ):
     """Matrix Cross-Entropy LVQ with Neural Gas neighborhood cooperation.
 
     Combines three key ideas:
@@ -82,130 +83,31 @@ class MCELVQ_NG(SupervisedPrototypeModel):
         Final gamma value after training.
     """
 
-    def __init__(self, latent_dim=None, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
+    def __init__(self, latent_dim=None, **kwargs):
         super().__init__(**kwargs)
         self.latent_dim = latent_dim
-        self.gamma_init = gamma_init
-        self.gamma_final = gamma_final
-        self.gamma_decay = gamma_decay
         self.omega_ = None
-        self.gamma_ = None
-
-        # Ensure gamma is frozen from optimizer (not trainable)
-        if self.freeze_params is None:
-            self.freeze_params = ['gamma']
-        elif 'gamma' not in self.freeze_params:
-            self.freeze_params = list(self.freeze_params) + ['gamma']
 
     def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
         params['omega'] = self.omega_
-        gamma = self.gamma_ if self.gamma_ is not None else (
-            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
-        )
-        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
         return params
 
-    def _init_state(self, X, y, key):
+    def _init_metric_params(self, params, X, prototypes, key):
         n_features = X.shape[1]
         latent_dim = self.latent_dim or n_features
-        key1, key2 = jax.random.split(key)
-
-        prototypes, proto_labels = self._init_prototypes(
-            X, y, self.n_prototypes_per_class, key1
-        )
         omega = identity_omega_init(n_features, latent_dim)
+        params['omega'] = omega
+        return params
 
-        # Compute gamma_init from prototype count if not set
-        if isinstance(self.n_prototypes_per_class, int):
-            max_per_class = self.n_prototypes_per_class
-        elif isinstance(self.n_prototypes_per_class, dict):
-            max_per_class = max(self.n_prototypes_per_class.values())
-        else:
-            max_per_class = max(self.n_prototypes_per_class)
-        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
-        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
-        self._gamma_init_actual = gamma_init
-
-        # Compute decay factor
-        if self.gamma_decay is not None:
-            self._gamma_decay = self.gamma_decay
-        else:
-            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
-
-        params = {
-            'prototypes': prototypes,
-            'omega': omega,
-            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
-        }
-        opt_state = self._optimizer.init(params)
-        from prosemble.models.prototype_base import SupervisedState
-        state = SupervisedState(
-            prototypes=prototypes,
-            opt_state=opt_state,
-            loss=jnp.array(float('inf')),
-            iteration=0,
-            converged=False,
-        )
-        return state, params, proto_labels
-
-    def _compute_loss(self, params, X, y, proto_labels):
-        prototypes = params['prototypes']
-        omega = params['omega']
-        gamma = params['gamma']
-        n_classes = self.n_classes_
-
-        # 1. Global Omega distance: d(x, w) = ||Omega(x - w)||^2
-        diff = X[:, None, :] - prototypes[None, :, :]  # (n, p, d)
-        projected = jnp.einsum('npd,dl->npl', diff, omega)  # (n, p, l)
-        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
-
-        # 2. NG-weighted per-class distance pooling
-        INF = jnp.finfo(distances.dtype).max
-        class_dists_list = []
-
-        for c in range(n_classes):
-            # Mask: which prototypes belong to class c
-            class_mask = (proto_labels == c)  # (p,)
-
-            # Distances to class c prototypes (INF for non-class)
-            d_class = jnp.where(class_mask[None, :], distances, INF)  # (n, p)
-
-            # Rank within class c (double argsort)
-            order = jnp.argsort(d_class, axis=1)
-            ranks = jnp.argsort(order, axis=1).astype(jnp.float32)  # (n, p)
-
-            # NG neighborhood function
-            h = jnp.exp(-ranks / (gamma + 1e-10))  # (n, p)
-            h = jnp.where(class_mask[None, :], h, 0.0)  # zero non-class
-
-            # Normalize within class
-            C = jnp.sum(h, axis=1, keepdims=True)  # (n, 1)
-            h_normalized = h / (C + 1e-10)  # (n, p)
-
-            # NG-weighted class distance
-            weighted_dist = jnp.sum(h_normalized * distances, axis=1)  # (n,)
-            class_dists_list.append(weighted_dist)
-
-        # 3. Stack into (n, n_classes)
-        class_dists = jnp.stack(class_dists_list, axis=1)  # (n, n_classes)
-
-        # 4. Cross-entropy loss
-        logits = -class_dists  # negate: smaller distance = larger logit
-        log_probs = jax.nn.log_softmax(logits, axis=1)
-        target_one_hot = jax.nn.one_hot(y, n_classes)
-        return -jnp.mean(jnp.sum(target_one_hot * log_probs, axis=1))
-
-    def _post_update(self, params):
-        # Decay gamma (neighborhood range) each step
-        new_gamma = params['gamma'] * self._gamma_decay
-        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
-        return {**params, 'gamma': new_gamma}
+    def _compute_distances(self, params, X):
+        diff = X[:, None, :] - params['prototypes'][None, :, :]  # (n, p, d)
+        projected = jnp.einsum('npd,dl->npl', diff, params['omega'])  # (n, p, l)
+        return jnp.sum(projected ** 2, axis=2)  # (n, p)
 
     def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
         super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
         self.omega_ = params['omega']
-        self.gamma_ = float(params['gamma'])
 
     @property
     def omega_matrix(self):
@@ -268,22 +170,15 @@ class MCELVQ_NG(SupervisedPrototypeModel):
         arrays = super()._get_fitted_arrays()
         if self.omega_ is not None:
             arrays['omega_'] = np.asarray(self.omega_)
-        if self.gamma_ is not None:
-            arrays['gamma_'] = np.asarray(self.gamma_)
         return arrays
 
     def _set_fitted_arrays(self, arrays):
         super()._set_fitted_arrays(arrays)
         if 'omega_' in arrays:
             self.omega_ = jnp.asarray(arrays['omega_'])
-        if 'gamma_' in arrays:
-            self.gamma_ = float(arrays['gamma_'])
 
     def _get_hyperparams(self):
         hp = super()._get_hyperparams()
-        hp['gamma_init'] = self.gamma_init
-        hp['gamma_final'] = self.gamma_final
-        hp['gamma_decay'] = self.gamma_decay
         if self.latent_dim is not None:
             hp['latent_dim'] = self.latent_dim
         return hp

--- a/prosemble/models/tcelvq_ng.py
+++ b/prosemble/models/tcelvq_ng.py
@@ -31,7 +31,8 @@ import jax.numpy as jnp
 import numpy as np
 from jax import jit
 
-from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.models.celvq_ng_mixin import CELVQNGMixin
+from prosemble.models.crossentropy_lvq import CELVQ
 from prosemble.core.competitions import wtac
 from prosemble.core.initializers import random_omega_init
 from prosemble.core.utils import orthogonalize
@@ -48,7 +49,7 @@ def _predict_tcelvq_ng_jit(X, prototypes, omegas, proto_labels):
     return wtac(distances, proto_labels)
 
 
-class TCELVQ_NG(SupervisedPrototypeModel):
+class TCELVQ_NG(CELVQNGMixin, CELVQ):
     """Tangent Cross-Entropy LVQ with Neural Gas neighborhood cooperation.
 
     Combines three key ideas:
@@ -88,138 +89,42 @@ class TCELVQ_NG(SupervisedPrototypeModel):
         Final gamma value after training.
     """
 
-    def __init__(self, subspace_dim=2, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
+    def __init__(self, subspace_dim=2, **kwargs):
         super().__init__(**kwargs)
         self.subspace_dim = subspace_dim
-        self.gamma_init = gamma_init
-        self.gamma_final = gamma_final
-        self.gamma_decay = gamma_decay
         self.omegas_ = None
-        self.gamma_ = None
-
-        # Ensure gamma is frozen from optimizer (not trainable)
-        if self.freeze_params is None:
-            self.freeze_params = ['gamma']
-        elif 'gamma' not in self.freeze_params:
-            self.freeze_params = list(self.freeze_params) + ['gamma']
 
     def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
         params['omegas'] = self.omegas_
-        gamma = self.gamma_ if self.gamma_ is not None else (
-            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
-        )
-        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
         return params
 
-    def _init_state(self, X, y, key):
+    def _init_metric_params(self, params, X, prototypes, key):
         n_features = X.shape[1]
-        key1, key2 = jax.random.split(key)
-
-        prototypes, proto_labels = self._init_prototypes(
-            X, y, self.n_prototypes_per_class, key1
-        )
         n_protos = prototypes.shape[0]
-
-        # Initialize each Omega as random orthogonal
-        keys = jax.random.split(key2, n_protos)
+        keys = jax.random.split(key, n_protos)
         omegas = jnp.stack([
             random_omega_init(n_features, self.subspace_dim, k) for k in keys
         ])  # (p, d, subspace_dim)
+        params['omegas'] = omegas
+        return params
 
-        # Compute gamma_init from prototype count if not set
-        if isinstance(self.n_prototypes_per_class, int):
-            max_per_class = self.n_prototypes_per_class
-        elif isinstance(self.n_prototypes_per_class, dict):
-            max_per_class = max(self.n_prototypes_per_class.values())
-        else:
-            max_per_class = max(self.n_prototypes_per_class)
-        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
-        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
-        self._gamma_init_actual = gamma_init
-
-        # Compute decay factor
-        if self.gamma_decay is not None:
-            self._gamma_decay = self.gamma_decay
-        else:
-            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
-
-        params = {
-            'prototypes': prototypes,
-            'omegas': omegas,
-            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
-        }
-        opt_state = self._optimizer.init(params)
-        from prosemble.models.prototype_base import SupervisedState
-        state = SupervisedState(
-            prototypes=prototypes,
-            opt_state=opt_state,
-            loss=jnp.array(float('inf')),
-            iteration=0,
-            converged=False,
-        )
-        return state, params, proto_labels
-
-    def _compute_loss(self, params, X, y, proto_labels):
-        prototypes = params['prototypes']
-        omegas = params['omegas']  # (p, d, s)
-        gamma = params['gamma']
-        n_classes = self.n_classes_
-
-        # 1. Tangent distance: d(x, w_k) = ||(I - Omega_k Omega_k^T)(x - w_k)||^2
-        diff = X[:, None, :] - prototypes[None, :, :]  # (n, p, d)
-        proj_onto_subspace = jnp.einsum('npd,pds->nps', diff, omegas)  # (n, p, s)
-        reconstruction = jnp.einsum('nps,pds->npd', proj_onto_subspace, omegas)  # (n, p, d)
+    def _compute_distances(self, params, X):
+        diff = X[:, None, :] - params['prototypes'][None, :, :]  # (n, p, d)
+        proj_onto_subspace = jnp.einsum('npd,pds->nps', diff, params['omegas'])  # (n, p, s)
+        reconstruction = jnp.einsum('nps,pds->npd', proj_onto_subspace, params['omegas'])  # (n, p, d)
         tangent_diff = diff - reconstruction  # (n, p, d)
-        distances = jnp.sum(tangent_diff ** 2, axis=2)  # (n, p)
-
-        # 2. NG-weighted per-class distance pooling
-        INF = jnp.finfo(distances.dtype).max
-        class_dists_list = []
-
-        for c in range(n_classes):
-            # Mask: which prototypes belong to class c
-            class_mask = (proto_labels == c)  # (p,)
-
-            # Distances to class c prototypes (INF for non-class)
-            d_class = jnp.where(class_mask[None, :], distances, INF)  # (n, p)
-
-            # Rank within class c (double argsort)
-            order = jnp.argsort(d_class, axis=1)
-            ranks = jnp.argsort(order, axis=1).astype(jnp.float32)  # (n, p)
-
-            # NG neighborhood function
-            h = jnp.exp(-ranks / (gamma + 1e-10))  # (n, p)
-            h = jnp.where(class_mask[None, :], h, 0.0)  # zero non-class
-
-            # Normalize within class
-            C = jnp.sum(h, axis=1, keepdims=True)  # (n, 1)
-            h_normalized = h / (C + 1e-10)  # (n, p)
-
-            # NG-weighted class distance
-            weighted_dist = jnp.sum(h_normalized * distances, axis=1)  # (n,)
-            class_dists_list.append(weighted_dist)
-
-        # 3. Stack into (n, n_classes)
-        class_dists = jnp.stack(class_dists_list, axis=1)  # (n, n_classes)
-
-        # 4. Cross-entropy loss
-        logits = -class_dists  # negate: smaller distance = larger logit
-        log_probs = jax.nn.log_softmax(logits, axis=1)
-        target_one_hot = jax.nn.one_hot(y, n_classes)
-        return -jnp.mean(jnp.sum(target_one_hot * log_probs, axis=1))
+        return jnp.sum(tangent_diff ** 2, axis=2)  # (n, p)
 
     def _post_update(self, params):
         # Decay gamma AND re-orthogonalize tangent bases
-        new_gamma = params['gamma'] * self._gamma_decay
-        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        params = super()._post_update(params)
         omegas = jax.vmap(orthogonalize)(params['omegas'])
-        return {**params, 'gamma': new_gamma, 'omegas': omegas}
+        return {**params, 'omegas': omegas}
 
     def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
         super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
         self.omegas_ = params['omegas']
-        self.gamma_ = float(params['gamma'])
 
     def predict(self, X):
         """Predict using tangent distance."""
@@ -270,21 +175,14 @@ class TCELVQ_NG(SupervisedPrototypeModel):
         arrays = super()._get_fitted_arrays()
         if self.omegas_ is not None:
             arrays['omegas_'] = np.asarray(self.omegas_)
-        if self.gamma_ is not None:
-            arrays['gamma_'] = np.asarray(self.gamma_)
         return arrays
 
     def _set_fitted_arrays(self, arrays):
         super()._set_fitted_arrays(arrays)
         if 'omegas_' in arrays:
             self.omegas_ = jnp.asarray(arrays['omegas_'])
-        if 'gamma_' in arrays:
-            self.gamma_ = float(arrays['gamma_'])
 
     def _get_hyperparams(self):
         hp = super()._get_hyperparams()
         hp['subspace_dim'] = self.subspace_dim
-        hp['gamma_init'] = self.gamma_init
-        hp['gamma_final'] = self.gamma_final
-        hp['gamma_decay'] = self.gamma_decay
         return hp


### PR DESCRIPTION
## Summary
- Extract shared gamma scheduling, NG rank-weighted pooling, and cross-entropy loss into `CELVQNGMixin`
- Each model now only implements `_compute_distances()` for its metric-specific logic
- Reduces ~1050 lines to ~530 lines (~50% reduction) with zero behavioral change

## Test plan
- [x] All 60 CELVQ-NG tests pass
- [x] All 4 examples produce identical 98.67% accuracy
- [x] Full test suite (845 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)