### PR TITLE
docs: Complete parameter documentation across all model docstrings

### DIFF
--- a/prosemble/models/afcm.py
+++ b/prosemble/models/afcm.py
@@ -119,6 +119,11 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = AFCM(n_clusters=2, fuzzifier=2.0, a=1.0, b=1.0, k=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'a', 'b', 'k', 'init_method')

--- a/prosemble/models/base.py
+++ b/prosemble/models/base.py
@@ -47,6 +47,14 @@ class FuzzyClusteringBase(MetadataCollectorMixin, QuantizationMixin, ABC):
         Whether to show PCA variance in visualization
     save_plot_path : str, optional
         Path to save final plot
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool, default=False
+        If True, restore centroids from the lowest-objective epoch.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Class Attributes (for subclasses)
     ----------------------------------

--- a/prosemble/models/cbc.py
+++ b/prosemble/models/cbc.py
@@ -56,10 +56,22 @@ class CBC(SupervisedPrototypeModel):
         Bandwidth for Gaussian similarity.
     margin : float
         Margin for the margin loss.
+    components_initializer : callable, optional
+        Initializer for component vectors. Default: None.
+    reasonings_initializer : callable, optional
+        Initializer for reasoning matrix. Default: None.
+    similarity_fn : callable, optional
+        Similarity function for component detection. Default: None
+        (uses Gaussian similarity).
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, n_components=5, n_classes=2, sigma=1.0,

--- a/prosemble/models/celvq_ng.py
+++ b/prosemble/models/celvq_ng.py
@@ -47,10 +47,10 @@ class CELVQ_NG(CELVQNGMixin, CELVQ):
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
 
-    Attributes
-    ----------
-    gamma_ : float
-        Final gamma value after training.
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/crossentropy_lvq.py
+++ b/prosemble/models/crossentropy_lvq.py
@@ -31,6 +31,11 @@ class CELVQ(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_loss(self, params, X, y, proto_labels):

--- a/prosemble/models/fcm.py
+++ b/prosemble/models/fcm.py
@@ -163,6 +163,11 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
 
     Dunn, J. C. (1973). A Fuzzy Relative of the ISODATA Process and
     Its Use in Detecting Compact Well-Separated Clusters.
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'init_method')

--- a/prosemble/models/fpcm.py
+++ b/prosemble/models/fpcm.py
@@ -110,6 +110,11 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
     >>> labels = model.predict(X)
     >>> U = model.predict_proba(X)
     >>> T = model.get_typicality(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'eta', 'init_method')

--- a/prosemble/models/glvq.py
+++ b/prosemble/models/glvq.py
@@ -38,6 +38,11 @@ class GLVQ(SupervisedPrototypeModel):
         Parameter for transfer function (e.g., sigmoid steepness).
     optimizer : str or optax optimizer
         Optimizer ('adam', 'sgd', or optax object).
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, beta=10.0, **kwargs):
@@ -63,6 +68,20 @@ class GLVQ1(SupervisedPrototypeModel):
     """GLVQ with LVQ1-style loss (gradient-based).
 
     Loss: d+ when correct, -d- when wrong.
+
+    Parameters
+    ----------
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_loss(self, params, X, y, proto_labels):
@@ -74,6 +93,20 @@ class GLVQ21(SupervisedPrototypeModel):
     """GLVQ with LVQ2.1-style loss (gradient-based, unnormalized).
 
     Loss: d+ - d- (no normalization by d+ + d-).
+
+    Parameters
+    ----------
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_loss(self, params, X, y, proto_labels):

--- a/prosemble/models/growing_neural_gas.py
+++ b/prosemble/models/growing_neural_gas.py
@@ -41,8 +41,11 @@ class GrowingNeuralGas(UnsupervisedPrototypeModel):
         Insert a new node every this many steps.
     error_decay : float
         Error decay factor applied to all nodes.
-    random_seed : int
-        Random seed.
+
+    See Also
+    --------
+    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
+        callbacks, use_scan, patience, etc.).
     """
 
     def __init__(self, max_nodes=100, lr_winner=0.1, lr_neighbor=0.01,

--- a/prosemble/models/hcm.py
+++ b/prosemble/models/hcm.py
@@ -94,6 +94,11 @@ class HCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = HCM(n_clusters=2, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('init_method',)

--- a/prosemble/models/heskes_som.py
+++ b/prosemble/models/heskes_som.py
@@ -72,8 +72,11 @@ class HeskesSOM(UnsupervisedPrototypeModel):
         Final neighborhood radius.
     max_iter : int
         Number of training epochs.
-    random_seed : int
-        Random seed.
+
+    See Also
+    --------
+    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
+        callbacks, use_scan, patience, etc.).
     """
 
     def __init__(self, grid_height=10, grid_width=10,

--- a/prosemble/models/image_cbc.py
+++ b/prosemble/models/image_cbc.py
@@ -58,14 +58,17 @@ class ImageCBC(SupervisedPrototypeModel):
         Number of output classes.
     sigma : float
         Bandwidth for Gaussian similarity.
-    margin : float
-        Margin for the margin loss.
     activation : str
         CNN activation.
     max_iter : int
         Training epochs.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,

--- a/prosemble/models/image_lvq.py
+++ b/prosemble/models/image_lvq.py
@@ -53,12 +53,20 @@ class ImageGLVQ(SupervisedPrototypeModel):
         CNN activation: 'relu', 'sigmoid', 'tanh', etc.
     beta : float
         GLVQ transfer function parameter.
+    bb_lr : float, optional
+        Separate learning rate for the backbone network. If None,
+        uses the same lr as prototypes. Default: None.
     n_prototypes_per_class : int
         Prototypes per class.
     max_iter : int
         Training epochs.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,
@@ -216,7 +224,20 @@ class ImageGMLVQ(SupervisedPrototypeModel):
     omega_dim : int, optional
         Omega mapping dimension. If None, uses latent_dim.
     activation : str
+        CNN activation function.
     beta : float
+        GLVQ transfer function parameter.
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Training epochs.
+    lr : float
+        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,
@@ -348,13 +369,28 @@ class ImageGTLVQ(SupervisedPrototypeModel):
     input_shape : tuple
         (height, width, channels).
     channels : list of int
+        CNN channels per layer.
     kernel_sizes : list of int
+        Kernel sizes per conv layer.
     latent_dim : int
         CNN output dimension.
     subspace_dim : int
         Tangent subspace dimension per prototype.
     activation : str
+        CNN activation function.
     beta : float
+        GLVQ transfer function parameter.
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Training epochs.
+    lr : float
+        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,

--- a/prosemble/models/ipcm.py
+++ b/prosemble/models/ipcm.py
@@ -124,6 +124,11 @@ class IPCM(FuzzyClusteringBase):
     >>> model = IPCM(n_clusters=2, fuzzifier=2.0, tipifier=2.0, k=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'k', 'init_method')

--- a/prosemble/models/ipcm2.py
+++ b/prosemble/models/ipcm2.py
@@ -120,6 +120,11 @@ class IPCM2(FuzzyClusteringBase):
     >>> model = IPCM2(n_clusters=2, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'init_method')

--- a/prosemble/models/kafcm.py
+++ b/prosemble/models/kafcm.py
@@ -86,6 +86,11 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = KAFCM(n_clusters=2, sigma=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'a', 'b', 'k', 'init_method')

--- a/prosemble/models/kfcm.py
+++ b/prosemble/models/kfcm.py
@@ -106,6 +106,11 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = KFCM(n_clusters=2, sigma=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'init_method')

--- a/prosemble/models/kfpcm.py
+++ b/prosemble/models/kfpcm.py
@@ -28,6 +28,11 @@ class KFPCM(ScanFitMixin, FuzzyClusteringBase):
     KFPCM maintains two matrices (U and T) in kernel space. U has row-sum-to-1
     constraint (standard FCM), while T has column-sum-to-1 constraint per the
     original Pal, Pal & Bezdek (1997) FPCM formulation.
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'eta', 'sigma', 'init_method')

--- a/prosemble/models/kipcm.py
+++ b/prosemble/models/kipcm.py
@@ -29,6 +29,11 @@ class KIPCM(FuzzyClusteringBase):
     """Kernel Improved Possibilistic C-Means with JAX.
 
     KIPCM uses two-phase approach in kernel space with product-based centroids.
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'k', 'sigma', 'init_method')

--- a/prosemble/models/kipcm2.py
+++ b/prosemble/models/kipcm2.py
@@ -29,6 +29,11 @@ class KIPCM2(FuzzyClusteringBase):
     """Kernel Improved Possibilistic C-Means 2 with JAX.
 
     KIPCM2 uses exponential T update and modified objective in kernel space.
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'sigma', 'init_method')

--- a/prosemble/models/kmeans.py
+++ b/prosemble/models/kmeans.py
@@ -58,6 +58,10 @@ class KMeansPlusPlus:
         Number of iterations run
     objective_ : float
         Final objective function value
+
+    See Also
+    --------
+    HCM : Hard C-Means model used internally after initialization.
     """
 
     def __init__(

--- a/prosemble/models/kohonen_som.py
+++ b/prosemble/models/kohonen_som.py
@@ -53,8 +53,11 @@ class KohonenSOM(UnsupervisedPrototypeModel):
         Final learning rate.
     max_iter : int
         Number of training epochs.
-    random_seed : int
-        Random seed.
+
+    See Also
+    --------
+    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
+        callbacks, use_scan, patience, etc.).
     """
 
     def __init__(self, grid_height=10, grid_width=10,

--- a/prosemble/models/kpcm.py
+++ b/prosemble/models/kpcm.py
@@ -114,6 +114,11 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = KPCM(n_clusters=2, sigma=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'init_method')

--- a/prosemble/models/kpfcm.py
+++ b/prosemble/models/kpfcm.py
@@ -28,6 +28,11 @@ class KPFCM(ScanFitMixin, FuzzyClusteringBase):
 
     KPFCM combines fuzzy membership (U) and typicality (T) in kernel space
     with weights a and b.
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'a', 'b', 'eta', 'k', 'init_method')

--- a/prosemble/models/lcelvq_ng.py
+++ b/prosemble/models/lcelvq_ng.py
@@ -78,12 +78,10 @@ class LCELVQ_NG(CELVQNGMixin, CELVQ):
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
 
-    Attributes
-    ----------
-    omegas_ : array of shape (n_prototypes, n_features, latent_dim)
-        Learned per-prototype Omega matrices after training.
-    gamma_ : float
-        Final gamma value after training.
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, **kwargs):

--- a/prosemble/models/local_matrix_lvq.py
+++ b/prosemble/models/local_matrix_lvq.py
@@ -49,6 +49,15 @@ class LGMLVQ(SupervisedPrototypeModel):
         Learning rate.
     beta : float
         Transfer function steepness.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, beta=10.0, **kwargs):

--- a/prosemble/models/lvq1.py
+++ b/prosemble/models/lvq1.py
@@ -37,10 +37,11 @@ class LVQ1(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
-    epsilon : float
-        Convergence threshold.
-    random_seed : int
-        Random seed.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, **kwargs):

--- a/prosemble/models/lvq21.py
+++ b/prosemble/models/lvq21.py
@@ -36,6 +36,11 @@ class LVQ21(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, **kwargs):

--- a/prosemble/models/lvqmln.py
+++ b/prosemble/models/lvqmln.py
@@ -205,12 +205,20 @@ class LVQMLN(SupervisedPrototypeModel):
         Activation function: 'sigmoid', 'relu', 'tanh', 'leaky_relu', 'selu'.
     beta : float
         Transfer function parameter for GLVQ loss.
+    bb_lr : float, optional
+        Separate learning rate for the backbone network. If None,
+        uses the same lr as prototypes. Default: None.
     n_prototypes_per_class : int
         Prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate for both backbone and prototypes.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,

--- a/prosemble/models/matrix_lvq.py
+++ b/prosemble/models/matrix_lvq.py
@@ -53,6 +53,15 @@ class GMLVQ(SupervisedPrototypeModel):
         Learning rate.
     beta : float
         Transfer function steepness.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, beta=10.0, **kwargs):

--- a/prosemble/models/matrix_rslvq.py
+++ b/prosemble/models/matrix_rslvq.py
@@ -94,6 +94,11 @@ class MRSLVQ(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,
@@ -258,6 +263,11 @@ class LMRSLVQ(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,

--- a/prosemble/models/mcelvq_ng.py
+++ b/prosemble/models/mcelvq_ng.py
@@ -76,12 +76,10 @@ class MCELVQ_NG(CELVQNGMixin, CELVQ):
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
 
-    Attributes
-    ----------
-    omega_ : array
-        Learned Omega projection matrix after training.
-    gamma_ : float
-        Final gamma value after training.
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, **kwargs):

--- a/prosemble/models/median_lvq.py
+++ b/prosemble/models/median_lvq.py
@@ -36,8 +36,11 @@ class MedianLVQ(SupervisedPrototypeModel):
         Prototypes per class.
     max_iter : int
         Maximum training iterations.
-    random_seed : int
-        Random seed.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, **kwargs):

--- a/prosemble/models/mrslvq_ng.py
+++ b/prosemble/models/mrslvq_ng.py
@@ -85,6 +85,12 @@ class MRSLVQ_NG(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
     sigma : float
         Bandwidth of Gaussian mixture.
     latent_dim : int, optional
@@ -97,12 +103,11 @@ class MRSLVQ_NG(SupervisedPrototypeModel):
         Per-step multiplicative decay. Default: computed from max_iter.
     rejection_confidence : float, optional
         Minimum class probability for confident prediction (0 to 1).
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,
@@ -301,6 +306,12 @@ class LMRSLVQ_NG(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
     sigma : float
         Bandwidth of Gaussian mixture.
     latent_dim : int, optional
@@ -313,12 +324,11 @@ class LMRSLVQ_NG(SupervisedPrototypeModel):
         Per-step multiplicative decay. Default: computed from max_iter.
     rejection_confidence : float, optional
         Minimum class probability for confident prediction (0 to 1).
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,

--- a/prosemble/models/neural_gas.py
+++ b/prosemble/models/neural_gas.py
@@ -55,8 +55,11 @@ class NeuralGas(UnsupervisedPrototypeModel):
         Initial neighborhood range.
     lambda_final : float
         Final neighborhood range.
-    random_seed : int
-        Random seed.
+
+    See Also
+    --------
+    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
+        callbacks, use_scan, patience, etc.).
     """
 
     def __init__(self, lr_init=0.5, lr_final=0.01,

--- a/prosemble/models/oc_glvq.py
+++ b/prosemble/models/oc_glvq.py
@@ -65,6 +65,11 @@ class OCGLVQ(SupervisedPrototypeModel):
     ----------
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype visibility thresholds.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, n_prototypes=3, target_label=None, beta=10.0,

--- a/prosemble/models/oc_glvq_ng.py
+++ b/prosemble/models/oc_glvq_ng.py
@@ -44,6 +44,11 @@ class OCGLVQ_NG(NGCooperationMixin, OCGLVQ):
     ----------
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_gmlvq.py
+++ b/prosemble/models/oc_gmlvq.py
@@ -47,6 +47,11 @@ class OCGMLVQ(OCGLVQ):
     ----------
     omega_ : array of shape (n_features, latent_dim)
         Learned projection matrix.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, **kwargs):

--- a/prosemble/models/oc_gmlvq_ng.py
+++ b/prosemble/models/oc_gmlvq_ng.py
@@ -46,6 +46,11 @@ class OCGMLVQ_NG(NGCooperationMixin, OCGMLVQ):
         Learned projection matrix.
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_grlvq.py
+++ b/prosemble/models/oc_grlvq.py
@@ -43,6 +43,11 @@ class OCGRLVQ(OCGLVQ):
     ----------
     relevances_ : array of shape (n_features,)
         Learned per-feature relevance weights (softmax-normalized).
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, **kwargs):

--- a/prosemble/models/oc_grlvq_ng.py
+++ b/prosemble/models/oc_grlvq_ng.py
@@ -45,6 +45,11 @@ class OCGRLVQ_NG(NGCooperationMixin, OCGRLVQ):
         Learned per-feature relevance weights.
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_gtlvq.py
+++ b/prosemble/models/oc_gtlvq.py
@@ -48,6 +48,11 @@ class OCGTLVQ(OCGLVQ):
     ----------
     omegas_ : array of shape (n_prototypes, n_features, subspace_dim)
         Learned per-prototype orthonormal tangent bases.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, subspace_dim=2, **kwargs):

--- a/prosemble/models/oc_gtlvq_ng.py
+++ b/prosemble/models/oc_gtlvq_ng.py
@@ -46,6 +46,11 @@ class OCGTLVQ_NG(NGCooperationMixin, OCGTLVQ):
         Learned per-prototype orthonormal tangent bases.
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_lgmlvq.py
+++ b/prosemble/models/oc_lgmlvq.py
@@ -46,6 +46,11 @@ class OCLGMLVQ(OCGLVQ):
     ----------
     omegas_ : array of shape (n_prototypes, n_features, latent_dim)
         Learned per-prototype projection matrices.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, **kwargs):

--- a/prosemble/models/oc_lgmlvq_ng.py
+++ b/prosemble/models/oc_lgmlvq_ng.py
@@ -46,6 +46,11 @@ class OCLGMLVQ_NG(NGCooperationMixin, OCLGMLVQ):
         Learned per-prototype projection matrices.
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_mrslvq.py
+++ b/prosemble/models/oc_mrslvq.py
@@ -60,6 +60,11 @@ class OCMRSLVQ(OCGLVQ):
         Learned projection matrix.
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype visibility thresholds.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, **kwargs):
@@ -230,6 +235,11 @@ class OCLMRSLVQ(OCGLVQ):
         Learned per-prototype projection matrices.
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype visibility thresholds.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, **kwargs):

--- a/prosemble/models/oc_mrslvq_ng.py
+++ b/prosemble/models/oc_mrslvq_ng.py
@@ -64,6 +64,11 @@ class OCMRSLVQ_NG(OCRSLVQNGMixin, OCMRSLVQ):
         Learned per-prototype acceptance thresholds.
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):
@@ -110,6 +115,11 @@ class OCLMRSLVQ_NG(OCRSLVQNGMixin, OCLMRSLVQ):
         Learned per-prototype acceptance thresholds.
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_rslvq.py
+++ b/prosemble/models/oc_rslvq.py
@@ -54,6 +54,11 @@ class OCRSLVQ(OCGLVQ):
     ----------
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype acceptance thresholds.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, **kwargs):

--- a/prosemble/models/oc_rslvq_ng.py
+++ b/prosemble/models/oc_rslvq_ng.py
@@ -56,6 +56,11 @@ class OCRSLVQ_NG(OCRSLVQNGMixin, OCRSLVQ):
         Learned per-prototype acceptance thresholds.
     gamma_ : float
         Final gamma value after training.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/pcm.py
+++ b/prosemble/models/pcm.py
@@ -140,6 +140,11 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         - Initialization from FCM (init_method='fcm') is recommended as it provides
           better starting points than random initialization.
         - All computations are JIT-compiled and can run on GPU if available.
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'k', 'init_method')

--- a/prosemble/models/pfcm.py
+++ b/prosemble/models/pfcm.py
@@ -130,6 +130,11 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
 
     n_iter_ : int
         Number of iterations performed
+
+    See Also
+    --------
+    FuzzyClusteringBase : Full list of base parameters (distance_fn,
+        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'a', 'b', 'eta', 'k', 'init_method')

--- a/prosemble/models/plvq.py
+++ b/prosemble/models/plvq.py
@@ -71,6 +71,11 @@ class PLVQ(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,

--- a/prosemble/models/probabilistic_lvq.py
+++ b/prosemble/models/probabilistic_lvq.py
@@ -45,6 +45,11 @@ class SLVQ(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, rejection_confidence=None, **kwargs):
@@ -111,6 +116,11 @@ class RSLVQ(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, rejection_confidence=None, **kwargs):

--- a/prosemble/models/prototype_base.py
+++ b/prosemble/models/prototype_base.py
@@ -227,6 +227,19 @@ class SupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC):
         - 'sync_period': int (default 6) — sync every k steps
         - 'slow_step_size': float (default 0.5) — interpolation factor
         Default: None (no lookahead).
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
     mixed_precision : str or None, optional
         Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
         Master weights stay in float32; forward/backward pass runs in lower
@@ -1691,6 +1704,10 @@ class UnsupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC)
         If True (default), use jax.lax.scan for training (faster, JIT-compiled,
         but runs all max_iter iterations even after convergence).
         If False, use a Python for-loop with true early stopping.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore parameters from the lowest-loss epoch. Default: False.
     """
 
     def __init__(

--- a/prosemble/models/relevance_lvq.py
+++ b/prosemble/models/relevance_lvq.py
@@ -33,6 +33,15 @@ class GRLVQ(SupervisedPrototypeModel):
         Learning rate.
     beta : float
         Transfer function steepness parameter.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, beta=10.0, **kwargs):

--- a/prosemble/models/riemannian_neural_gas.py
+++ b/prosemble/models/riemannian_neural_gas.py
@@ -56,8 +56,11 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
         Final neighborhood range. Default: 0.01.
     tau : float
         Safety factor for injectivity radius bound. Default: 0.9.
-    random_seed : int
-        Random seed.
+
+    See Also
+    --------
+    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
+        callbacks, use_scan, patience, etc.).
     """
 
     def __init__(self, manifold, lr_init=0.3, lr_final=0.01,

--- a/prosemble/models/rslvq_ng.py
+++ b/prosemble/models/rslvq_ng.py
@@ -42,6 +42,12 @@ class RSLVQ_NG(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
     sigma : float
         Bandwidth of Gaussian mixture.
     gamma_init : float, optional
@@ -52,12 +58,11 @@ class RSLVQ_NG(SupervisedPrototypeModel):
         Per-step multiplicative decay. Default: computed from max_iter.
     rejection_confidence : float, optional
         Minimum class probability for confident prediction (0 to 1).
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, gamma_init=None, gamma_final=0.01,

--- a/prosemble/models/siamese_lvq.py
+++ b/prosemble/models/siamese_lvq.py
@@ -53,12 +53,22 @@ class SiameseGLVQ(SupervisedPrototypeModel):
         Activation: 'sigmoid', 'relu', 'tanh', 'leaky_relu', 'selu'.
     beta : float
         Transfer function parameter for GLVQ loss.
+    bb_lr : float, optional
+        Separate learning rate for the backbone network. Default: None.
+    both_path_gradients : bool
+        If True, compute gradients through both input and prototype
+        paths. Default: True.
     n_prototypes_per_class : int
         Prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
@@ -201,6 +211,22 @@ class SiameseGMLVQ(SupervisedPrototypeModel):
         Backbone activation.
     beta : float
         GLVQ transfer parameter.
+    bb_lr : float, optional
+        Separate learning rate for the backbone network. Default: None.
+    both_path_gradients : bool
+        If True, compute gradients through both input and prototype
+        paths. Default: True.
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
@@ -352,6 +378,22 @@ class SiameseGTLVQ(SupervisedPrototypeModel):
         Backbone activation.
     beta : float
         GLVQ transfer parameter.
+    bb_lr : float, optional
+        Separate learning rate for the backbone network. Default: None.
+    both_path_gradients : bool
+        If True, compute gradients through both input and prototype
+        paths. Default: True.
+    n_prototypes_per_class : int
+        Prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=4,

--- a/prosemble/models/slng.py
+++ b/prosemble/models/slng.py
@@ -76,6 +76,15 @@ class SLNG(SupervisedPrototypeModel):
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,

--- a/prosemble/models/smng.py
+++ b/prosemble/models/smng.py
@@ -77,6 +77,15 @@ class SMNG(SupervisedPrototypeModel):
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,

--- a/prosemble/models/srng.py
+++ b/prosemble/models/srng.py
@@ -54,6 +54,15 @@ class SRNG(SupervisedPrototypeModel):
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, beta=10.0, gamma_init=None, gamma_final=0.01,

--- a/prosemble/models/stng.py
+++ b/prosemble/models/stng.py
@@ -81,6 +81,15 @@ class STNG(SupervisedPrototypeModel):
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, subspace_dim=2, beta=10.0, gamma_init=None,

--- a/prosemble/models/svq_occ.py
+++ b/prosemble/models/svq_occ.py
@@ -79,6 +79,11 @@ class SVQOCC(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     _valid_costs = ('contrastive', 'brier', 'cross_entropy')

--- a/prosemble/models/svq_occ_lm.py
+++ b/prosemble/models/svq_occ_lm.py
@@ -50,6 +50,11 @@ class SVQOCC_LM(SVQOCC):
     ----------
     omegas_ : array of shape (n_prototypes, n_features, latent_dim)
         Learned per-prototype projection matrices.
+
+    See Also
+    --------
+    SVQOCC : Full SVQ-OCC parameter documentation.
+    SupervisedPrototypeModel : Full list of base parameters.
     """
 
     def __init__(self, latent_dim=None, **kwargs):

--- a/prosemble/models/svq_occ_m.py
+++ b/prosemble/models/svq_occ_m.py
@@ -50,6 +50,11 @@ class SVQOCC_M(SVQOCC):
     ----------
     omega_ : array of shape (n_features, latent_dim)
         Learned projection matrix.
+
+    See Also
+    --------
+    SVQOCC : Full SVQ-OCC parameter documentation.
+    SupervisedPrototypeModel : Full list of base parameters.
     """
 
     def __init__(self, latent_dim=None, **kwargs):

--- a/prosemble/models/svq_occ_r.py
+++ b/prosemble/models/svq_occ_r.py
@@ -61,6 +61,11 @@ class SVQOCC_R(SVQOCC):
     ----------
     relevances_ : array of shape (n_features,)
         Learned per-feature relevance weights (softmax-normalized).
+
+    See Also
+    --------
+    SVQOCC : Full SVQ-OCC parameter documentation.
+    SupervisedPrototypeModel : Full list of base parameters.
     """
 
     def __init__(self, **kwargs):

--- a/prosemble/models/svq_occ_t.py
+++ b/prosemble/models/svq_occ_t.py
@@ -54,6 +54,11 @@ class SVQOCC_T(SVQOCC):
     ----------
     omegas_ : array of shape (n_prototypes, n_features, subspace_dim)
         Learned per-prototype orthonormal tangent bases.
+
+    See Also
+    --------
+    SVQOCC : Full SVQ-OCC parameter documentation.
+    SupervisedPrototypeModel : Full list of base parameters.
     """
 
     def __init__(self, subspace_dim=2, **kwargs):

--- a/prosemble/models/tangent_lvq.py
+++ b/prosemble/models/tangent_lvq.py
@@ -51,6 +51,15 @@ class GTLVQ(SupervisedPrototypeModel):
         Learning rate.
     beta : float
         Transfer function steepness.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping. Default: identity.
+    margin : float
+        Margin added to the loss. Default: 0.0.
+
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, subspace_dim=2, beta=10.0, **kwargs):

--- a/prosemble/models/tcelvq_ng.py
+++ b/prosemble/models/tcelvq_ng.py
@@ -82,12 +82,10 @@ class TCELVQ_NG(CELVQNGMixin, CELVQ):
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
 
-    Attributes
-    ----------
-    omegas_ : array of shape (n_prototypes, n_features, subspace_dim)
-        Learned tangent subspace bases after training.
-    gamma_ : float
-        Final gamma value after training.
+    See Also
+    --------
+    SupervisedPrototypeModel : Full list of base parameters (optimizer,
+        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, subspace_dim=2, **kwargs):


### PR DESCRIPTION
## Summary
- Add missing params to base class docstrings (lr_scheduler, prototypes_initializer, distance_fn, patience, etc.)
- Add missing model-specific params (bb_lr, both_path_gradients, initializers in CBC)
- Add transfer_fn/margin to models that use them in _compute_loss
- Add Parameters section to GLVQ1 and GLVQ21
- Add See Also block to all 65+ model classes referencing their base class
- Remove redundant base params from subclasses

## Test plan
- [x] 1144 tests pass
- [x] Sphinx build succeeds with 0 new warnings