### PR TITLE
docs: Remove unnecessary contents directive for Furo theme

### DIFF
--- a/sphinx-docs/guides/advanced.rst
+++ b/sphinx-docs/guides/advanced.rst
@@ -5,10 +5,6 @@ Prosemble leverages JAX for GPU acceleration, JIT compilation, and
 functional training loops. This guide covers all advanced features
 available for supervised prototype models and fuzzy clustering models.
 
-.. contents:: On this page
-   :local:
-   :depth: 2
-
 JIT-Compiled Inference
 -----------------------
 


### PR DESCRIPTION
## Summary
- Remove `.. contents::` directive from advanced.rst — Furo theme handles page navigation via its sidebar, making this directive unnecessary and causing a build warning

## Test plan
- [ ] Verify ReadTheDocs build succeeds without warnings
- [ ] Confirm sidebar navigation still works correctly on the advanced features page