### PR TITLE
feat: Add Probabilistic LVQ with Neural Gas (RSLVQ-NG family)

### DIFF
--- a/examples/lmrslvq_ng_iris.py
+++ b/examples/lmrslvq_ng_iris.py
@@ -1,0 +1,63 @@
+"""
+Localized Matrix RSLVQ with Neural Gas (LMRSLVQ_NG) example using Iris Data with JAX.
+
+This example demonstrates:
+- RSLVQ probabilistic loss with NG neighborhood cooperation
+- Per-prototype Omega_k matrices for local metric adaptation
+- Gamma decay during training
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import LMRSLVQ_NG
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape}")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup LMRSLVQ_NG model
+model = LMRSLVQ_NG(
+    sigma=1.0,
+    latent_dim=2,
+    n_prototypes_per_class=2,
+    max_iter=100,
+    lr=0.01,
+    gamma_init=3.0,
+    gamma_final=0.01,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining LMRSLVQ_NG...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Per-prototype Omegas
+print(f"\nPer-prototype Omegas shape: {model.omegas_.shape}")
+
+# Class probabilities
+proba = model.predict_proba(X_test[:5])
+print(f"\nClass probabilities (first 5 samples):\n{proba}")

--- a/examples/mrslvq_ng_iris.py
+++ b/examples/mrslvq_ng_iris.py
@@ -1,0 +1,65 @@
+"""
+Matrix RSLVQ with Neural Gas Cooperation (MRSLVQ_NG) example using Iris Data with JAX.
+
+This example demonstrates:
+- RSLVQ probabilistic loss with NG neighborhood cooperation
+- Global Omega matrix for metric adaptation
+- Omega-projected distances: d(x, w) = (x-w)^T Omega^T Omega (x-w)
+- Gamma decay during training
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import MRSLVQ_NG
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape}")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup MRSLVQ_NG model with latent_dim for dimensionality reduction
+model = MRSLVQ_NG(
+    sigma=1.0,
+    latent_dim=2,
+    n_prototypes_per_class=2,
+    max_iter=100,
+    lr=0.01,
+    gamma_init=3.0,
+    gamma_final=0.01,
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining MRSLVQ_NG...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Omega matrix
+print(f"\nOmega shape: {model.omega_matrix.shape}")
+print(f"Lambda (relevance matrix):\n{model.lambda_matrix}")
+
+# Class probabilities
+proba = model.predict_proba(X_test[:5])
+print(f"\nClass probabilities (first 5 samples):\n{proba}")

--- a/examples/rslvq_ng_iris.py
+++ b/examples/rslvq_ng_iris.py
@@ -1,0 +1,59 @@
+"""
+RSLVQ with Neural Gas Cooperation (RSLVQ_NG) example using Iris Data with JAX.
+
+This example demonstrates:
+- RSLVQ probabilistic loss with NG neighborhood cooperation
+- Gamma decay: neighborhood range shrinks during training
+- When gamma -> 0, recovers standard RSLVQ behavior
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import RSLVQ_NG
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape} ({X.shape[1]} features)")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup RSLVQ_NG model
+model = RSLVQ_NG(
+    sigma=1.0,
+    n_prototypes_per_class=3,
+    max_iter=200,
+    lr=0.01,
+    gamma_init=5.0,       # Start with wide neighborhood cooperation
+    gamma_final=0.01,     # End near standard RSLVQ behavior
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining RSLVQ_NG...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Class probabilities
+proba = model.predict_proba(X_test[:5])
+print(f"\nClass probabilities (first 5 samples):\n{proba}")

--- a/prosemble/core/losses.py
+++ b/prosemble/core/losses.py
@@ -241,6 +241,61 @@ def rslvq_loss(distances, target_labels, prototype_labels, sigma=1.0):
     return jnp.mean(-jnp.log(likelihood + 1e-10))
 
 
+@jit
+def ng_rslvq_loss(distances, target_labels, prototype_labels, sigma=1.0, gamma=1.0):
+    """RSLVQ loss with Neural Gas rank-based neighborhood cooperation.
+
+    Combines Gaussian mixture prototype probabilities with NG rank weights
+    to create a neighborhood-cooperative probabilistic assignment:
+
+        p(k|x) = exp(-d_k / 2σ²) / Σ exp(-d_j / 2σ²)   [Gaussian]
+        h_k = exp(-rank_k / γ) / Σ exp(-rank_j / γ)      [NG weights]
+        w_k = p(k|x) · h_k / Σ p(j|x) · h_j             [combined]
+
+    The loss is -log(Σ w_k for correct class / Σ w_k for all).
+
+    Parameters
+    ----------
+    distances : array of shape (n, p)
+        Squared distances from samples to prototypes.
+    target_labels : array of shape (n,)
+        True class labels for samples.
+    prototype_labels : array of shape (p,)
+        Class labels assigned to prototypes.
+    sigma : float
+        Bandwidth of Gaussian mixture.
+    gamma : float
+        Neural Gas neighborhood range.
+
+    Returns
+    -------
+    scalar
+        Mean negative log-likelihood with NG cooperation.
+    """
+    # 1. Gaussian mixture probabilities (numerically stable)
+    log_probs = -distances / (2.0 * sigma ** 2)
+    log_norm = jnp.max(log_probs, axis=1, keepdims=True)
+    probs = jnp.exp(log_probs - log_norm)
+    probs = probs / (jnp.sum(probs, axis=1, keepdims=True) + 1e-10)
+
+    # 2. NG rank-based weighting (double argsort for ranks)
+    order = jnp.argsort(distances, axis=1)
+    ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+    h = jnp.exp(-ranks / (gamma + 1e-10))
+    h = h / (jnp.sum(h, axis=1, keepdims=True) + 1e-10)
+
+    # 3. Combined weights (Gaussian × NG), renormalized
+    weighted_probs = h * probs
+    weighted_probs = weighted_probs / (jnp.sum(weighted_probs, axis=1, keepdims=True) + 1e-10)
+
+    # 4. Sum correct-class weighted probabilities
+    same_class = (target_labels[:, None] == prototype_labels[None, :])
+    correct = jnp.sum(weighted_probs * same_class, axis=1)
+
+    # 5. RSLVQ objective: -log(P_correct)
+    return jnp.mean(-jnp.log(correct + 1e-10))
+
+
 # --- Cross-Entropy LVQ Loss ---
 
 @partial(jit, static_argnums=(3,))

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -46,6 +46,8 @@ try:
     from .median_lvq import MedianLVQ
     from .probabilistic_lvq import SLVQ, RSLVQ
     from .matrix_rslvq import MRSLVQ, LMRSLVQ
+    from .rslvq_ng import RSLVQ_NG
+    from .mrslvq_ng import MRSLVQ_NG, LMRSLVQ_NG
     from .cbc import CBC
     from .lvqmln import LVQMLN
     from .plvq import PLVQ
@@ -95,6 +97,7 @@ try:
         'LVQ1': LVQ1, 'LVQ21': LVQ21, 'MedianLVQ': MedianLVQ,
         'SLVQ': SLVQ, 'RSLVQ': RSLVQ,
         'MRSLVQ': MRSLVQ, 'LMRSLVQ': LMRSLVQ,
+        'RSLVQ_NG': RSLVQ_NG, 'MRSLVQ_NG': MRSLVQ_NG, 'LMRSLVQ_NG': LMRSLVQ_NG,
         'CBC': CBC,
         'LVQMLN': LVQMLN, 'PLVQ': PLVQ,
         'SiameseGLVQ': SiameseGLVQ, 'SiameseGMLVQ': SiameseGMLVQ,
@@ -145,6 +148,7 @@ __all__ = [
     'CELVQ', 'CELVQ_NG', 'MCELVQ_NG', 'LCELVQ_NG', 'TCELVQ_NG',
     'LVQ1', 'LVQ21', 'MedianLVQ',
     'SLVQ', 'RSLVQ', 'MRSLVQ', 'LMRSLVQ',
+    'RSLVQ_NG', 'MRSLVQ_NG', 'LMRSLVQ_NG',
     'CBC',
     'LVQMLN', 'PLVQ',
     'SiameseGLVQ', 'SiameseGMLVQ', 'SiameseGTLVQ',

--- a/prosemble/models/mrslvq_ng.py
+++ b/prosemble/models/mrslvq_ng.py
@@ -1,0 +1,496 @@
+"""
+Matrix RSLVQ with Neural Gas Cooperation (MRSLVQ_NG, LMRSLVQ_NG).
+
+Combines RSLVQ's probabilistic soft-assignment with Neural Gas
+neighborhood cooperation and learned linear metric adaptation.
+
+MRSLVQ_NG: global Omega matrix + NG cooperation
+LMRSLVQ_NG: per-prototype Omega matrices + NG cooperation
+
+When gamma -> 0, recovers standard MRSLVQ / LMRSLVQ behavior.
+
+References
+----------
+.. [1] Schneider, P., Biehl, M., & Hammer, B. (2009). Adaptive
+       Relevance Matrices in Learning Vector Quantization. Neural
+       Computation.
+.. [2] Seo, S., & Obermayer, K. (2007). Soft Nearest Prototype
+       Classification. IEEE Trans. Neural Networks.
+.. [3] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+       Neural Gas with General Similarity Measure. Neural Processing
+       Letters.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import jit
+from functools import partial
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.core.competitions import wtac
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.losses import ng_rslvq_loss
+from prosemble.core.pooling import stratified_min_pooling
+
+
+@jit
+def _predict_mrslvq_ng_jit(X, prototypes, omega, proto_labels):
+    """JIT-compiled MRSLVQ_NG prediction with learned Omega metric."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,dl->npl', diff, omega)
+    distances = jnp.sum(projected ** 2, axis=2)
+    return wtac(distances, proto_labels)
+
+
+@partial(jit, static_argnums=(4,))
+def _predict_proba_mrslvq_ng_jit(X, prototypes, omega, proto_labels, n_classes):
+    """JIT-compiled MRSLVQ_NG probability prediction."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,dl->npl', diff, omega)
+    distances = jnp.sum(projected ** 2, axis=2)
+    class_dists = stratified_min_pooling(distances, proto_labels, n_classes)
+    return jax.nn.softmax(-class_dists, axis=1)
+
+
+@jit
+def _predict_lmrslvq_ng_jit(X, prototypes, omegas, proto_labels):
+    """JIT-compiled LMRSLVQ_NG prediction with per-prototype Omega metrics."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,pdl->npl', diff, omegas)
+    distances = jnp.sum(projected ** 2, axis=2)
+    return wtac(distances, proto_labels)
+
+
+@partial(jit, static_argnums=(4,))
+def _predict_proba_lmrslvq_ng_jit(X, prototypes, omegas, proto_labels, n_classes):
+    """JIT-compiled LMRSLVQ_NG probability prediction."""
+    diff = X[:, None, :] - prototypes[None, :, :]
+    projected = jnp.einsum('npd,pdl->npl', diff, omegas)
+    distances = jnp.sum(projected ** 2, axis=2)
+    class_dists = stratified_min_pooling(distances, proto_labels, n_classes)
+    return jax.nn.softmax(-class_dists, axis=1)
+
+
+class MRSLVQ_NG(SupervisedPrototypeModel):
+    """Matrix Robust Soft LVQ with Neural Gas Cooperation.
+
+    Combines:
+    - RSLVQ probabilistic loss: -log(P(correct|x))
+    - Neural Gas cooperation: all prototypes weighted by rank via
+      exp(-rank / gamma)
+    - Global Omega matrix for metric adaptation:
+      d(x, w) = (x - w)^T Omega^T Omega (x - w)
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture.
+    latent_dim : int, optional
+        Dimensionality of the latent space. If None, uses input dim.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay. Default: computed from max_iter.
+    rejection_confidence : float, optional
+        Minimum class probability for confident prediction (0 to 1).
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    """
+
+    def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None,
+                 rejection_confidence=None, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.latent_dim = latent_dim
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.rejection_confidence = rejection_confidence
+        self.omega_ = None
+        self.gamma_ = None
+
+        # Freeze gamma from optimizer
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _get_resume_params(self, params):
+        params['omega'] = self.omega_
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim or n_features
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+        omega = identity_omega_init(n_features, latent_dim)
+
+        # Compute gamma_init from prototype count
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+
+        gamma_init = (self.gamma_init if self.gamma_init is not None
+                      else max_per_class / 2.0)
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (
+                self.gamma_final / gamma_init
+            ) ** (1.0 / self.max_iter)
+
+        params = {
+            'prototypes': prototypes,
+            'omega': omega,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omega = params['omega']
+        gamma = params['gamma']
+        diff = X[:, None, :] - prototypes[None, :, :]  # (n, p, d)
+        projected = jnp.einsum('npd,dl->npl', diff, omega)  # (n, p, l)
+        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+        return ng_rslvq_loss(distances, y, proto_labels,
+                             sigma=self.sigma, gamma=gamma)
+
+    def _post_update(self, params):
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {**params, 'gamma': new_gamma}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omega_ = params['omega']
+        self.gamma_ = float(params['gamma'])
+
+    @property
+    def omega_matrix(self):
+        """Return the learned Omega matrix."""
+        if self.omega_ is None:
+            raise ValueError("Model not fitted.")
+        return self.omega_
+
+    @property
+    def lambda_matrix(self):
+        """Return Lambda = Omega^T Omega (relevance matrix)."""
+        if self.omega_ is None:
+            raise ValueError("Model not fitted.")
+        return self.omega_.T @ self.omega_
+
+    def predict(self, X):
+        """Predict using learned Omega distance."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_mrslvq_ng_jit(
+            X, self.prototypes_, self.omega_, self.prototype_labels_
+        )
+
+    def predict_proba(self, X):
+        """Predict class probabilities using Omega-projected distances."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_proba_mrslvq_ng_jit(
+            X, self.prototypes_, self.omega_, self.prototype_labels_,
+            self.n_classes_
+        )
+
+    def predict_with_rejection(self, X, confidence=None):
+        """Predict with rejection option.
+
+        Samples whose maximum class probability is below the confidence
+        threshold are assigned label -1 (rejected).
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+        confidence : float, optional
+            Override the model's rejection_confidence for this call.
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        threshold = (confidence if confidence is not None
+                     else self.rejection_confidence)
+        if threshold is None:
+            return self.predict(X)
+
+        X = jnp.asarray(X, dtype=jnp.float32)
+        proba = self.predict_proba(X)
+        max_proba = jnp.max(proba, axis=1)
+        preds = jnp.argmax(proba, axis=1)
+        return jnp.where(max_proba >= threshold, preds, -1)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omega_ is not None:
+            attrs.append('omega_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_ is not None:
+            arrays['omega_'] = np.asarray(self.omega_)
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_' in arrays:
+            self.omega_ = jnp.asarray(arrays['omega_'])
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        hp['rejection_confidence'] = self.rejection_confidence
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp
+
+
+class LMRSLVQ_NG(SupervisedPrototypeModel):
+    """Localized Matrix Robust Soft LVQ with Neural Gas Cooperation.
+
+    Each prototype k has its own Omega_k matrix. Combined with RSLVQ
+    probabilistic loss and NG rank-based neighborhood cooperation.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture.
+    latent_dim : int, optional
+        Latent space dimensionality per prototype. If None, uses input dim.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay. Default: computed from max_iter.
+    rejection_confidence : float, optional
+        Minimum class probability for confident prediction (0 to 1).
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    """
+
+    def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None,
+                 rejection_confidence=None, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.latent_dim = latent_dim
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.rejection_confidence = rejection_confidence
+        self.omegas_ = None
+        self.gamma_ = None
+
+        # Freeze gamma from optimizer
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _get_resume_params(self, params):
+        params['omegas'] = self.omegas_
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim or n_features
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+        n_protos = prototypes.shape[0]
+        omega_single = identity_omega_init(n_features, latent_dim)
+        omegas = jnp.tile(omega_single[None, :, :], (n_protos, 1, 1))
+
+        # Compute gamma_init from prototype count
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+
+        gamma_init = (self.gamma_init if self.gamma_init is not None
+                      else max_per_class / 2.0)
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (
+                self.gamma_final / gamma_init
+            ) ** (1.0 / self.max_iter)
+
+        params = {
+            'prototypes': prototypes,
+            'omegas': omegas,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']  # (p, d, l)
+        gamma = params['gamma']
+        diff = X[:, None, :] - prototypes[None, :, :]  # (n, p, d)
+        projected = jnp.einsum('npd,pdl->npl', diff, omegas)  # (n, p, l)
+        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+        return ng_rslvq_loss(distances, y, proto_labels,
+                             sigma=self.sigma, gamma=gamma)
+
+    def _post_update(self, params):
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {**params, 'gamma': new_gamma}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omegas_ = params['omegas']
+        self.gamma_ = float(params['gamma'])
+
+    def predict(self, X):
+        """Predict using local Omega distances."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_lmrslvq_ng_jit(
+            X, self.prototypes_, self.omegas_, self.prototype_labels_
+        )
+
+    def predict_proba(self, X):
+        """Predict class probabilities using local Omega-projected distances."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_proba_lmrslvq_ng_jit(
+            X, self.prototypes_, self.omegas_, self.prototype_labels_,
+            self.n_classes_
+        )
+
+    def predict_with_rejection(self, X, confidence=None):
+        """Predict with rejection option.
+
+        Samples whose maximum class probability is below the confidence
+        threshold are assigned label -1 (rejected).
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+        confidence : float, optional
+            Override the model's rejection_confidence for this call.
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        threshold = (confidence if confidence is not None
+                     else self.rejection_confidence)
+        if threshold is None:
+            return self.predict(X)
+
+        X = jnp.asarray(X, dtype=jnp.float32)
+        proba = self.predict_proba(X)
+        max_proba = jnp.max(proba, axis=1)
+        preds = jnp.argmax(proba, axis=1)
+        return jnp.where(max_proba >= threshold, preds, -1)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omegas_ is not None:
+            attrs.append('omegas_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omegas_ is not None:
+            arrays['omegas_'] = np.asarray(self.omegas_)
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omegas_' in arrays:
+            self.omegas_ = jnp.asarray(arrays['omegas_'])
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        hp['rejection_confidence'] = self.rejection_confidence
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp

--- a/prosemble/models/rslvq_ng.py
+++ b/prosemble/models/rslvq_ng.py
@@ -1,0 +1,191 @@
+"""
+RSLVQ with Neural Gas Cooperation (RSLVQ_NG).
+
+Combines RSLVQ's probabilistic soft-assignment with Neural Gas
+neighborhood cooperation. All prototypes contribute to the loss
+via Gaussian mixture probabilities, modulated by NG rank-based
+neighborhood weights.
+
+When gamma -> 0, only the nearest prototype matters, recovering
+standard RSLVQ behavior.
+
+References
+----------
+.. [1] Seo, S., & Obermayer, K. (2007). Soft Nearest Prototype
+       Classification. IEEE Trans. Neural Networks.
+.. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+       Neural Gas with General Similarity Measure. Neural Processing
+       Letters.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.core.losses import ng_rslvq_loss
+
+
+class RSLVQ_NG(SupervisedPrototypeModel):
+    """Robust Soft LVQ with Neural Gas Cooperation.
+
+    Combines:
+    - RSLVQ probabilistic loss: -log(P(correct|x))
+    - Neural Gas cooperation: all prototypes weighted by rank via
+      exp(-rank / gamma)
+    - Euclidean distance
+
+    The NG neighborhood modulates RSLVQ's Gaussian probabilities,
+    emphasizing nearby prototypes. Gamma decays during training from
+    gamma_init to gamma_final.
+
+    Parameters
+    ----------
+    sigma : float
+        Bandwidth of Gaussian mixture.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay. Default: computed from max_iter.
+    rejection_confidence : float, optional
+        Minimum class probability for confident prediction (0 to 1).
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    """
+
+    def __init__(self, sigma=1.0, gamma_init=None, gamma_final=0.01,
+                 gamma_decay=None, rejection_confidence=None, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.rejection_confidence = rejection_confidence
+        self.gamma_ = None
+
+        # Freeze gamma from optimizer
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _get_resume_params(self, params):
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _init_state(self, X, y, key):
+        key1, key2 = jax.random.split(key)
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+
+        # Compute gamma_init from prototype count
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+
+        gamma_init = (self.gamma_init if self.gamma_init is not None
+                      else max_per_class / 2.0)
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (
+                self.gamma_final / gamma_init
+            ) ** (1.0 / self.max_iter)
+
+        params = {
+            'prototypes': prototypes,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        gamma = params['gamma']
+        distances = self.distance_fn(X, prototypes)
+        return ng_rslvq_loss(distances, y, proto_labels,
+                             sigma=self.sigma, gamma=gamma)
+
+    def _post_update(self, params):
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {**params, 'gamma': new_gamma}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.gamma_ = float(params['gamma'])
+
+    def predict_with_rejection(self, X, confidence=None):
+        """Predict with rejection option.
+
+        Samples whose maximum class probability is below the confidence
+        threshold are assigned label -1 (rejected).
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+        confidence : float, optional
+            Override the model's rejection_confidence for this call.
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        threshold = (confidence if confidence is not None
+                     else self.rejection_confidence)
+        if threshold is None:
+            return self.predict(X)
+
+        X = jnp.asarray(X, dtype=jnp.float32)
+        proba = self.predict_proba(X)
+        max_proba = jnp.max(proba, axis=1)
+        preds = jnp.argmax(proba, axis=1)
+        return jnp.where(max_proba >= threshold, preds, -1)
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma'] = self.sigma
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        hp['rejection_confidence'] = self.rejection_confidence
+        return hp

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -58,6 +58,18 @@ Supervised LVQ
    :members: fit, predict, predict_proba
    :undoc-members:
 
+.. autoclass:: prosemble.models.RSLVQ_NG
+   :members: fit, predict, predict_proba
+   :undoc-members:
+
+.. autoclass:: prosemble.models.MRSLVQ_NG
+   :members: fit, predict, predict_proba
+   :undoc-members:
+
+.. autoclass:: prosemble.models.LMRSLVQ_NG
+   :members: fit, predict, predict_proba
+   :undoc-members:
+
 .. autoclass:: prosemble.models.GLVQ1
    :members: fit, predict
    :undoc-members:

--- a/sphinx-docs/guides/supervised.rst
+++ b/sphinx-docs/guides/supervised.rst
@@ -235,6 +235,68 @@ log-likelihood training with confidence-based rejection.
    )
    model.fit(X_train, y_train)
 
+Probabilistic LVQ with Neural Gas (RSLVQ-NG Family)
+----------------------------------------------------
+
+The RSLVQ-NG family combines RSLVQ's Gaussian mixture probabilistic
+assignment with Neural Gas rank-based neighborhood cooperation. All
+prototypes participate in the loss, weighted by both their Gaussian
+probability and NG rank.
+
+**RSLVQ_NG** — Euclidean distance (base variant):
+
+.. code-block:: python
+
+   from prosemble.models import RSLVQ_NG
+
+   model = RSLVQ_NG(
+       n_prototypes_per_class=3,
+       sigma=1.0,
+       gamma_init=5.0,
+       gamma_final=0.01,
+       max_iter=100,
+       lr=0.01,
+   )
+   model.fit(X_train, y_train)
+
+**MRSLVQ_NG** — Global Omega matrix metric learning:
+
+.. code-block:: python
+
+   from prosemble.models import MRSLVQ_NG
+
+   model = MRSLVQ_NG(
+       n_prototypes_per_class=2,
+       latent_dim=2,
+       sigma=1.0,
+       gamma_init=5.0,
+       gamma_final=0.01,
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X_train, y_train)
+
+   # Learned metric matrices
+   print(model.omega_matrix.shape)   # (n_features, latent_dim)
+   print(model.lambda_matrix)        # Omega^T @ Omega
+
+**LMRSLVQ_NG** — Per-prototype local Omega matrices:
+
+.. code-block:: python
+
+   from prosemble.models import LMRSLVQ_NG
+
+   model = LMRSLVQ_NG(
+       n_prototypes_per_class=2,
+       latent_dim=2,
+       sigma=1.0,
+       gamma_init=5.0,
+       gamma_final=0.01,
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X_train, y_train)
+
 Median LVQ
 ----------
 

--- a/tests/test_mrslvq_ng.py
+++ b/tests/test_mrslvq_ng.py
@@ -1,0 +1,200 @@
+"""Tests for MRSLVQ_NG and LMRSLVQ_NG."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from prosemble.models.mrslvq_ng import MRSLVQ_NG, LMRSLVQ_NG
+
+
+@pytest.fixture
+def separable_2d():
+    X = jnp.array([
+        [0.0, 0.0], [0.1, 0.1], [0.2, 0.0], [-0.1, 0.2],
+        [1.0, 1.0], [1.1, 1.1], [1.2, 1.0], [0.9, 1.2],
+    ])
+    y = jnp.array([0, 0, 0, 0, 1, 1, 1, 1])
+    return X, y
+
+
+@pytest.fixture
+def iris_data():
+    from sklearn.datasets import load_iris
+    data = load_iris()
+    return jnp.array(data.data, dtype=jnp.float32), jnp.array(data.target, dtype=jnp.int32)
+
+
+class TestMRSLVQNG:
+    def test_fit_predict(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (8,)
+
+    def test_loss_decreases(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_omega_matrix(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=30, lr=0.05)
+        model.fit(X, y)
+        omega = model.omega_matrix
+        assert omega.shape == (2, 2)
+
+    def test_lambda_matrix(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=30, lr=0.05)
+        model.fit(X, y)
+        lam = model.lambda_matrix
+        assert lam.shape == (2, 2)
+        np.testing.assert_allclose(lam, lam.T, atol=1e-5)
+
+    def test_latent_dim(self, iris_data):
+        X, y = iris_data
+        model = MRSLVQ_NG(
+            sigma=1.0, latent_dim=2, n_prototypes_per_class=1,
+            max_iter=30, lr=0.01,
+        )
+        model.fit(X, y)
+        assert model.omega_matrix.shape == (4, 2)
+
+    def test_accuracy(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=100, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy >= 0.75
+
+    def test_predict_proba(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        proba = model.predict_proba(X)
+        assert proba.shape == (8, 2)
+        np.testing.assert_allclose(jnp.sum(proba, axis=1), 1.0, atol=1e-5)
+
+    def test_gamma_decays(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=2, max_iter=50, lr=0.05,
+            gamma_init=5.0, gamma_final=0.01,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 5.0
+        assert model.gamma_ >= 0.01
+
+    def test_rejection(self, separable_2d):
+        X, y = separable_2d
+        model = MRSLVQ_NG(
+            sigma=0.5, rejection_confidence=0.99,
+            n_prototypes_per_class=1, max_iter=50, lr=0.05,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_rejection(X)
+        assert preds.shape == (8,)
+        assert jnp.any(preds == -1) or jnp.all(preds >= 0)
+
+    def test_save_load(self, separable_2d, tmp_path):
+        X, y = separable_2d
+        model = MRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        path = str(tmp_path / "mrslvq_ng.npz")
+        model.save(path)
+        loaded = MRSLVQ_NG.load(path)
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+    def test_iris_accuracy(self, iris_data):
+        X, y = iris_data
+        model = MRSLVQ_NG(
+            sigma=1.0, n_prototypes_per_class=2, max_iter=100, lr=0.01,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy > 0.6
+
+
+class TestLMRSLVQNG:
+    def test_fit_predict(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (8,)
+
+    def test_loss_decreases(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_local_omegas(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=20, lr=0.05)
+        model.fit(X, y)
+        assert model.omegas_.shape == (2, 2, 2)  # 2 protos, 2x2 omegas
+
+    def test_latent_dim(self, iris_data):
+        X, y = iris_data
+        model = LMRSLVQ_NG(
+            sigma=1.0, latent_dim=2, n_prototypes_per_class=1,
+            max_iter=20, lr=0.01,
+        )
+        model.fit(X, y)
+        assert model.omegas_.shape == (3, 4, 2)  # 3 protos, 4x2 omegas
+
+    def test_accuracy(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=100, lr=0.05)
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy >= 0.75
+
+    def test_predict_proba(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        proba = model.predict_proba(X)
+        assert proba.shape == (8, 2)
+        np.testing.assert_allclose(jnp.sum(proba, axis=1), 1.0, atol=1e-5)
+
+    def test_gamma_decays(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=2, max_iter=50, lr=0.05,
+            gamma_init=5.0, gamma_final=0.01,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 5.0
+        assert model.gamma_ >= 0.01
+
+    def test_rejection(self, separable_2d):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(
+            sigma=0.5, rejection_confidence=0.99,
+            n_prototypes_per_class=1, max_iter=50, lr=0.05,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_rejection(X)
+        assert preds.shape == (8,)
+
+    def test_save_load(self, separable_2d, tmp_path):
+        X, y = separable_2d
+        model = LMRSLVQ_NG(sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.05)
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        path = str(tmp_path / "lmrslvq_ng.npz")
+        model.save(path)
+        loaded = LMRSLVQ_NG.load(path)
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)

--- a/tests/test_rslvq_ng.py
+++ b/tests/test_rslvq_ng.py
@@ -1,0 +1,183 @@
+"""Tests for RSLVQ with Neural Gas Cooperation (RSLVQ_NG)."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tempfile
+import os
+
+from prosemble.models.rslvq_ng import RSLVQ_NG
+
+
+@pytest.fixture
+def iris_data():
+    """Iris dataset."""
+    from sklearn.datasets import load_iris
+    data = load_iris()
+    X = jnp.array(data.data, dtype=jnp.float32)
+    y = jnp.array(data.target, dtype=jnp.int32)
+    return X, y
+
+
+@pytest.fixture
+def separable_2d():
+    """Easy 2-class 2D dataset."""
+    X = jnp.array([
+        [0.0, 0.0], [0.1, 0.1], [0.2, 0.0], [-0.1, 0.2],
+        [1.0, 1.0], [1.1, 1.1], [1.2, 1.0], [0.9, 1.2],
+    ])
+    y = jnp.array([0, 0, 0, 0, 1, 1, 1, 1])
+    return X, y
+
+
+class TestRSLVQNGBasic:
+    def test_fit_predict(self, separable_2d):
+        X, y = separable_2d
+        model = RSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=2, max_iter=50, lr=0.01,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy >= 0.75
+
+    def test_iris(self, iris_data):
+        X, y = iris_data
+        model = RSLVQ_NG(
+            sigma=1.0, n_prototypes_per_class=2, max_iter=100, lr=0.01,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy > 0.60
+
+    def test_loss_decreases(self, separable_2d):
+        X, y = separable_2d
+        model = RSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=2, max_iter=50, lr=0.01,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[-1] < model.loss_history_[0]
+
+    def test_prototypes_shape(self, iris_data):
+        X, y = iris_data
+        model = RSLVQ_NG(
+            sigma=1.0, n_prototypes_per_class=3, max_iter=20, lr=0.01,
+        )
+        model.fit(X, y)
+        assert model.prototypes_.shape == (9, 4)  # 3 classes * 3 per class
+
+
+class TestRSLVQNGGammaDecay:
+    def test_gamma_decays(self, separable_2d):
+        X, y = separable_2d
+        model = RSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=2, max_iter=50, lr=0.01,
+            gamma_init=5.0, gamma_final=0.01,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 5.0
+        assert model.gamma_ >= 0.01
+
+    def test_gamma_reaches_final(self, separable_2d):
+        X, y = separable_2d
+        model = RSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=2, max_iter=200, lr=0.01,
+            gamma_init=5.0, gamma_final=0.01,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 5.0
+
+    def test_custom_gamma_decay(self, separable_2d):
+        X, y = separable_2d
+        model = RSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=2, max_iter=50, lr=0.01,
+            gamma_init=5.0, gamma_decay=0.95,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 1.0
+
+
+class TestRSLVQNGPrediction:
+    def test_predict_proba(self, separable_2d):
+        X, y = separable_2d
+        model = RSLVQ_NG(
+            sigma=0.5, n_prototypes_per_class=1, max_iter=50, lr=0.01,
+        )
+        model.fit(X, y)
+        proba = model.predict_proba(X)
+        assert proba.shape == (8, 2)
+        np.testing.assert_allclose(jnp.sum(proba, axis=1), 1.0, atol=1e-5)
+
+    def test_rejection(self, separable_2d):
+        X, y = separable_2d
+        model = RSLVQ_NG(
+            sigma=0.5, rejection_confidence=0.99,
+            n_prototypes_per_class=1, max_iter=50, lr=0.01,
+        )
+        model.fit(X, y)
+        preds = model.predict_with_rejection(X)
+        assert preds.shape == (8,)
+        assert jnp.any(preds == -1) or jnp.all(preds >= 0)
+
+
+class TestRSLVQNGSaveLoad:
+    def test_save_load_roundtrip(self, iris_data):
+        X, y = iris_data
+        model = RSLVQ_NG(
+            sigma=1.0, n_prototypes_per_class=2, max_iter=50, lr=0.01,
+        )
+        model.fit(X, y)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "rslvq_ng_model")
+            model.save(path)
+
+            loaded = RSLVQ_NG.load(path)
+            np.testing.assert_allclose(
+                np.asarray(model.prototypes_),
+                np.asarray(loaded.prototypes_),
+            )
+            preds_orig = model.predict(X)
+            preds_loaded = loaded.predict(X)
+            np.testing.assert_array_equal(preds_orig, preds_loaded)
+
+
+class TestRSLVQNGResume:
+    def test_resume_training(self, iris_data):
+        X, y = iris_data
+        model = RSLVQ_NG(
+            sigma=1.0, n_prototypes_per_class=2, max_iter=30, lr=0.01,
+        )
+        model.fit(X, y)
+        acc_before = float(jnp.mean(model.predict(X) == y))
+
+        model.fit(X, y, resume=True)
+        acc_after = float(jnp.mean(model.predict(X) == y))
+        assert acc_after >= acc_before - 0.05
+
+    def test_partial_fit(self, iris_data):
+        X, y = iris_data
+        model = RSLVQ_NG(
+            sigma=1.0, n_prototypes_per_class=2, max_iter=30, lr=0.01,
+        )
+        model.fit(X, y)
+        n_iter_before = model.n_iter_
+        model.partial_fit(X, y)
+        assert model.n_iter_ == n_iter_before + 1
+
+
+class TestRSLVQNGSmallGamma:
+    def test_small_gamma_like_rslvq(self, iris_data):
+        """With very small gamma, RSLVQ_NG should behave similarly to RSLVQ."""
+        X, y = iris_data
+        model = RSLVQ_NG(
+            sigma=1.0, n_prototypes_per_class=1, max_iter=100, lr=0.01,
+            gamma_init=0.001, gamma_final=0.001,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy > 0.60


### PR DESCRIPTION
## Summary
- Add `ng_rslvq_loss` combining Gaussian mixture probabilities with NG rank-based weighting
- **RSLVQ_NG**: Euclidean distance + Neural Gas cooperation
- **MRSLVQ_NG**: Global Omega metric learning + Neural Gas cooperation
- **LMRSLVQ_NG**: Per-prototype local Omega matrices + Neural Gas cooperation

## Test plan
- [x] 33 new tests pass (test_rslvq_ng.py + test_mrslvq_ng.py)
- [x] 3 examples run with good accuracy (96-100% on Iris)
- [x] Sphinx docs build with no warnings for new models