### PR TITLE
docs: Fix RST formatting and documentation issues

### DIFF
--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -135,15 +135,15 @@ Supervised Neural Gas
    :undoc-members:
 
 .. autoclass:: prosemble.models.SMNG
-   :members: fit, predict
+   :members: fit, predict, predict_proba
    :undoc-members:
 
 .. autoclass:: prosemble.models.SLNG
-   :members: fit, predict
+   :members: fit, predict, predict_proba
    :undoc-members:
 
 .. autoclass:: prosemble.models.STNG
-   :members: fit, predict
+   :members: fit, predict, predict_proba
    :undoc-members:
 
 Cross-Entropy Neural Gas

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 project = 'Prosemble'
-copyright = '2024, Nana Abeka Otoo'
+copyright = '2024-2026, Nana Abeka Otoo'
 author = 'Nana Abeka Otoo'
 release = '2.0.0'
 

--- a/sphinx-docs/guides/topology.rst
+++ b/sphinx-docs/guides/topology.rst
@@ -144,7 +144,7 @@ is highest, automatically focusing model capacity on complex data regions.
 .. note::
 
    **Riemannian Neural Gas** (Neural Gas on manifolds: SO(n), SPD(n),
-   Grassmannian) is planned for **v1.1**.
+   Grassmannian) is available via ``prosemble.models.RiemannianNeuralGas``.
 
 Choosing a Model
 ----------------

--- a/sphinx-docs/installation.rst
+++ b/sphinx-docs/installation.rst
@@ -53,6 +53,6 @@ Verify Installation
 
    >>> import prosemble
    >>> print(prosemble.__version__)
-   1.0.0
+   2.0.0
    >>> import jax
    >>> print(jax.devices())  # Check available devices


### PR DESCRIPTION
## Summary
- Fix RST formatting in docstrings across 30+ files for proper Sphinx rendering (math formulas, bullet lists, substitution references)
- Update installation example version from 1.0.0 to 2.0.0
- Update copyright year to 2024-2026
- Add `predict_proba` to SMNG, SLNG, STNG API docs
- Update Riemannian Neural Gas status (now available in v2.0.0)
- Fix PFCM API docs to reference correct `predict_typicality` method
- Create `_static/` directory to suppress Sphinx warning

## Test plan
- [ ] Verify ReadTheDocs build completes without warnings
- [ ] Check mathematical formulas render correctly in API docs
- [ ] Confirm SMNG/SLNG/STNG show predict_proba in API reference