### PR TITLE
feat: Register SMNG, SLNG, STNG models for v2.0.0

### DIFF
--- a/examples/slng_iris.py
+++ b/examples/slng_iris.py
@@ -1,0 +1,60 @@
+"""
+Supervised Localized Matrix Neural Gas (SLNG) example using Iris Data with JAX.
+
+This example demonstrates:
+- Neighborhood cooperation: all same-class prototypes participate in
+  learning, weighted by rank (unlike GLVQ which only uses the closest)
+- Per-prototype Omega matrices learn local metrics for each region
+- Gamma decay: neighborhood range shrinks during training
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import SLNG
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape} ({X.shape[1]} features)")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup SLNG model
+model = SLNG(
+    n_prototypes_per_class=3,
+    max_iter=200,
+    lr=0.01,
+    gamma_init=5.0,       # Start with wide neighborhood cooperation
+    gamma_final=0.01,     # End near standard LGMLVQ behavior
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining SLNG...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Per-prototype Omega matrices
+n_protos = model.prototypes_.shape[0]
+print(f"\nNumber of prototypes: {n_protos}")
+print(f"Omegas shape: {model.omegas_.shape} (n_protos, n_features, latent_dim)")

--- a/examples/smng_iris.py
+++ b/examples/smng_iris.py
@@ -1,0 +1,60 @@
+"""
+Supervised Matrix Neural Gas (SMNG) example using Iris Data with JAX.
+
+This example demonstrates:
+- Neighborhood cooperation: all same-class prototypes participate in
+  learning, weighted by rank (unlike GLVQ which only uses the closest)
+- Global Omega matrix learns discriminative subspace (feature correlations)
+- Gamma decay: neighborhood range shrinks during training
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import SMNG
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape} ({X.shape[1]} features)")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup SMNG model
+model = SMNG(
+    n_prototypes_per_class=3,
+    max_iter=200,
+    lr=0.01,
+    gamma_init=5.0,       # Start with wide neighborhood cooperation
+    gamma_final=0.01,     # End near standard GMLVQ behavior
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining SMNG...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Lambda matrix (feature relevance)
+lambda_mat = model.lambda_matrix
+print(f"\nLambda matrix (Omega^T @ Omega) shape: {lambda_mat.shape}")
+print(f"Omega matrix shape: {model.omega_matrix.shape}")

--- a/examples/stng_iris.py
+++ b/examples/stng_iris.py
@@ -1,0 +1,62 @@
+"""
+Supervised Tangent Neural Gas (STNG) example using Iris Data with JAX.
+
+This example demonstrates:
+- Neighborhood cooperation: all same-class prototypes participate in
+  learning, weighted by rank (unlike GLVQ which only uses the closest)
+- Per-prototype tangent subspaces learn invariance directions
+- Orthogonalization maintained after each update
+- Gamma decay: neighborhood range shrinks during training
+"""
+
+import jax.numpy as jnp
+from prosemble.datasets import load_iris_jax
+from prosemble.core.utils import train_test_split_jax
+from prosemble.models import STNG
+
+# Load data
+dataset = load_iris_jax()
+X, y = dataset.input_data, dataset.labels
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split_jax(
+    X, y, test_size=0.2, random_seed=42
+)
+
+print(f"Dataset: {X.shape} ({X.shape[1]} features)")
+print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+
+# Setup STNG model
+model = STNG(
+    n_prototypes_per_class=3,
+    subspace_dim=2,       # Each prototype learns a 2D tangent subspace
+    max_iter=200,
+    lr=0.01,
+    gamma_init=5.0,       # Start with wide neighborhood cooperation
+    gamma_final=0.01,     # End near standard GTLVQ behavior
+    random_seed=42,
+)
+
+# Fit model
+print("\nTraining STNG...")
+model.fit(X_train, y_train)
+
+# Results
+print(f"Converged in {model.n_iter_} iterations")
+print(f"Final loss: {model.loss_:.4f}")
+print(f"Final gamma: {model.gamma_:.4f}")
+
+# Predictions
+train_preds = model.predict(X_train)
+test_preds = model.predict(X_test)
+
+train_acc = float(jnp.mean(train_preds == y_train))
+test_acc = float(jnp.mean(test_preds == y_test))
+
+print(f"\nTrain accuracy: {train_acc:.2%}")
+print(f"Test accuracy:  {test_acc:.2%}")
+
+# Tangent subspace info
+n_protos = model.prototypes_.shape[0]
+print(f"\nNumber of prototypes: {n_protos}")
+print(f"Omegas shape: {model.omegas_.shape} (n_protos, n_features, subspace_dim)")

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -33,6 +33,9 @@ try:
     from .glvq import GLVQ, GLVQ1, GLVQ21
     from .relevance_lvq import GRLVQ
     from .srng import SRNG
+    from .smng import SMNG
+    from .slng import SLNG
+    from .stng import STNG
     from .matrix_lvq import GMLVQ
     from .local_matrix_lvq import LGMLVQ
     from .tangent_lvq import GTLVQ
@@ -90,7 +93,7 @@ try:
         'KPFCM': KPFCM, 'KIPCM': KIPCM, 'KIPCM2': KIPCM2,
         # Supervised LVQ
         'GLVQ': GLVQ, 'GLVQ1': GLVQ1, 'GLVQ21': GLVQ21,
-        'GRLVQ': GRLVQ, 'SRNG': SRNG,
+        'GRLVQ': GRLVQ, 'SRNG': SRNG, 'SMNG': SMNG, 'SLNG': SLNG, 'STNG': STNG,
         'GMLVQ': GMLVQ, 'LGMLVQ': LGMLVQ,
         'GTLVQ': GTLVQ, 'CELVQ': CELVQ, 'CELVQ_NG': CELVQ_NG,
         'MCELVQ_NG': MCELVQ_NG, 'LCELVQ_NG': LCELVQ_NG, 'TCELVQ_NG': TCELVQ_NG,
@@ -143,7 +146,7 @@ __all__ = [
     'PCM', 'PFCM', 'SOM',
     # Supervised LVQ family
     'GLVQ', 'GLVQ1', 'GLVQ21',
-    'GRLVQ', 'SRNG',
+    'GRLVQ', 'SRNG', 'SMNG', 'SLNG', 'STNG',
     'GMLVQ', 'LGMLVQ', 'GTLVQ',
     'CELVQ', 'CELVQ_NG', 'MCELVQ_NG', 'LCELVQ_NG', 'TCELVQ_NG',
     'LVQ1', 'LVQ21', 'MedianLVQ',

--- a/prosemble/models/slng.py
+++ b/prosemble/models/slng.py
@@ -47,6 +47,7 @@ class SLNG(SupervisedPrototypeModel):
     """Supervised Localized Matrix Neural Gas.
 
     Combines three key ideas:
+
     - GLVQ loss: (d+ - d-) / (d+ + d-) for margin-based classification
     - Neural Gas cooperation: all same-class prototypes participate in
       the loss, weighted by rank via exp(-rank / gamma)

--- a/prosemble/models/smng.py
+++ b/prosemble/models/smng.py
@@ -48,6 +48,7 @@ class SMNG(SupervisedPrototypeModel):
     """Supervised Matrix Neural Gas.
 
     Combines three key ideas:
+
     - GLVQ loss: (d+ - d-) / (d+ + d-) for margin-based classification
     - Neural Gas cooperation: all same-class prototypes participate in
       the loss, weighted by rank via exp(-rank / gamma)

--- a/prosemble/models/stng.py
+++ b/prosemble/models/stng.py
@@ -51,6 +51,7 @@ class STNG(SupervisedPrototypeModel):
     """Supervised Tangent Neural Gas.
 
     Combines three key ideas:
+
     - GLVQ loss: (d+ - d-) / (d+ + d-) for margin-based classification
     - Neural Gas cooperation: all same-class prototypes participate in
       the loss, weighted by rank via exp(-rank / gamma)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prosemble"
-version = "1.1.3"
+version = "2.0.0"
 description = "A python project for prototype-based machine learning models"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -48,7 +48,7 @@ exclude = ["docs*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.1.3"
+current_version = "2.0.0"
 commit = true
 tag = true
 

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -134,6 +134,18 @@ Supervised Neural Gas
    :members: fit, predict, predict_proba
    :undoc-members:
 
+.. autoclass:: prosemble.models.SMNG
+   :members: fit, predict
+   :undoc-members:
+
+.. autoclass:: prosemble.models.SLNG
+   :members: fit, predict
+   :undoc-members:
+
+.. autoclass:: prosemble.models.STNG
+   :members: fit, predict
+   :undoc-members:
+
 Cross-Entropy Neural Gas
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sphinx-docs/guides/supervised.rst
+++ b/sphinx-docs/guides/supervised.rst
@@ -409,6 +409,63 @@ per-feature relevance weights (like GRLVQ).
    # Inspect relevances (SRNG learns feature weights like GRLVQ)
    print(model.relevances_)
 
+Supervised Matrix Neural Gas (SMNG, SLNG, STNG)
+------------------------------------------------
+
+The SMNG family extends SRNG with matrix metric adaptation while keeping
+Neural Gas neighborhood cooperation. All same-class prototypes participate
+in the loss weighted by rank.
+
+**SMNG** — Global Omega matrix (like GMLVQ + Neural Gas):
+
+.. code-block:: python
+
+   from prosemble.models import SMNG
+
+   model = SMNG(
+       n_prototypes_per_class=3,
+       gamma_init=5.0,
+       gamma_final=0.01,
+       max_iter=200,
+       lr=0.01,
+   )
+   model.fit(X_train, y_train)
+   print(model.omega_matrix.shape)   # (n_features, latent_dim)
+   print(model.lambda_matrix.shape)  # (n_features, n_features)
+
+**SLNG** — Per-prototype Omega matrices (like LGMLVQ + Neural Gas):
+
+.. code-block:: python
+
+   from prosemble.models import SLNG
+
+   model = SLNG(
+       n_prototypes_per_class=3,
+       gamma_init=5.0,
+       gamma_final=0.01,
+       max_iter=200,
+       lr=0.01,
+   )
+   model.fit(X_train, y_train)
+   print(model.omegas_.shape)  # (n_protos, n_features, latent_dim)
+
+**STNG** — Per-prototype tangent subspaces (like GTLVQ + Neural Gas):
+
+.. code-block:: python
+
+   from prosemble.models import STNG
+
+   model = STNG(
+       n_prototypes_per_class=3,
+       subspace_dim=2,
+       gamma_init=5.0,
+       gamma_final=0.01,
+       max_iter=200,
+       lr=0.01,
+   )
+   model.fit(X_train, y_train)
+   print(model.omegas_.shape)  # (n_protos, n_features, subspace_dim)
+
 Cross-Entropy Neural Gas (CELVQ-NG Family)
 -------------------------------------------
 


### PR DESCRIPTION
## Summary
- Register SMNG (Supervised Matrix Neural Gas), SLNG (Supervised Localized Matrix Neural Gas), STNG (Supervised Tangent Neural Gas) in the public API
- Add example scripts demonstrating each model on Iris dataset
- Add Sphinx API documentation and user guide entries
- Fix RST docstring formatting warnings
- Bump version to 2.0.0

## Test plan
- [x] All 49 SMNG/SLNG/STNG tests pass
- [x] All 1144 tests pass (full suite)
- [x] Example scripts run with 96-100% accuracy
- [x] Sphinx docs build with no new warnings