### PR TITLE
docs: Replace **kwargs with explicit params for Sphinx autodoc

### DIFF
--- a/prosemble/models/afcm.py
+++ b/prosemble/models/afcm.py
@@ -141,11 +141,13 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
         init_method: str = 'fcm',
         random_seed: int = 42,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -165,10 +167,13 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
             epsilon=epsilon,
             random_seed=random_seed,
             distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/cbc.py
+++ b/prosemble/models/cbc.py
@@ -76,9 +76,32 @@ class CBC(SupervisedPrototypeModel):
 
     def __init__(self, n_components=5, n_classes=2, sigma=1.0,
                  margin=0.3, components_initializer=None,
-                 reasonings_initializer=None, similarity_fn=None, **kwargs):
-        kwargs['margin'] = margin
-        super().__init__(**kwargs)
+                 reasonings_initializer=None, similarity_fn=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.n_components = n_components
         self._n_classes = n_classes
         self.sigma = sigma

--- a/prosemble/models/celvq_ng_mixin.py
+++ b/prosemble/models/celvq_ng_mixin.py
@@ -38,8 +38,31 @@ class CELVQNGMixin:
     """
 
     def __init__(self, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_decay=None, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay

--- a/prosemble/models/fcm.py
+++ b/prosemble/models/fcm.py
@@ -182,11 +182,13 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
         init_method: str = 'random',
         random_seed: int = 42,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str = None,
-        **kwargs
+        callbacks=None,
     ):
         # Model-specific validation first
         if fuzzifier <= 1.0:
@@ -194,9 +196,10 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
 
         super().__init__(
             n_clusters=n_clusters, max_iter=max_iter, epsilon=epsilon,
-            random_seed=random_seed, distance_fn=distance_fn, plot_steps=plot_steps,
+            random_seed=random_seed, distance_fn=distance_fn, patience=patience,
+            restore_best=restore_best, plot_steps=plot_steps,
             show_confidence=show_confidence, show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path, callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/fpcm.py
+++ b/prosemble/models/fpcm.py
@@ -130,11 +130,13 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
         init_method: str = 'fcm',
         random_seed: int = 42,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -150,10 +152,13 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
             epsilon=epsilon,
             random_seed=random_seed,
             distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/glvq.py
+++ b/prosemble/models/glvq.py
@@ -45,8 +45,30 @@ class GLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, beta=10.0, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, beta=10.0, n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.beta = beta
 
     def _compute_loss(self, params, X, y, proto_labels):

--- a/prosemble/models/growing_neural_gas.py
+++ b/prosemble/models/growing_neural_gas.py
@@ -50,9 +50,15 @@ class GrowingNeuralGas(UnsupervisedPrototypeModel):
 
     def __init__(self, max_nodes=100, lr_winner=0.1, lr_neighbor=0.01,
                  max_age=50, insert_interval=100, error_decay=0.995,
-                 **kwargs):
-        kwargs.setdefault('n_prototypes', 2)  # start with 2
-        super().__init__(**kwargs)
+                 n_prototypes=2, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, callbacks=None,
+                 use_scan=True, patience=None, restore_best=False):
+        super().__init__(
+            n_prototypes=n_prototypes, max_iter=max_iter, lr=lr,
+            epsilon=epsilon, random_seed=random_seed, distance_fn=distance_fn,
+            callbacks=callbacks, use_scan=use_scan, patience=patience,
+            restore_best=restore_best,
+        )
         self.max_nodes = max_nodes
         self.lr_winner = lr_winner
         self.lr_neighbor = lr_neighbor

--- a/prosemble/models/hcm.py
+++ b/prosemble/models/hcm.py
@@ -112,11 +112,13 @@ class HCM(ScanFitMixin, FuzzyClusteringBase):
         init_method: str = 'random',
         random_seed: int = 42,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if init_method not in ['random', 'kmeans++']:
@@ -128,10 +130,13 @@ class HCM(ScanFitMixin, FuzzyClusteringBase):
             epsilon=epsilon,
             random_seed=random_seed,
             distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.init_method = init_method

--- a/prosemble/models/heskes_som.py
+++ b/prosemble/models/heskes_som.py
@@ -80,10 +80,17 @@ class HeskesSOM(UnsupervisedPrototypeModel):
     """
 
     def __init__(self, grid_height=10, grid_width=10,
-                 sigma_init=None, sigma_final=0.5, **kwargs):
+                 sigma_init=None, sigma_final=0.5,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, callbacks=None, use_scan=True,
+                 patience=None, restore_best=False):
         n_prototypes = grid_height * grid_width
-        kwargs['n_prototypes'] = n_prototypes
-        super().__init__(**kwargs)
+        super().__init__(
+            n_prototypes=n_prototypes, max_iter=max_iter, lr=lr,
+            epsilon=epsilon, random_seed=random_seed, distance_fn=distance_fn,
+            callbacks=callbacks, use_scan=use_scan, patience=patience,
+            restore_best=restore_best,
+        )
         self.grid_height = grid_height
         self.grid_width = grid_width
         self.sigma_init = sigma_init

--- a/prosemble/models/image_cbc.py
+++ b/prosemble/models/image_cbc.py
@@ -74,9 +74,32 @@ class ImageCBC(SupervisedPrototypeModel):
     def __init__(self, input_shape=(28, 28, 1), channels=None,
                  kernel_sizes=None, latent_dim=32,
                  n_components=5, n_classes=2, sigma=1.0,
-                 activation='relu', **kwargs):
-        kwargs.setdefault('margin', 0.3)
-        super().__init__(**kwargs)
+                 activation='relu', margin=0.3,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.input_shape = input_shape
         self.channels = channels or [16, 32]
         self.kernel_sizes = kernel_sizes or [3, 3]

--- a/prosemble/models/image_lvq.py
+++ b/prosemble/models/image_lvq.py
@@ -71,8 +71,32 @@ class ImageGLVQ(SupervisedPrototypeModel):
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,
                  kernel_sizes=None, latent_dim=32,
-                 activation='relu', beta=10.0, bb_lr=None, **kwargs):
-        super().__init__(**kwargs)
+                 activation='relu', beta=10.0, bb_lr=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.input_shape = input_shape
         self.channels = channels or [16, 32]
         self.kernel_sizes = kernel_sizes or [3, 3]
@@ -242,8 +266,32 @@ class ImageGMLVQ(SupervisedPrototypeModel):
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,
                  kernel_sizes=None, latent_dim=32,
-                 omega_dim=None, activation='relu', beta=10.0, **kwargs):
-        super().__init__(**kwargs)
+                 omega_dim=None, activation='relu', beta=10.0,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.input_shape = input_shape
         self.channels = channels or [16, 32]
         self.kernel_sizes = kernel_sizes or [3, 3]
@@ -395,8 +443,32 @@ class ImageGTLVQ(SupervisedPrototypeModel):
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,
                  kernel_sizes=None, latent_dim=32,
-                 subspace_dim=2, activation='relu', beta=10.0, **kwargs):
-        super().__init__(**kwargs)
+                 subspace_dim=2, activation='relu', beta=10.0,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.input_shape = input_shape
         self.channels = channels or [16, 32]
         self.kernel_sizes = kernel_sizes or [3, 3]

--- a/prosemble/models/ipcm.py
+++ b/prosemble/models/ipcm.py
@@ -145,11 +145,13 @@ class IPCM(FuzzyClusteringBase):
         init_method: str = 'fcm',
         random_seed: int = 42,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -167,10 +169,13 @@ class IPCM(FuzzyClusteringBase):
             epsilon=epsilon,
             random_seed=random_seed,
             distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/ipcm2.py
+++ b/prosemble/models/ipcm2.py
@@ -140,11 +140,13 @@ class IPCM2(FuzzyClusteringBase):
         init_method: str = 'fcm',
         random_seed: int = 42,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -160,10 +162,13 @@ class IPCM2(FuzzyClusteringBase):
             epsilon=epsilon,
             random_seed=random_seed,
             distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/kafcm.py
+++ b/prosemble/models/kafcm.py
@@ -108,11 +108,14 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
         epsilon: float = 1e-5,
         init_method: str = 'kfcm',
         random_seed: int = 42,
+        distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -131,10 +134,14 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
             max_iter=max_iter,
             epsilon=epsilon,
             random_seed=random_seed,
+            distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/kfcm.py
+++ b/prosemble/models/kfcm.py
@@ -125,11 +125,14 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
         epsilon: float = 1e-5,
         init_method: str = 'random',
         random_seed: int = 42,
+        distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -144,10 +147,14 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
             max_iter=max_iter,
             epsilon=epsilon,
             random_seed=random_seed,
+            distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/kfpcm.py
+++ b/prosemble/models/kfpcm.py
@@ -40,14 +40,17 @@ class KFPCM(ScanFitMixin, FuzzyClusteringBase):
 
     def __init__(self, n_clusters: int, fuzzifier: float = 2.0, eta: float = 2.0,
                  sigma: float = 1.0, max_iter: int = 100, epsilon: float = 1e-5,
-                 init_method: str = 'kfcm', random_seed: int = 42, plot_steps: bool = False,
-                 show_confidence: bool = True, show_pca_variance: bool = True,
-                 save_plot_path: str | None = None, **kwargs):
+                 init_method: str = 'kfcm', random_seed: int = 42, distance_fn=None,
+                 patience: int | None = None, restore_best: bool = False,
+                 plot_steps: bool = False, show_confidence: bool = True,
+                 show_pca_variance: bool = True, save_plot_path: str | None = None,
+                 callbacks=None):
         super().__init__(
             n_clusters=n_clusters, max_iter=max_iter, epsilon=epsilon,
-            random_seed=random_seed, plot_steps=plot_steps,
+            random_seed=random_seed, distance_fn=distance_fn, patience=patience,
+            restore_best=restore_best, plot_steps=plot_steps,
             show_confidence=show_confidence, show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path, callbacks=callbacks,
         )
         if fuzzifier <= 1.0:
             raise ValueError("fuzzifier must be > 1.0")

--- a/prosemble/models/kipcm.py
+++ b/prosemble/models/kipcm.py
@@ -41,9 +41,11 @@ class KIPCM(FuzzyClusteringBase):
 
     def __init__(self, n_clusters: int, fuzzifier: float = 2.0, tipifier: float = 2.0,
                  k: float = 1.0, sigma: float = 1.0, max_iter: int = 100, epsilon: float = 1e-5,
-                 init_method: str = 'kfcm', random_seed: int = 42, plot_steps: bool = False,
-                 show_confidence: bool = True, show_pca_variance: bool = True,
-                 save_plot_path: str | None = None):
+                 init_method: str = 'kfcm', random_seed: int = 42, distance_fn=None,
+                 patience: int | None = None, restore_best: bool = False,
+                 plot_steps: bool = False, show_confidence: bool = True,
+                 show_pca_variance: bool = True, save_plot_path: str | None = None,
+                 callbacks=None):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
             raise ValueError("fuzzifier must be > 1.0")
@@ -59,10 +61,14 @@ class KIPCM(FuzzyClusteringBase):
             max_iter=max_iter,
             epsilon=epsilon,
             random_seed=random_seed,
+            distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
             save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/kipcm2.py
+++ b/prosemble/models/kipcm2.py
@@ -41,9 +41,11 @@ class KIPCM2(FuzzyClusteringBase):
 
     def __init__(self, n_clusters: int, fuzzifier: float = 2.0, tipifier: float = 2.0,
                  sigma: float = 1.0, max_iter: int = 100, epsilon: float = 1e-5,
-                 init_method: str = 'kfcm', random_seed: int = 42, plot_steps: bool = False,
-                 show_confidence: bool = True, show_pca_variance: bool = True,
-                 save_plot_path: str | None = None):
+                 init_method: str = 'kfcm', random_seed: int = 42, distance_fn=None,
+                 patience: int | None = None, restore_best: bool = False,
+                 plot_steps: bool = False, show_confidence: bool = True,
+                 show_pca_variance: bool = True, save_plot_path: str | None = None,
+                 callbacks=None):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
             raise ValueError("fuzzifier must be > 1.0")
@@ -57,10 +59,14 @@ class KIPCM2(FuzzyClusteringBase):
             max_iter=max_iter,
             epsilon=epsilon,
             random_seed=random_seed,
+            distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
             save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/kohonen_som.py
+++ b/prosemble/models/kohonen_som.py
@@ -62,10 +62,17 @@ class KohonenSOM(UnsupervisedPrototypeModel):
 
     def __init__(self, grid_height=10, grid_width=10,
                  sigma_init=None, sigma_final=0.5,
-                 lr_init=0.5, lr_final=0.01, **kwargs):
+                 lr_init=0.5, lr_final=0.01,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, callbacks=None, use_scan=True,
+                 patience=None, restore_best=False):
         n_prototypes = grid_height * grid_width
-        kwargs['n_prototypes'] = n_prototypes
-        super().__init__(**kwargs)
+        super().__init__(
+            n_prototypes=n_prototypes, max_iter=max_iter, lr=lr,
+            epsilon=epsilon, random_seed=random_seed, distance_fn=distance_fn,
+            callbacks=callbacks, use_scan=use_scan, patience=patience,
+            restore_best=restore_best,
+        )
         self.grid_height = grid_height
         self.grid_width = grid_width
         self.sigma_init = sigma_init  # default: max(h, w) / 2

--- a/prosemble/models/kpcm.py
+++ b/prosemble/models/kpcm.py
@@ -134,11 +134,14 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
         epsilon: float = 1e-5,
         init_method: str = 'kfcm',
         random_seed: int = 42,
+        distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str | None = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -155,10 +158,14 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
             max_iter=max_iter,
             epsilon=epsilon,
             random_seed=random_seed,
+            distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/kpfcm.py
+++ b/prosemble/models/kpfcm.py
@@ -41,8 +41,10 @@ class KPFCM(ScanFitMixin, FuzzyClusteringBase):
     def __init__(self, n_clusters: int, fuzzifier: float = 2.0, eta: float = 2.0,
                  a: float = 1.0, b: float = 1.0, k: float = 1.0, sigma: float = 1.0,
                  max_iter: int = 100, epsilon: float = 1e-5, init_method: str = 'kfcm',
-                 random_seed: int = 42, plot_steps: bool = False, show_confidence: bool = True,
-                 show_pca_variance: bool = True, save_plot_path: str | None = None, **kwargs):
+                 random_seed: int = 42, distance_fn=None, patience: int | None = None,
+                 restore_best: bool = False, plot_steps: bool = False,
+                 show_confidence: bool = True, show_pca_variance: bool = True,
+                 save_plot_path: str | None = None, callbacks=None):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
             raise ValueError("fuzzifier must be > 1.0")
@@ -62,10 +64,14 @@ class KPFCM(ScanFitMixin, FuzzyClusteringBase):
             max_iter=max_iter,
             epsilon=epsilon,
             random_seed=random_seed,
+            distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/lcelvq_ng.py
+++ b/prosemble/models/lcelvq_ng.py
@@ -84,8 +84,35 @@ class LCELVQ_NG(CELVQNGMixin, CELVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.omegas_ = None
 

--- a/prosemble/models/local_matrix_lvq.py
+++ b/prosemble/models/local_matrix_lvq.py
@@ -60,8 +60,31 @@ class LGMLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, latent_dim=None, beta=10.0, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, beta=10.0,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.beta = beta
         self.omegas_ = None

--- a/prosemble/models/lvq1.py
+++ b/prosemble/models/lvq1.py
@@ -44,10 +44,30 @@ class LVQ1(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, **kwargs):
-        # Override optimizer since LVQ1 doesn't use gradient descent
-        kwargs.setdefault('optimizer', 'adam')  # won't be used
-        super().__init__(**kwargs)
+    def __init__(self, n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
 
     def fit(self, X, y, initial_prototypes=None):
         """Fit LVQ1 using competitive learning (no gradients)."""

--- a/prosemble/models/lvq21.py
+++ b/prosemble/models/lvq21.py
@@ -43,9 +43,30 @@ class LVQ21(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, **kwargs):
-        kwargs.setdefault('optimizer', 'adam')
-        super().__init__(**kwargs)
+    def __init__(self, n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
 
     def fit(self, X, y, initial_prototypes=None):
         """Fit LVQ2.1 using competitive learning."""

--- a/prosemble/models/lvqmln.py
+++ b/prosemble/models/lvqmln.py
@@ -222,8 +222,32 @@ class LVQMLN(SupervisedPrototypeModel):
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
-                 activation='sigmoid', beta=10.0, bb_lr=None, **kwargs):
-        super().__init__(**kwargs)
+                 activation='sigmoid', beta=10.0, bb_lr=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.hidden_sizes = hidden_sizes or [10]
         self.latent_dim = latent_dim
         self.activation = activation

--- a/prosemble/models/matrix_lvq.py
+++ b/prosemble/models/matrix_lvq.py
@@ -64,8 +64,31 @@ class GMLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, latent_dim=None, beta=10.0, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, beta=10.0,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.beta = beta
         self.omega_ = None

--- a/prosemble/models/matrix_rslvq.py
+++ b/prosemble/models/matrix_rslvq.py
@@ -102,8 +102,30 @@ class MRSLVQ(SupervisedPrototypeModel):
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,
-                 **kwargs):
-        super().__init__(**kwargs)
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.latent_dim = latent_dim
         self.rejection_confidence = rejection_confidence
@@ -271,8 +293,30 @@ class LMRSLVQ(SupervisedPrototypeModel):
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,
-                 **kwargs):
-        super().__init__(**kwargs)
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.latent_dim = latent_dim
         self.rejection_confidence = rejection_confidence

--- a/prosemble/models/mcelvq_ng.py
+++ b/prosemble/models/mcelvq_ng.py
@@ -82,8 +82,35 @@ class MCELVQ_NG(CELVQNGMixin, CELVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.omega_ = None
 

--- a/prosemble/models/median_lvq.py
+++ b/prosemble/models/median_lvq.py
@@ -43,9 +43,30 @@ class MedianLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, **kwargs):
-        kwargs.setdefault('optimizer', 'adam')
-        super().__init__(**kwargs)
+    def __init__(self, n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
 
     def fit(self, X, y, initial_prototypes=None):
         """Fit MedianLVQ."""

--- a/prosemble/models/mrslvq_ng.py
+++ b/prosemble/models/mrslvq_ng.py
@@ -112,8 +112,31 @@ class MRSLVQ_NG(SupervisedPrototypeModel):
 
     def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,
                  gamma_final=0.01, gamma_decay=None,
-                 rejection_confidence=None, **kwargs):
-        super().__init__(**kwargs)
+                 rejection_confidence=None, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.latent_dim = latent_dim
         self.gamma_init = gamma_init
@@ -333,8 +356,31 @@ class LMRSLVQ_NG(SupervisedPrototypeModel):
 
     def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,
                  gamma_final=0.01, gamma_decay=None,
-                 rejection_confidence=None, **kwargs):
-        super().__init__(**kwargs)
+                 rejection_confidence=None, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.latent_dim = latent_dim
         self.gamma_init = gamma_init

--- a/prosemble/models/neural_gas.py
+++ b/prosemble/models/neural_gas.py
@@ -62,9 +62,17 @@ class NeuralGas(UnsupervisedPrototypeModel):
         callbacks, use_scan, patience, etc.).
     """
 
-    def __init__(self, lr_init=0.5, lr_final=0.01,
-                 lambda_init=None, lambda_final=0.01, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, n_prototypes, lr_init=0.5, lr_final=0.01,
+                 lambda_init=None, lambda_final=0.01,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, callbacks=None, use_scan=True,
+                 patience=None, restore_best=False):
+        super().__init__(
+            n_prototypes=n_prototypes, max_iter=max_iter, lr=lr,
+            epsilon=epsilon, random_seed=random_seed, distance_fn=distance_fn,
+            callbacks=callbacks, use_scan=use_scan, patience=patience,
+            restore_best=restore_best,
+        )
         self.lr_init = lr_init
         self.lr_final = lr_final
         self.lambda_init = lambda_init  # defaults to n_prototypes/2

--- a/prosemble/models/oc_glvq.py
+++ b/prosemble/models/oc_glvq.py
@@ -73,8 +73,30 @@ class OCGLVQ(SupervisedPrototypeModel):
     """
 
     def __init__(self, n_prototypes=3, target_label=None, beta=10.0,
-                 **kwargs):
-        super().__init__(n_prototypes_per_class=n_prototypes, **kwargs)
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.n_prototypes = n_prototypes
         self.target_label = target_label
         self.beta = beta

--- a/prosemble/models/oc_glvq_ng_mixin.py
+++ b/prosemble/models/oc_glvq_ng_mixin.py
@@ -38,8 +38,32 @@ class NGCooperationMixin:
     """
 
     def __init__(self, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_decay=None, n_prototypes=3, target_label=None,
+                 beta=10.0, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None, **kwargs):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
+        )
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay

--- a/prosemble/models/oc_gmlvq.py
+++ b/prosemble/models/oc_gmlvq.py
@@ -54,8 +54,31 @@ class OCGMLVQ(OCGLVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,
+                 beta=10.0, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.omega_ = None
 

--- a/prosemble/models/oc_grlvq.py
+++ b/prosemble/models/oc_grlvq.py
@@ -50,8 +50,31 @@ class OCGRLVQ(OCGLVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, n_prototypes=3, target_label=None, beta=10.0,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.relevances_ = None
 
     def _get_resume_params(self, params):

--- a/prosemble/models/oc_gtlvq.py
+++ b/prosemble/models/oc_gtlvq.py
@@ -55,8 +55,31 @@ class OCGTLVQ(OCGLVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, subspace_dim=2, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, subspace_dim=2, n_prototypes=3, target_label=None,
+                 beta=10.0, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.subspace_dim = subspace_dim
         self.omegas_ = None
 

--- a/prosemble/models/oc_lgmlvq.py
+++ b/prosemble/models/oc_lgmlvq.py
@@ -53,8 +53,31 @@ class OCLGMLVQ(OCGLVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,
+                 beta=10.0, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.omegas_ = None
 

--- a/prosemble/models/oc_mrslvq.py
+++ b/prosemble/models/oc_mrslvq.py
@@ -67,8 +67,32 @@ class OCMRSLVQ(OCGLVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, sigma=1.0, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, sigma=1.0, latent_dim=None, n_prototypes=3,
+                 target_label=None, beta=10.0, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.latent_dim = latent_dim
         self.omega_ = None
@@ -242,8 +266,32 @@ class OCLMRSLVQ(OCGLVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, sigma=1.0, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, sigma=1.0, latent_dim=None, n_prototypes=3,
+                 target_label=None, beta=10.0, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.latent_dim = latent_dim
         self.omegas_ = None

--- a/prosemble/models/oc_rslvq.py
+++ b/prosemble/models/oc_rslvq.py
@@ -61,8 +61,31 @@ class OCRSLVQ(OCGLVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, sigma=1.0, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, sigma=1.0, n_prototypes=3, target_label=None,
+                 beta=10.0, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
 
     def _compute_loss(self, params, X, y, proto_labels):

--- a/prosemble/models/oc_rslvq_ng_mixin.py
+++ b/prosemble/models/oc_rslvq_ng_mixin.py
@@ -46,8 +46,32 @@ class OCRSLVQNGMixin:
     """
 
     def __init__(self, sigma=1.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_decay=None, n_prototypes=3, target_label=None,
+                 beta=10.0, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None, **kwargs):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
+        )
         self.sigma = sigma
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final

--- a/prosemble/models/pcm.py
+++ b/prosemble/models/pcm.py
@@ -160,11 +160,13 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         init_method: str = 'fcm',
         random_seed: int | None = None,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str = None,
-        **kwargs
+        callbacks=None,
     ):
         # Validate model-specific parameters
         if fuzzifier <= 1.0:
@@ -184,10 +186,13 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
             epsilon=epsilon,
             random_seed=random_seed,
             distance_fn=distance_fn,
+            patience=patience,
+            restore_best=restore_best,
             plot_steps=plot_steps,
             show_confidence=show_confidence,
             show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path,
+            callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/pfcm.py
+++ b/prosemble/models/pfcm.py
@@ -153,11 +153,13 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
         init_method: str = 'fcm',
         random_seed: int = 42,
         distance_fn=None,
+        patience: int | None = None,
+        restore_best: bool = False,
         plot_steps: bool = False,
         show_confidence: bool = True,
         show_pca_variance: bool = True,
         save_plot_path: str = None,
-        **kwargs
+        callbacks=None,
     ):
         # Model-specific validation first
         if fuzzifier <= 1.0:
@@ -173,9 +175,10 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
 
         super().__init__(
             n_clusters=n_clusters, max_iter=max_iter, epsilon=epsilon,
-            random_seed=random_seed, distance_fn=distance_fn, plot_steps=plot_steps,
+            random_seed=random_seed, distance_fn=distance_fn, patience=patience,
+            restore_best=restore_best, plot_steps=plot_steps,
             show_confidence=show_confidence, show_pca_variance=show_pca_variance,
-            save_plot_path=save_plot_path, **kwargs
+            save_plot_path=save_plot_path, callbacks=callbacks,
         )
 
         self.fuzzifier = fuzzifier

--- a/prosemble/models/plvq.py
+++ b/prosemble/models/plvq.py
@@ -79,9 +79,32 @@ class PLVQ(SupervisedPrototypeModel):
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
-                 activation='sigmoid', sigma=1.0,
-                 loss_type='rslvq', **kwargs):
-        super().__init__(**kwargs)
+                 activation='sigmoid', sigma=1.0, loss_type='rslvq',
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.hidden_sizes = hidden_sizes or [10]
         self.latent_dim = latent_dim
         self.activation = activation

--- a/prosemble/models/probabilistic_lvq.py
+++ b/prosemble/models/probabilistic_lvq.py
@@ -52,8 +52,31 @@ class SLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, sigma=1.0, rejection_confidence=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, sigma=1.0, rejection_confidence=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.rejection_confidence = rejection_confidence
 
@@ -123,8 +146,31 @@ class RSLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, sigma=1.0, rejection_confidence=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, sigma=1.0, rejection_confidence=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.rejection_confidence = rejection_confidence
 

--- a/prosemble/models/relevance_lvq.py
+++ b/prosemble/models/relevance_lvq.py
@@ -44,8 +44,30 @@ class GRLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, beta=10.0, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, beta=10.0, n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.beta = beta
         self.relevances_ = None
 

--- a/prosemble/models/riemannian_neural_gas.py
+++ b/prosemble/models/riemannian_neural_gas.py
@@ -63,11 +63,18 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
         callbacks, use_scan, patience, etc.).
     """
 
-    def __init__(self, manifold, lr_init=0.3, lr_final=0.01,
+    def __init__(self, manifold, n_prototypes, lr_init=0.3, lr_final=0.01,
                  lambda_init=None, lambda_final=0.01,
-                 tau=0.9, **kwargs):
+                 tau=0.9, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, callbacks=None,
+                 patience=None, restore_best=False):
         # RNG uses Python loop — funm may not be scan-compatible
-        super().__init__(use_scan=False, **kwargs)
+        super().__init__(
+            n_prototypes=n_prototypes, max_iter=max_iter, lr=lr,
+            epsilon=epsilon, random_seed=random_seed, distance_fn=distance_fn,
+            callbacks=callbacks, use_scan=False, patience=patience,
+            restore_best=restore_best,
+        )
         self.manifold = manifold
         self.lr_init = lr_init
         self.lr_final = lr_final

--- a/prosemble/models/rslvq_ng.py
+++ b/prosemble/models/rslvq_ng.py
@@ -66,8 +66,32 @@ class RSLVQ_NG(SupervisedPrototypeModel):
     """
 
     def __init__(self, sigma=1.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, rejection_confidence=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_decay=None, rejection_confidence=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.sigma = sigma
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final

--- a/prosemble/models/siamese_lvq.py
+++ b/prosemble/models/siamese_lvq.py
@@ -73,8 +73,32 @@ class SiameseGLVQ(SupervisedPrototypeModel):
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
                  activation='sigmoid', beta=10.0, bb_lr=None,
-                 both_path_gradients=True, **kwargs):
-        super().__init__(**kwargs)
+                 both_path_gradients=True,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.hidden_sizes = hidden_sizes or [10]
         self.latent_dim = latent_dim
         self.activation = activation
@@ -231,8 +255,32 @@ class SiameseGMLVQ(SupervisedPrototypeModel):
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
                  omega_dim=None, activation='sigmoid', beta=10.0,
-                 bb_lr=None, both_path_gradients=True, **kwargs):
-        super().__init__(**kwargs)
+                 bb_lr=None, both_path_gradients=True,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.hidden_sizes = hidden_sizes or [10]
         self.latent_dim = latent_dim
         self.omega_dim = omega_dim
@@ -398,8 +446,32 @@ class SiameseGTLVQ(SupervisedPrototypeModel):
 
     def __init__(self, hidden_sizes=None, latent_dim=4,
                  subspace_dim=2, activation='sigmoid', beta=10.0,
-                 bb_lr=None, both_path_gradients=True, **kwargs):
-        super().__init__(**kwargs)
+                 bb_lr=None, both_path_gradients=True,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.hidden_sizes = hidden_sizes or [10]
         self.latent_dim = latent_dim
         self.subspace_dim = subspace_dim

--- a/prosemble/models/slng.py
+++ b/prosemble/models/slng.py
@@ -88,8 +88,32 @@ class SLNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.beta = beta
         self.gamma_init = gamma_init

--- a/prosemble/models/smng.py
+++ b/prosemble/models/smng.py
@@ -89,8 +89,32 @@ class SMNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.beta = beta
         self.gamma_init = gamma_init

--- a/prosemble/models/srng.py
+++ b/prosemble/models/srng.py
@@ -66,8 +66,31 @@ class SRNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, beta=10.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_decay=None, n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.beta = beta
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final

--- a/prosemble/models/stng.py
+++ b/prosemble/models/stng.py
@@ -93,8 +93,32 @@ class STNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, subspace_dim=2, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, **kwargs):
-        super().__init__(**kwargs)
+                 gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.subspace_dim = subspace_dim
         self.beta = beta
         self.gamma_init = gamma_init

--- a/prosemble/models/svq_occ.py
+++ b/prosemble/models/svq_occ.py
@@ -93,8 +93,29 @@ class SVQOCC(SupervisedPrototypeModel):
                  cost_function='contrastive', response_type='gaussian',
                  sigma=0.1, gamma_resp=1.0, nu=1.0,
                  lambda_init=None, lambda_final=0.01, lambda_decay=None,
-                 **kwargs):
-        super().__init__(n_prototypes_per_class=n_prototypes, **kwargs)
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.n_prototypes = n_prototypes
         self.target_label = target_label
         self.alpha = alpha

--- a/prosemble/models/svq_occ_lm.py
+++ b/prosemble/models/svq_occ_lm.py
@@ -57,8 +57,37 @@ class SVQOCC_LM(SVQOCC):
     SupervisedPrototypeModel : Full list of base parameters.
     """
 
-    def __init__(self, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,
+                 alpha=0.5, cost_function='contrastive',
+                 response_type='gaussian', sigma=0.1, gamma_resp=1.0,
+                 nu=1.0, lambda_init=None, lambda_final=0.01,
+                 lambda_decay=None, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            alpha=alpha, cost_function=cost_function,
+            response_type=response_type, sigma=sigma,
+            gamma_resp=gamma_resp, nu=nu, lambda_init=lambda_init,
+            lambda_final=lambda_final, lambda_decay=lambda_decay,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.omegas_ = None
 

--- a/prosemble/models/svq_occ_m.py
+++ b/prosemble/models/svq_occ_m.py
@@ -57,8 +57,37 @@ class SVQOCC_M(SVQOCC):
     SupervisedPrototypeModel : Full list of base parameters.
     """
 
-    def __init__(self, latent_dim=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,
+                 alpha=0.5, cost_function='contrastive',
+                 response_type='gaussian', sigma=0.1, gamma_resp=1.0,
+                 nu=1.0, lambda_init=None, lambda_final=0.01,
+                 lambda_decay=None, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            alpha=alpha, cost_function=cost_function,
+            response_type=response_type, sigma=sigma,
+            gamma_resp=gamma_resp, nu=nu, lambda_init=lambda_init,
+            lambda_final=lambda_final, lambda_decay=lambda_decay,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.latent_dim = latent_dim
         self.omega_ = None
 

--- a/prosemble/models/svq_occ_r.py
+++ b/prosemble/models/svq_occ_r.py
@@ -68,8 +68,37 @@ class SVQOCC_R(SVQOCC):
     SupervisedPrototypeModel : Full list of base parameters.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, n_prototypes=3, target_label=None, alpha=0.5,
+                 cost_function='contrastive', response_type='gaussian',
+                 sigma=0.1, gamma_resp=1.0, nu=1.0,
+                 lambda_init=None, lambda_final=0.01, lambda_decay=None,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            alpha=alpha, cost_function=cost_function,
+            response_type=response_type, sigma=sigma,
+            gamma_resp=gamma_resp, nu=nu, lambda_init=lambda_init,
+            lambda_final=lambda_final, lambda_decay=lambda_decay,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.relevances_ = None
 
     def _get_resume_params(self, params):

--- a/prosemble/models/svq_occ_t.py
+++ b/prosemble/models/svq_occ_t.py
@@ -61,8 +61,37 @@ class SVQOCC_T(SVQOCC):
     SupervisedPrototypeModel : Full list of base parameters.
     """
 
-    def __init__(self, subspace_dim=2, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, subspace_dim=2, n_prototypes=3, target_label=None,
+                 alpha=0.5, cost_function='contrastive',
+                 response_type='gaussian', sigma=0.1, gamma_resp=1.0,
+                 nu=1.0, lambda_init=None, lambda_final=0.01,
+                 lambda_decay=None, max_iter=100, lr=0.01, epsilon=1e-6,
+                 random_seed=42, distance_fn=None, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=True, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            alpha=alpha, cost_function=cost_function,
+            response_type=response_type, sigma=sigma,
+            gamma_resp=gamma_resp, nu=nu, lambda_init=lambda_init,
+            lambda_final=lambda_final, lambda_decay=lambda_decay,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.subspace_dim = subspace_dim
         self.omegas_ = None
 

--- a/prosemble/models/tangent_lvq.py
+++ b/prosemble/models/tangent_lvq.py
@@ -62,8 +62,31 @@ class GTLVQ(SupervisedPrototypeModel):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, subspace_dim=2, beta=10.0, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, subspace_dim=2, beta=10.0,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None, mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.subspace_dim = subspace_dim
         self.beta = beta
         self.omegas_ = None

--- a/prosemble/models/tcelvq_ng.py
+++ b/prosemble/models/tcelvq_ng.py
@@ -88,8 +88,35 @@ class TCELVQ_NG(CELVQNGMixin, CELVQ):
         distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
-    def __init__(self, subspace_dim=2, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, subspace_dim=2, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
         self.subspace_dim = subspace_dim
         self.omegas_ = None
 


### PR DESCRIPTION
## Summary
- Expand all model `__init__` signatures to list parameters explicitly instead of `**kwargs`
- Sphinx autodoc now shows the full parameter list for every model (matching scikit-learn style)
- 60 files changed across all model families (supervised, NG, one-class, SVQ-OCC, clustering, topology)
- No behavioral changes — purely documentation improvement

## Test plan
- [x] 1144 tests pass
- [x] Sphinx build succeeds (0 new warnings)