### PR TITLE
chore: Update Nix package to v2.0.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,8 +5,8 @@
 # 2. Add to pkgs/top-level/python-packages.nix:
 #      prosemble = callPackage ../development/python-modules/prosemble { };
 # 3. Update the hash after publishing to PyPI:
-#      nix-prefetch-url --unpack https://github.com/naotoo1/prosemble/archive/refs/tags/v1.0.0.tar.gz
-# 4. PR title: python3Packages.prosemble: init at 1.0.0
+#      nix-prefetch-url --unpack https://github.com/naotoo1/prosemble/archive/refs/tags/v2.0.0.tar.gz
+# 4. PR title: python3Packages.prosemble: init at 2.0.0
 {
   lib,
   buildPythonPackage,
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "prosemble";
-  version = "1.0.0";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "naotoo1";
     repo = "prosemble";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    hash = "sha256-6Oa7V7tFle74oYBNEaJ1ZCrrku8cav92YkzpnCxsH5c=";
   };
 
   build-system = [
@@ -68,16 +68,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTestPaths = [
-    # Deferred to v1.1
-    "tests/test_oc_glvq.py"
-    "tests/test_oc_glvq_ng.py"
-    "tests/test_oc_glvq_variants.py"
-    "tests/test_svq_occ.py"
-    "tests/test_svq_occ_r.py"
-    "tests/test_svq_occ_variants.py"
-    "tests/test_smng.py"
-    "tests/test_slng.py"
-    "tests/test_stng.py"
     "tests/test_riemannian_neural_gas.py"
   ];
 


### PR DESCRIPTION
## Summary
- Update Nix package version from 1.0.0 to 2.0.0
- Update source hash to match v2.0.0 tag
- Remove disabled test paths (all tests now pass)
- Only test_riemannian_neural_gas.py remains disabled (import error)

## Test plan
- [x] `nix-build` succeeds — 1144 tests pass in sandbox