### PR TITLE
docs: Add complete parameter descriptions to all model docstrings

### DIFF
--- a/prosemble/models/afcm.py
+++ b/prosemble/models/afcm.py
@@ -67,32 +67,41 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
     fuzzifier : float, default=2.0
-        Fuzziness parameter (must be > 1.0)
+        Fuzziness parameter (must be > 1.0).
     a : float, default=1.0
-        Weight for fuzzy membership term (must be > 0)
+        Weight for fuzzy membership term (must be > 0).
     b : float, default=1.0
-        Weight for typicality term (must be > 0)
+        Weight for typicality term (must be > 0).
     k : float, default=1.0
-        Scaling parameter for gamma (must be > 0)
-    max_iter : int, default=100
-        Maximum number of iterations
-    epsilon : float, default=1e-5
-        Convergence threshold
+        Scaling parameter for gamma (must be > 0).
     init_method : {'fcm'}, default='fcm'
-        Initialization method
-    random_seed : int, default=42
-        Random seed for reproducibility
-    plot_steps : bool, default=False
-        Whether to visualize clustering progress
-    show_confidence : bool, default=True
-        Whether to show confidence in visualization
-    show_pca_variance : bool, default=True
-        Whether to show PCA variance in visualization
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save final plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -119,11 +128,6 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = AFCM(n_clusters=2, fuzzifier=2.0, a=1.0, b=1.0, k=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'a', 'b', 'k', 'init_method')

--- a/prosemble/models/cbc.py
+++ b/prosemble/models/cbc.py
@@ -53,25 +53,93 @@ class CBC(SupervisedPrototypeModel):
     n_classes : int
         Number of output classes.
     sigma : float
-        Bandwidth for Gaussian similarity.
+        Bandwidth for Gaussian similarity in component detection.
     margin : float
         Margin for the margin loss.
     components_initializer : callable, optional
-        Initializer for component vectors. Default: None.
+        Initializer for component vectors. Signature:
+        ``(X, key, n_components) -> components``. Default: None
+        (selects random training samples).
     reasonings_initializer : callable, optional
-        Initializer for reasoning matrix. Default: None.
+        Initializer for the reasoning matrix. Signature:
+        ``(n_components, n_classes, key) -> reasonings``. Default: None
+        (initializes near-uniform with small noise).
     similarity_fn : callable, optional
         Similarity function for component detection. Default: None
         (uses Gaussian similarity).
+    n_prototypes_per_class : int
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['components'] to freeze the components and only train reasonings.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, n_components=5, n_classes=2, sigma=1.0,

--- a/prosemble/models/celvq_ng.py
+++ b/prosemble/models/celvq_ng.py
@@ -33,24 +33,89 @@ class CELVQ_NG(CELVQNGMixin, CELVQ):
 
     Parameters
     ----------
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/celvq_ng_mixin.py
+++ b/prosemble/models/celvq_ng_mixin.py
@@ -35,6 +35,81 @@ class CELVQNGMixin:
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, gamma_init=None, gamma_final=0.01,

--- a/prosemble/models/fcm.py
+++ b/prosemble/models/fcm.py
@@ -94,29 +94,40 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (c)
-
     fuzzifier : float, default=2.0
         Fuzzification parameter (m). Must be > 1.
         - m = 1: Hard clustering (crisp membership)
         - m = 2: Standard fuzzy clustering
-        - m → ∞: Maximum fuzziness (equal membership)
-
-    max_iter : int, default=100
-        Maximum number of iterations
-
-    epsilon : float, default=1e-5
-        Convergence tolerance. Algorithm stops when:
-        ||V_new - V_old||_F < epsilon
-
+        - m -> inf: Maximum fuzziness (equal membership)
     init_method : str, default='random'
         Initialization method for U matrix:
         - 'random': Random Dirichlet distribution
         - 'kmeans++': K-means++ centroids then compute U
-
-    random_seed : int, default=42
-        Random seed for reproducibility
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
+    save_plot_path : str, optional
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -163,11 +174,6 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
 
     Dunn, J. C. (1973). A Fuzzy Relative of the ISODATA Process and
     Its Use in Detecting Compact Well-Separated Clusters.
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'init_method')

--- a/prosemble/models/fpcm.py
+++ b/prosemble/models/fpcm.py
@@ -62,28 +62,37 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
     fuzzifier : float, default=2.0
-        Fuzziness parameter for U matrix (must be > 1.0)
+        Fuzziness parameter for U matrix (must be > 1.0).
     eta : float, default=2.0
-        Fuzziness parameter for T matrix (must be > 1.0)
-    max_iter : int, default=100
-        Maximum number of iterations
-    epsilon : float, default=1e-5
-        Convergence threshold for centroid change
+        Fuzziness parameter for T matrix (must be > 1.0).
     init_method : {'random', 'fcm'}, default='fcm'
-        Method for initializing U and T matrices
-    random_seed : int, default=42
-        Random seed for reproducibility
-    plot_steps : bool, default=False
-        Whether to visualize clustering progress (2D PCA projection)
-    show_confidence : bool, default=True
-        Whether to show confidence in visualization
-    show_pca_variance : bool, default=True
-        Whether to show PCA variance in visualization
+        Method for initializing U and T matrices.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save final plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -110,11 +119,6 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
     >>> labels = model.predict(X)
     >>> U = model.predict_proba(X)
     >>> T = model.get_typicality(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'eta', 'init_method')

--- a/prosemble/models/glvq.py
+++ b/prosemble/models/glvq.py
@@ -24,25 +24,83 @@ class GLVQ(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    beta : float
+        Parameter for transfer function (e.g., sigmoid steepness).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer/activation function for loss shaping.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to mu before transfer.
-    beta : float
-        Parameter for transfer function (e.g., sigmoid steepness).
-    optimizer : str or optax optimizer
-        Optimizer ('adam', 'sgd', or optax object).
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, beta=10.0, n_prototypes_per_class=1, max_iter=100,

--- a/prosemble/models/growing_neural_gas.py
+++ b/prosemble/models/growing_neural_gas.py
@@ -29,8 +29,6 @@ class GrowingNeuralGas(UnsupervisedPrototypeModel):
     ----------
     max_nodes : int
         Maximum number of nodes.
-    max_iter : int
-        Number of training steps (epochs over data).
     lr_winner : float
         Learning rate for the winning node.
     lr_neighbor : float
@@ -41,11 +39,28 @@ class GrowingNeuralGas(UnsupervisedPrototypeModel):
         Insert a new node every this many steps.
     error_decay : float
         Error decay factor applied to all nodes.
-
-    See Also
-    --------
-    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
-        callbacks, use_scan, patience, etc.).
+    n_prototypes : int
+        Number of prototypes/nodes.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Initial learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    distance_fn : callable, optional
+        Distance function.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore parameters from the lowest-loss epoch. Default: False.
     """
 
     def __init__(self, max_nodes=100, lr_winner=0.1, lr_neighbor=0.01,

--- a/prosemble/models/hcm.py
+++ b/prosemble/models/hcm.py
@@ -54,24 +54,33 @@ class HCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
-    max_iter : int, default=100
-        Maximum number of iterations
-    epsilon : float, default=1e-5
-        Convergence threshold for centroid change
     init_method : {'random', 'kmeans++'}, default='random'
-        Method for initializing centroids
-    random_seed : int, default=42
-        Random seed for reproducibility
-    plot_steps : bool, default=False
-        Whether to visualize clustering progress (2D PCA projection)
-    show_confidence : bool, default=True
-        Whether to show confidence in visualization
-    show_pca_variance : bool, default=True
-        Whether to show PCA variance in visualization
+        Method for initializing centroids.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save final plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -94,11 +103,6 @@ class HCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = HCM(n_clusters=2, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('init_method',)

--- a/prosemble/models/heskes_som.py
+++ b/prosemble/models/heskes_som.py
@@ -67,16 +67,29 @@ class HeskesSOM(UnsupervisedPrototypeModel):
     grid_width : int
         Width of the 2D grid.
     sigma_init : float, optional
-        Initial neighborhood radius. Default: max(h, w) / 2.
+        Initial neighborhood radius. Default: max(grid_height, grid_width) / 2.
     sigma_final : float
         Final neighborhood radius.
     max_iter : int
-        Number of training epochs.
-
-    See Also
-    --------
-    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
-        callbacks, use_scan, patience, etc.).
+        Maximum training iterations.
+    lr : float
+        Initial learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    distance_fn : callable, optional
+        Distance function.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore parameters from the lowest-loss epoch. Default: False.
     """
 
     def __init__(self, grid_height=10, grid_width=10,

--- a/prosemble/models/image_cbc.py
+++ b/prosemble/models/image_cbc.py
@@ -45,30 +45,97 @@ class ImageCBC(SupervisedPrototypeModel):
     Parameters
     ----------
     input_shape : tuple
-        (height, width, channels) of input images.
+        Shape of input images as (height, width, channels).
     channels : list of int
-        CNN output channels per layer.
+        CNN output channels per convolutional layer, e.g. [16, 32].
     kernel_sizes : list of int
-        Kernel sizes per conv layer.
+        Kernel sizes per convolutional layer, e.g. [3, 3].
     latent_dim : int
-        CNN embedding dimension.
+        Dimension of the CNN embedding space.
     n_components : int
         Number of components (classless prototypes).
     n_classes : int
         Number of output classes.
     sigma : float
-        Bandwidth for Gaussian similarity.
+        Bandwidth for Gaussian similarity in component detection.
     activation : str
-        CNN activation.
+        Activation function for the CNN backbone. Supported values:
+        'relu', 'sigmoid', 'tanh', 'leaky_relu', 'selu'.
+    margin : float
+        Margin for the margin loss.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
     max_iter : int
-        Training epochs.
+        Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train components.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,

--- a/prosemble/models/image_lvq.py
+++ b/prosemble/models/image_lvq.py
@@ -42,31 +42,96 @@ class ImageGLVQ(SupervisedPrototypeModel):
     Parameters
     ----------
     input_shape : tuple
-        (height, width, channels) of input images.
+        Shape of input images as (height, width, channels).
     channels : list of int
-        CNN output channels per layer. e.g. [16, 32].
+        CNN output channels per convolutional layer, e.g. [16, 32].
     kernel_sizes : list of int
-        Kernel sizes per conv layer. e.g. [3, 3].
+        Kernel sizes per convolutional layer, e.g. [3, 3].
     latent_dim : int
-        Embedding dimension.
+        Dimension of the CNN embedding space.
     activation : str
-        CNN activation: 'relu', 'sigmoid', 'tanh', etc.
+        Activation function for the CNN backbone. Supported values:
+        'relu', 'sigmoid', 'tanh', 'leaky_relu', 'selu'.
     beta : float
-        GLVQ transfer function parameter.
+        Transfer function parameter for GLVQ loss.
     bb_lr : float, optional
         Separate learning rate for the backbone network. If None,
         uses the same lr as prototypes. Default: None.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
-        Training epochs.
+        Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,
@@ -238,30 +303,96 @@ class ImageGMLVQ(SupervisedPrototypeModel):
     Parameters
     ----------
     input_shape : tuple
-        (height, width, channels).
+        Shape of input images as (height, width, channels).
     channels : list of int
-        CNN channels per layer.
+        CNN output channels per convolutional layer, e.g. [16, 32].
     kernel_sizes : list of int
-        Kernel sizes per layer.
+        Kernel sizes per convolutional layer, e.g. [3, 3].
     latent_dim : int
-        CNN output dimension.
+        Dimension of the CNN embedding space.
     omega_dim : int, optional
-        Omega mapping dimension. If None, uses latent_dim.
+        Omega mapping dimension (number of rows in Omega). If None,
+        uses latent_dim (square matrix). Default: None.
     activation : str
-        CNN activation function.
+        Activation function for the CNN backbone. Supported values:
+        'relu', 'sigmoid', 'tanh', 'leaky_relu', 'selu'.
     beta : float
-        GLVQ transfer function parameter.
+        Transfer function parameter for GLVQ loss.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
-        Training epochs.
+        Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,
@@ -415,30 +546,96 @@ class ImageGTLVQ(SupervisedPrototypeModel):
     Parameters
     ----------
     input_shape : tuple
-        (height, width, channels).
+        Shape of input images as (height, width, channels).
     channels : list of int
-        CNN channels per layer.
+        CNN output channels per convolutional layer, e.g. [16, 32].
     kernel_sizes : list of int
-        Kernel sizes per conv layer.
+        Kernel sizes per convolutional layer, e.g. [3, 3].
     latent_dim : int
-        CNN output dimension.
+        Dimension of the CNN embedding space.
     subspace_dim : int
-        Tangent subspace dimension per prototype.
+        Tangent subspace dimension per prototype. Each prototype gets a
+        learned orthonormal basis of this rank in latent space.
     activation : str
-        CNN activation function.
+        Activation function for the CNN backbone. Supported values:
+        'relu', 'sigmoid', 'tanh', 'leaky_relu', 'selu'.
     beta : float
-        GLVQ transfer function parameter.
+        Transfer function parameter for GLVQ loss.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
-        Training epochs.
+        Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, input_shape=(28, 28, 1), channels=None,

--- a/prosemble/models/ipcm.py
+++ b/prosemble/models/ipcm.py
@@ -74,30 +74,39 @@ class IPCM(FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
     fuzzifier : float, default=2.0
-        Fuzziness parameter for U matrix (m_f, must be > 1.0)
+        Fuzziness parameter for U matrix (m_f, must be > 1.0).
     tipifier : float, default=2.0
-        Possibilistic parameter for T matrix (m_p, must be > 1.0)
+        Possibilistic parameter for T matrix (m_p, must be > 1.0).
     k : float, default=1.0
-        Scaling parameter for gamma in phase 1 (must be > 0)
-    max_iter : int, default=100
-        Maximum number of iterations per phase
-    epsilon : float, default=1e-5
-        Convergence threshold for centroid change
+        Scaling parameter for gamma in phase 1 (must be > 0).
     init_method : {'fcm'}, default='fcm'
-        Method for initializing U matrix (must use FCM)
-    random_seed : int, default=42
-        Random seed for reproducibility
-    plot_steps : bool, default=False
-        Whether to visualize clustering progress (2D PCA projection)
-    show_confidence : bool, default=True
-        Whether to show confidence in visualization
-    show_pca_variance : bool, default=True
-        Whether to show PCA variance in visualization
+        Method for initializing U matrix (must use FCM).
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save final plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -124,11 +133,6 @@ class IPCM(FuzzyClusteringBase):
     >>> model = IPCM(n_clusters=2, fuzzifier=2.0, tipifier=2.0, k=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'k', 'init_method')

--- a/prosemble/models/ipcm2.py
+++ b/prosemble/models/ipcm2.py
@@ -72,28 +72,37 @@ class IPCM2(FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
     fuzzifier : float, default=2.0
-        Fuzziness parameter for U matrix (m_f, must be > 1.0)
+        Fuzziness parameter for U matrix (m_f, must be > 1.0).
     tipifier : float, default=2.0
-        Possibilistic parameter for T matrix (m_p, must be > 1.0)
-    max_iter : int, default=100
-        Maximum number of iterations per phase
-    epsilon : float, default=1e-5
-        Convergence threshold for centroid change
+        Possibilistic parameter for T matrix (m_p, must be > 1.0).
     init_method : {'fcm'}, default='fcm'
-        Method for initializing U matrix
-    random_seed : int, default=42
-        Random seed for reproducibility
-    plot_steps : bool, default=False
-        Whether to visualize clustering progress
-    show_confidence : bool, default=True
-        Whether to show confidence in visualization
-    show_pca_variance : bool, default=True
-        Whether to show PCA variance in visualization
+        Method for initializing U matrix.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save final plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -120,11 +129,6 @@ class IPCM2(FuzzyClusteringBase):
     >>> model = IPCM2(n_clusters=2, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'init_method')

--- a/prosemble/models/kafcm.py
+++ b/prosemble/models/kafcm.py
@@ -49,34 +49,43 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
     fuzzifier : float, default=2.0
-        Fuzziness parameter (must be > 1.0)
+        Fuzziness parameter (must be > 1.0).
     a : float, default=1.0
-        Weight for fuzzy membership (must be > 0)
+        Weight for fuzzy membership (must be > 0).
     b : float, default=1.0
-        Weight for typicality (must be > 0)
+        Weight for typicality (must be > 0).
     k : float, default=1.0
-        Scaling parameter for gamma (must be > 0)
+        Scaling parameter for gamma (must be > 0).
     sigma : float, default=1.0
-        Kernel bandwidth (must be > 0)
-    max_iter : int, default=100
-        Maximum iterations
-    epsilon : float, default=1e-5
-        Convergence threshold
+        Kernel bandwidth parameter (must be > 0).
     init_method : {'kfcm'}, default='kfcm'
-        Initialization method
-    random_seed : int, default=42
-        Random seed
-    plot_steps : bool, default=False
-        Whether to visualize
-    show_confidence : bool, default=True
-        Show confidence in visualization
-    show_pca_variance : bool, default=True
-        Show PCA variance
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Examples
     --------
@@ -86,11 +95,6 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = KAFCM(n_clusters=2, sigma=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'a', 'b', 'k', 'init_method')

--- a/prosemble/models/kfcm.py
+++ b/prosemble/models/kfcm.py
@@ -62,28 +62,37 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
     fuzzifier : float, default=2.0
-        Fuzziness parameter (must be > 1.0)
+        Fuzziness parameter (must be > 1.0).
     sigma : float, default=1.0
-        Kernel bandwidth parameter (must be > 0)
-    max_iter : int, default=100
-        Maximum number of iterations
-    epsilon : float, default=1e-5
-        Convergence threshold
+        Kernel bandwidth parameter (must be > 0).
     init_method : {'random'}, default='random'
-        Initialization method
-    random_seed : int, default=42
-        Random seed for reproducibility
-    plot_steps : bool, default=False
-        Whether to visualize clustering progress
-    show_confidence : bool, default=True
-        Whether to show confidence in visualization
-    show_pca_variance : bool, default=True
-        Whether to show PCA variance in visualization
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save final plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -106,11 +115,6 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = KFCM(n_clusters=2, sigma=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'init_method')

--- a/prosemble/models/kfpcm.py
+++ b/prosemble/models/kfpcm.py
@@ -29,10 +29,41 @@ class KFPCM(ScanFitMixin, FuzzyClusteringBase):
     constraint (standard FCM), while T has column-sum-to-1 constraint per the
     original Pal, Pal & Bezdek (1997) FPCM formulation.
 
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
+    Parameters
+    ----------
+    fuzzifier : float, default=2.0
+        Fuzziness parameter for U matrix (must be > 1.0).
+    eta : float, default=2.0
+        Fuzziness parameter for T matrix (must be > 1.0).
+    sigma : float, default=1.0
+        Kernel bandwidth parameter (must be > 0).
+    init_method : {'kfcm', 'random'}, default='kfcm'
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
+    save_plot_path : str, optional
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
     """
 
     _hyperparams = ('fuzzifier', 'eta', 'sigma', 'init_method')

--- a/prosemble/models/kipcm.py
+++ b/prosemble/models/kipcm.py
@@ -30,10 +30,43 @@ class KIPCM(FuzzyClusteringBase):
 
     KIPCM uses two-phase approach in kernel space with product-based centroids.
 
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
+    Parameters
+    ----------
+    fuzzifier : float, default=2.0
+        Fuzziness parameter for U matrix (must be > 1.0).
+    tipifier : float, default=2.0
+        Possibilistic parameter for T matrix (must be > 1.0).
+    k : float, default=1.0
+        Scaling parameter for gamma in phase 1 (must be > 0).
+    sigma : float, default=1.0
+        Kernel bandwidth parameter (must be > 0).
+    init_method : {'kfcm'}, default='kfcm'
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
+    save_plot_path : str, optional
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'k', 'sigma', 'init_method')

--- a/prosemble/models/kipcm2.py
+++ b/prosemble/models/kipcm2.py
@@ -30,10 +30,41 @@ class KIPCM2(FuzzyClusteringBase):
 
     KIPCM2 uses exponential T update and modified objective in kernel space.
 
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
+    Parameters
+    ----------
+    fuzzifier : float, default=2.0
+        Fuzziness parameter for U matrix (must be > 1.0).
+    tipifier : float, default=2.0
+        Possibilistic parameter for T matrix (must be > 1.0).
+    sigma : float, default=1.0
+        Kernel bandwidth parameter (must be > 0).
+    init_method : {'kfcm'}, default='kfcm'
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
+    save_plot_path : str, optional
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
     """
 
     _hyperparams = ('fuzzifier', 'tipifier', 'sigma', 'init_method')

--- a/prosemble/models/kohonen_som.py
+++ b/prosemble/models/kohonen_som.py
@@ -43,8 +43,8 @@ class KohonenSOM(UnsupervisedPrototypeModel):
         Height of the 2D grid.
     grid_width : int
         Width of the 2D grid.
-    sigma_init : float
-        Initial neighborhood radius.
+    sigma_init : float, optional
+        Initial neighborhood radius. Default: max(grid_height, grid_width) / 2.
     sigma_final : float
         Final neighborhood radius.
     lr_init : float
@@ -52,12 +52,25 @@ class KohonenSOM(UnsupervisedPrototypeModel):
     lr_final : float
         Final learning rate.
     max_iter : int
-        Number of training epochs.
-
-    See Also
-    --------
-    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
-        callbacks, use_scan, patience, etc.).
+        Maximum training iterations.
+    lr : float
+        Initial learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    distance_fn : callable, optional
+        Distance function.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore parameters from the lowest-loss epoch. Default: False.
     """
 
     def __init__(self, grid_height=10, grid_width=10,

--- a/prosemble/models/kpcm.py
+++ b/prosemble/models/kpcm.py
@@ -66,30 +66,39 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters (must be >= 2)
     fuzzifier : float, default=2.0
-        Fuzziness parameter (must be > 1.0)
+        Fuzziness parameter (must be > 1.0).
     k : float, default=1.0
-        Scaling parameter for gamma (must be > 0)
+        Scaling parameter for gamma (must be > 0).
     sigma : float, default=1.0
-        Kernel bandwidth parameter (must be > 0)
-    max_iter : int, default=100
-        Maximum number of iterations
-    epsilon : float, default=1e-5
-        Convergence threshold
+        Kernel bandwidth parameter (must be > 0).
     init_method : {'kfcm'}, default='kfcm'
-        Initialization method
-    random_seed : int, default=42
-        Random seed for reproducibility
-    plot_steps : bool, default=False
-        Whether to visualize clustering progress
-    show_confidence : bool, default=True
-        Whether to show confidence in visualization
-    show_pca_variance : bool, default=True
-        Whether to show PCA variance in visualization
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
     save_plot_path : str, optional
-        Path to save final plot
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -114,11 +123,6 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     >>> model = KPCM(n_clusters=2, sigma=1.0, random_seed=42)
     >>> model.fit(X)
     >>> labels = model.predict(X)
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'init_method')

--- a/prosemble/models/kpfcm.py
+++ b/prosemble/models/kpfcm.py
@@ -29,10 +29,47 @@ class KPFCM(ScanFitMixin, FuzzyClusteringBase):
     KPFCM combines fuzzy membership (U) and typicality (T) in kernel space
     with weights a and b.
 
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
+    Parameters
+    ----------
+    fuzzifier : float, default=2.0
+        Fuzzification parameter for membership (must be > 1.0).
+    eta : float, default=2.0
+        Fuzzification parameter for typicality (must be > 1.0).
+    a : float, default=1.0
+        Weight for fuzzy membership term (must be > 0).
+    b : float, default=1.0
+        Weight for typicality term (must be > 0).
+    k : float, default=1.0
+        Scaling parameter for gamma (must be > 0).
+    sigma : float, default=1.0
+        Kernel bandwidth parameter (must be > 0).
+    init_method : {'kfcm'}, default='kfcm'
+        Initialization method.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
+    save_plot_path : str, optional
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
     """
 
     _hyperparams = ('fuzzifier', 'sigma', 'a', 'b', 'eta', 'k', 'init_method')

--- a/prosemble/models/lcelvq_ng.py
+++ b/prosemble/models/lcelvq_ng.py
@@ -64,24 +64,89 @@ class LCELVQ_NG(CELVQNGMixin, CELVQ):
     ----------
     latent_dim : int, optional
         Latent space dimensionality per prototype. If None, uses input dim.
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, latent_dim=None, gamma_init=None,

--- a/prosemble/models/local_matrix_lvq.py
+++ b/prosemble/models/local_matrix_lvq.py
@@ -41,23 +41,83 @@ class LGMLVQ(SupervisedPrototypeModel):
     ----------
     latent_dim : int, optional
         Latent space dimensionality per prototype. If None, uses input dim.
+    beta : float
+        Transfer function steepness.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-    beta : float
-        Transfer function steepness.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, latent_dim=None, beta=10.0,

--- a/prosemble/models/lvq1.py
+++ b/prosemble/models/lvq1.py
@@ -32,16 +32,80 @@ class LVQ1(SupervisedPrototypeModel):
     Parameters
     ----------
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, n_prototypes_per_class=1, max_iter=100, lr=0.01,

--- a/prosemble/models/lvq21.py
+++ b/prosemble/models/lvq21.py
@@ -31,16 +31,80 @@ class LVQ21(SupervisedPrototypeModel):
     Parameters
     ----------
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, n_prototypes_per_class=1, max_iter=100, lr=0.01,

--- a/prosemble/models/lvqmln.py
+++ b/prosemble/models/lvqmln.py
@@ -209,16 +209,80 @@ class LVQMLN(SupervisedPrototypeModel):
         Separate learning rate for the backbone network. If None,
         uses the same lr as prototypes. Default: None.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
-        Learning rate for both backbone and prototypes.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,

--- a/prosemble/models/matrix_lvq.py
+++ b/prosemble/models/matrix_lvq.py
@@ -45,23 +45,83 @@ class GMLVQ(SupervisedPrototypeModel):
     ----------
     latent_dim : int, optional
         Dimensionality of the latent space. If None, uses input dim.
+    beta : float
+        Transfer function steepness.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-    beta : float
-        Transfer function steepness.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, latent_dim=None, beta=10.0,

--- a/prosemble/models/matrix_rslvq.py
+++ b/prosemble/models/matrix_rslvq.py
@@ -89,16 +89,80 @@ class MRSLVQ(SupervisedPrototypeModel):
         Samples below this threshold are rejected (labeled -1) when using
         ``predict_with_rejection()``. Default is None (no rejection).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,
@@ -280,16 +344,80 @@ class LMRSLVQ(SupervisedPrototypeModel):
         Samples below this threshold are rejected (labeled -1) when using
         ``predict_with_rejection()``. Default is None (no rejection).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, rejection_confidence=None,

--- a/prosemble/models/mcelvq_ng.py
+++ b/prosemble/models/mcelvq_ng.py
@@ -61,25 +61,90 @@ class MCELVQ_NG(CELVQNGMixin, CELVQ):
     Parameters
     ----------
     latent_dim : int, optional
-        Dimensionality of the latent space. If None, uses input dim.
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
+        Dimensionality of the Omega projection space. If None, uses input dim.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, latent_dim=None, gamma_init=None,

--- a/prosemble/models/median_lvq.py
+++ b/prosemble/models/median_lvq.py
@@ -33,14 +33,80 @@ class MedianLVQ(SupervisedPrototypeModel):
     Parameters
     ----------
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, n_prototypes_per_class=1, max_iter=100, lr=0.01,

--- a/prosemble/models/mrslvq_ng.py
+++ b/prosemble/models/mrslvq_ng.py
@@ -85,29 +85,96 @@ class MRSLVQ_NG(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    sigma : float
+        Bandwidth for RSLVQ Gaussian mixture probability computation.
+    latent_dim : int, optional
+        Dimensionality of the Omega projection space. If None, uses input dim.
+    gamma_init : float, optional
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay factor for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    rejection_confidence : float, optional
+        Minimum class probability for confident prediction (0 to 1).
+        Samples below this threshold are rejected (label -1).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-    sigma : float
-        Bandwidth of Gaussian mixture.
-    latent_dim : int, optional
-        Dimensionality of the latent space. If None, uses input dim.
-    gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
-    gamma_final : float
-        Final neighborhood range. Default: 0.01.
-    gamma_decay : float, optional
-        Per-step multiplicative decay. Default: computed from max_iter.
-    rejection_confidence : float, optional
-        Minimum class probability for confident prediction (0 to 1).
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,
@@ -329,29 +396,96 @@ class LMRSLVQ_NG(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    sigma : float
+        Bandwidth for RSLVQ Gaussian mixture probability computation.
+    latent_dim : int, optional
+        Latent space dimensionality per prototype. If None, uses input dim.
+    gamma_init : float, optional
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay factor for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    rejection_confidence : float, optional
+        Minimum class probability for confident prediction (0 to 1).
+        Samples below this threshold are rejected (label -1).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-    sigma : float
-        Bandwidth of Gaussian mixture.
-    latent_dim : int, optional
-        Latent space dimensionality per prototype. If None, uses input dim.
-    gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
-    gamma_final : float
-        Final neighborhood range. Default: 0.01.
-    gamma_decay : float, optional
-        Per-step multiplicative decay. Default: computed from max_iter.
-    rejection_confidence : float, optional
-        Minimum class probability for confident prediction (0 to 1).
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, gamma_init=None,

--- a/prosemble/models/neural_gas.py
+++ b/prosemble/models/neural_gas.py
@@ -43,23 +43,36 @@ class NeuralGas(UnsupervisedPrototypeModel):
 
     Parameters
     ----------
-    n_prototypes : int
-        Number of prototypes.
-    max_iter : int
-        Maximum training epochs.
     lr_init : float
         Initial learning rate.
     lr_final : float
         Final learning rate.
-    lambda_init : float
-        Initial neighborhood range.
+    lambda_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
     lambda_final : float
         Final neighborhood range.
-
-    See Also
-    --------
-    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
-        callbacks, use_scan, patience, etc.).
+    n_prototypes : int
+        Number of prototypes/nodes.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Initial learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    distance_fn : callable, optional
+        Distance function.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore parameters from the lowest-loss epoch. Default: False.
     """
 
     def __init__(self, n_prototypes, lr_init=0.5, lr_final=0.01,

--- a/prosemble/models/oc_glvq.py
+++ b/prosemble/models/oc_glvq.py
@@ -48,7 +48,7 @@ class OCGLVQ(SupervisedPrototypeModel):
     Parameters
     ----------
     n_prototypes : int
-        Number of prototypes for the target class. Default: 3.
+        Number of prototypes for the target class.
     target_label : int, optional
         Which label is the target (normal) class. Default: auto-detect
         as the most frequent class.
@@ -58,18 +58,80 @@ class OCGLVQ(SupervisedPrototypeModel):
         Maximum training iterations.
     lr : float
         Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to μ before transfer. Default: 0.0.
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype visibility thresholds.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, n_prototypes=3, target_label=None, beta=10.0,

--- a/prosemble/models/oc_glvq_ng.py
+++ b/prosemble/models/oc_glvq_ng.py
@@ -27,28 +27,97 @@ class OCGLVQ_NG(NGCooperationMixin, OCGLVQ):
 
     Parameters
     ----------
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_glvq_ng_mixin.py
+++ b/prosemble/models/oc_glvq_ng_mixin.py
@@ -35,6 +35,85 @@ class NGCooperationMixin:
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, gamma_init=None, gamma_final=0.01,

--- a/prosemble/models/oc_gmlvq.py
+++ b/prosemble/models/oc_gmlvq.py
@@ -42,16 +42,84 @@ class OCGMLVQ(OCGLVQ):
         Target (normal) class label. Default: auto-detect.
     beta : float
         Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
     omega_ : array of shape (n_features, latent_dim)
         Learned projection matrix.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,

--- a/prosemble/models/oc_gmlvq_ng.py
+++ b/prosemble/models/oc_gmlvq_ng.py
@@ -27,18 +27,92 @@ class OCGMLVQ_NG(NGCooperationMixin, OCGMLVQ):
     ----------
     latent_dim : int, optional
         Dimensionality of the projected space. Default: n_features.
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -46,11 +120,6 @@ class OCGMLVQ_NG(NGCooperationMixin, OCGMLVQ):
         Learned projection matrix.
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_grlvq.py
+++ b/prosemble/models/oc_grlvq.py
@@ -38,16 +38,84 @@ class OCGRLVQ(OCGLVQ):
         Target (normal) class label. Default: auto-detect.
     beta : float
         Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
     relevances_ : array of shape (n_features,)
         Learned per-feature relevance weights (softmax-normalized).
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, n_prototypes=3, target_label=None, beta=10.0,

--- a/prosemble/models/oc_grlvq_ng.py
+++ b/prosemble/models/oc_grlvq_ng.py
@@ -26,18 +26,92 @@ class OCGRLVQ_NG(NGCooperationMixin, OCGRLVQ):
 
     Parameters
     ----------
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -45,11 +119,6 @@ class OCGRLVQ_NG(NGCooperationMixin, OCGRLVQ):
         Learned per-feature relevance weights.
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_gtlvq.py
+++ b/prosemble/models/oc_gtlvq.py
@@ -43,16 +43,84 @@ class OCGTLVQ(OCGLVQ):
         Target (normal) class label. Default: auto-detect.
     beta : float
         Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
     omegas_ : array of shape (n_prototypes, n_features, subspace_dim)
         Learned per-prototype orthonormal tangent bases.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, subspace_dim=2, n_prototypes=3, target_label=None,

--- a/prosemble/models/oc_gtlvq_ng.py
+++ b/prosemble/models/oc_gtlvq_ng.py
@@ -27,18 +27,92 @@ class OCGTLVQ_NG(NGCooperationMixin, OCGTLVQ):
     ----------
     subspace_dim : int
         Dimensionality of each tangent subspace. Default: 2.
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -46,11 +120,6 @@ class OCGTLVQ_NG(NGCooperationMixin, OCGTLVQ):
         Learned per-prototype orthonormal tangent bases.
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_lgmlvq.py
+++ b/prosemble/models/oc_lgmlvq.py
@@ -41,16 +41,84 @@ class OCLGMLVQ(OCGLVQ):
         Target (normal) class label. Default: auto-detect.
     beta : float
         Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
     omegas_ : array of shape (n_prototypes, n_features, latent_dim)
         Learned per-prototype projection matrices.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,

--- a/prosemble/models/oc_lgmlvq_ng.py
+++ b/prosemble/models/oc_lgmlvq_ng.py
@@ -27,18 +27,92 @@ class OCLGMLVQ_NG(NGCooperationMixin, OCLGMLVQ):
     ----------
     latent_dim : int, optional
         Dimensionality of each projected space. Default: n_features.
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -46,11 +120,6 @@ class OCLGMLVQ_NG(NGCooperationMixin, OCLGMLVQ):
         Learned per-prototype projection matrices.
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_mrslvq.py
+++ b/prosemble/models/oc_mrslvq.py
@@ -53,6 +53,79 @@ class OCMRSLVQ(OCGLVQ):
         Target (normal) class label. Default: auto-detect.
     beta : float
         Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -60,11 +133,6 @@ class OCMRSLVQ(OCGLVQ):
         Learned projection matrix.
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype visibility thresholds.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, n_prototypes=3,
@@ -252,6 +320,79 @@ class OCLMRSLVQ(OCGLVQ):
         Target (normal) class label. Default: auto-detect.
     beta : float
         Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -259,11 +400,6 @@ class OCLMRSLVQ(OCGLVQ):
         Learned per-prototype projection matrices.
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype visibility thresholds.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, latent_dim=None, n_prototypes=3,

--- a/prosemble/models/oc_mrslvq_ng.py
+++ b/prosemble/models/oc_mrslvq_ng.py
@@ -43,18 +43,92 @@ class OCMRSLVQ_NG(OCRSLVQNGMixin, OCMRSLVQ):
         Bandwidth of Gaussian mixture for prototype weighting.
     latent_dim : int, optional
         Dimensionality of the projected space. Default: n_features.
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -64,11 +138,6 @@ class OCMRSLVQ_NG(OCRSLVQNGMixin, OCMRSLVQ):
         Learned per-prototype acceptance thresholds.
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):
@@ -94,18 +163,92 @@ class OCLMRSLVQ_NG(OCRSLVQNGMixin, OCLMRSLVQ):
         Bandwidth of Gaussian mixture for prototype weighting.
     latent_dim : int, optional
         Latent space dimensionality per prototype. Default: n_features.
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -115,11 +258,6 @@ class OCLMRSLVQ_NG(OCRSLVQNGMixin, OCLMRSLVQ):
         Learned per-prototype acceptance thresholds.
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_rslvq.py
+++ b/prosemble/models/oc_rslvq.py
@@ -49,16 +49,84 @@ class OCRSLVQ(OCGLVQ):
         Target (normal) class label. Default: auto-detect.
     beta : float
         Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
     thetas_ : array of shape (n_prototypes,)
         Learned per-prototype acceptance thresholds.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def __init__(self, sigma=1.0, n_prototypes=3, target_label=None,

--- a/prosemble/models/oc_rslvq_ng.py
+++ b/prosemble/models/oc_rslvq_ng.py
@@ -37,18 +37,92 @@ class OCRSLVQ_NG(OCRSLVQNGMixin, OCRSLVQ):
     ----------
     sigma : float
         Bandwidth of Gaussian mixture for prototype weighting.
-    n_prototypes : int
-        Number of prototypes for the target class.
-    target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
-    beta : float
-        Sigmoid steepness. Default: 10.0.
     gamma_init : float, optional
         Initial neighborhood range. Default: n_prototypes / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -56,11 +130,6 @@ class OCRSLVQ_NG(OCRSLVQNGMixin, OCRSLVQ):
         Learned per-prototype acceptance thresholds.
     gamma_ : float
         Final gamma value after training.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
     """
 
     def _compute_distances(self, params, X):

--- a/prosemble/models/oc_rslvq_ng_mixin.py
+++ b/prosemble/models/oc_rslvq_ng_mixin.py
@@ -43,6 +43,85 @@ class OCRSLVQNGMixin:
     gamma_decay : float, optional
         Per-step multiplicative decay for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, gamma_init=None, gamma_final=0.01,

--- a/prosemble/models/pcm.py
+++ b/prosemble/models/pcm.py
@@ -74,77 +74,88 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
     the typicality of a point to one cluster is independent of its typicality
     to other clusters.
 
-    Parameters:
-        n_clusters: int
-            Number of clusters to form.
+    Parameters
+    ----------
+    fuzzifier : float, default=2.0
+        Fuzzification parameter (m > 1). Higher values result in fuzzier
+        clusters.
+    k : float, default=1.0
+        Parameter for gamma computation. Typical values are in [0.01, 1.0].
+        Lower values make the algorithm more sensitive to outliers.
+    init_method : {'fcm', 'random'}, default='fcm'
+        Initialization method:
+        - 'fcm': Initialize using FCM results (recommended)
+        - 'random': Random initialization
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
+    save_plot_path : str, optional
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
-        fuzzifier: float, default=2.0
-            Fuzzification parameter (m > 1). Higher values result in fuzzier clusters.
+    Attributes
+    ----------
+    centroids_ : ndarray of shape (n_clusters, n_features)
+        Cluster centroids after fitting.
 
-        k: float, default=1.0
-            Parameter for gamma computation. Typical values are in [0.01, 1.0].
-            Lower values make the algorithm more sensitive to outliers.
+    T_ : ndarray of shape (n_samples, n_clusters)
+        Typicality matrix after fitting.
 
-        max_iter: int, default=100
-            Maximum number of iterations.
+    gamma_ : ndarray of shape (n_clusters,)
+        Scale parameters for each cluster.
 
-        epsilon: float, default=1e-5
-            Convergence tolerance. Algorithm stops when centroid change is below this.
+    n_iter_ : int
+        Number of iterations run.
 
-        init_method: {'fcm', 'random'}, default='fcm'
-            Initialization method:
-            - 'fcm': Initialize using FCM results (recommended)
-            - 'random': Random initialization
+    objective_ : float
+        Final objective function value.
 
-        random_seed: int, optional
-            Random seed for reproducibility.
-
-    Attributes:
-        centroids_: ndarray of shape (n_clusters, n_features)
-            Cluster centroids after fitting.
-
-        T_: ndarray of shape (n_samples, n_clusters)
-            Typicality matrix after fitting.
-
-        gamma_: ndarray of shape (n_clusters,)
-            Scale parameters for each cluster.
-
-        n_iter_: int
-            Number of iterations run.
-
-        objective_: float
-            Final objective function value.
-
-    Examples:
-        >>> import jax.numpy as jnp
-        >>> from prosemble.models import PCM
-        >>>
-        >>> # Generate sample data
-        >>> X = jnp.array([[1, 2], [1.5, 1.8], [5, 8], [8, 8], [1, 0.6], [9, 11]])
-        >>>
-        >>> # Fit PCM model
-        >>> model = PCM(n_clusters=2, fuzzifier=2.0, k=1.0)
-        >>> model.fit(X)
-        >>>
-        >>> # Get cluster assignments
-        >>> labels = model.predict(X)
-        >>>
-        >>> # Get typicality values
-        >>> typicalities = model.predict_proba(X)
-
-    Notes:
-        - PCM is less sensitive to outliers than FCM because typicality values
-          are computed independently for each cluster.
-        - The parameter k controls the sensitivity to outliers. Smaller values
-          make the algorithm more sensitive.
-        - Initialization from FCM (init_method='fcm') is recommended as it provides
-          better starting points than random initialization.
-        - All computations are JIT-compiled and can run on GPU if available.
-
-    See Also
+    Examples
     --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
+    >>> import jax.numpy as jnp
+    >>> from prosemble.models import PCM
+    >>>
+    >>> # Generate sample data
+    >>> X = jnp.array([[1, 2], [1.5, 1.8], [5, 8], [8, 8], [1, 0.6], [9, 11]])
+    >>>
+    >>> # Fit PCM model
+    >>> model = PCM(n_clusters=2, fuzzifier=2.0, k=1.0)
+    >>> model.fit(X)
+    >>>
+    >>> # Get cluster assignments
+    >>> labels = model.predict(X)
+    >>>
+    >>> # Get typicality values
+    >>> typicalities = model.predict_proba(X)
+
+    Notes
+    -----
+    - PCM is less sensitive to outliers than FCM because typicality values
+      are computed independently for each cluster.
+    - The parameter k controls the sensitivity to outliers. Smaller values
+      make the algorithm more sensitive.
+    - Initialization from FCM (init_method='fcm') is recommended as it provides
+      better starting points than random initialization.
+    - All computations are JIT-compiled and can run on GPU if available.
     """
 
     _hyperparams = ('fuzzifier', 'k', 'init_method')

--- a/prosemble/models/pfcm.py
+++ b/prosemble/models/pfcm.py
@@ -69,47 +69,43 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
 
     Parameters
     ----------
-    n_clusters : int
-        Number of clusters
-
     fuzzifier : float, default=2.0
-        Fuzzification parameter for membership (m)
-
+        Fuzzification parameter for membership (m). Must be > 1.
     eta : float, default=2.0
-        Fuzzification parameter for typicality (η)
-
+        Fuzzification parameter for typicality (eta). Must be > 1.
     a : float, default=1.0
-        Weight for fuzzy membership term
-
+        Weight for fuzzy membership term. Must be >= 0.
     b : float, default=1.0
-        Weight for typicality term
-
+        Weight for typicality term. Must be >= 0.
     k : float, default=1.0
-        Parameter for gamma computation
-
-    max_iter : int, default=100
-        Maximum iterations
-
-    epsilon : float, default=1e-5
-        Convergence tolerance
-
+        Parameter for gamma computation. Must be > 0.
     init_method : str, default='fcm'
-        Initialization: 'fcm' or 'random'
-
-    random_seed : int, default=42
-        Random seed
-
-    plot_steps : bool, default=False
-        Enable live visualization
-
-    show_confidence : bool, default=True
-        Show confidence in visualization
-
-    show_pca_variance : bool, default=True
-        Show PCA variance in visualization
-
-    save_plot_path : str, default=None
-        Path to save final plot
+        Initialization method: 'fcm' or 'random'.
+    n_clusters : int
+        Number of clusters (must be >= 2).
+    max_iter : int
+        Maximum number of iterations.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Pairwise distance function. Default: squared Euclidean.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore centroids from the lowest-objective epoch.
+        Default: False.
+    plot_steps : bool
+        Whether to visualize clustering progress. Default: False.
+    show_confidence : bool
+        Whether to show confidence in visualization. Default: True.
+    show_pca_variance : bool
+        Whether to show PCA variance in visualization. Default: True.
+    save_plot_path : str, optional
+        Path to save final plot.
+    callbacks : list, optional
+        List of Callback objects for monitoring/visualization.
 
     Attributes
     ----------
@@ -130,11 +126,6 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
 
     n_iter_ : int
         Number of iterations performed
-
-    See Also
-    --------
-    FuzzyClusteringBase : Full list of base parameters (distance_fn,
-        patience, restore_best, callbacks, etc.).
     """
 
     _hyperparams = ('fuzzifier', 'a', 'b', 'eta', 'k', 'init_method')

--- a/prosemble/models/plvq.py
+++ b/prosemble/models/plvq.py
@@ -66,16 +66,80 @@ class PLVQ(SupervisedPrototypeModel):
     loss_type : str
         'rslvq' (robust, default) or 'nllr' (likelihood ratio).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,

--- a/prosemble/models/probabilistic_lvq.py
+++ b/prosemble/models/probabilistic_lvq.py
@@ -40,16 +40,80 @@ class SLVQ(SupervisedPrototypeModel):
         Samples below this threshold are rejected (labeled -1) when using
         ``predict_with_rejection()``. Default is None (no rejection).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, rejection_confidence=None,
@@ -134,16 +198,80 @@ class RSLVQ(SupervisedPrototypeModel):
         Samples below this threshold are rejected (labeled -1) when using
         ``predict_with_rejection()``. Default is None (no rejection).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, rejection_confidence=None,

--- a/prosemble/models/relevance_lvq.py
+++ b/prosemble/models/relevance_lvq.py
@@ -25,23 +25,83 @@ class GRLVQ(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    beta : float
+        Transfer function steepness parameter.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-    beta : float
-        Transfer function steepness parameter.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, beta=10.0, n_prototypes_per_class=1, max_iter=100,

--- a/prosemble/models/riemannian_neural_gas.py
+++ b/prosemble/models/riemannian_neural_gas.py
@@ -43,9 +43,7 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
         ``log_map``, ``exp_map``, ``random_point``, ``project``,
         and ``injectivity_radius``.
     n_prototypes : int
-        Number of prototypes.
-    max_iter : int
-        Maximum training epochs.
+        Number of prototypes/nodes.
     lr_init : float
         Initial learning rate. Default: 0.3.
     lr_final : float
@@ -56,11 +54,22 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
         Final neighborhood range. Default: 0.01.
     tau : float
         Safety factor for injectivity radius bound. Default: 0.9.
-
-    See Also
-    --------
-    UnsupervisedPrototypeModel : Full list of base parameters (distance_fn,
-        callbacks, use_scan, patience, etc.).
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Initial learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    distance_fn : callable, optional
+        Distance function.
+    callbacks : list, optional
+        Callback objects.
+    patience : int, optional
+        Epochs with no improvement before early stopping. Default: None.
+    restore_best : bool
+        If True, restore parameters from the lowest-loss epoch. Default: False.
     """
 
     def __init__(self, manifold, n_prototypes, lr_init=0.3, lr_final=0.01,

--- a/prosemble/models/rslvq_ng.py
+++ b/prosemble/models/rslvq_ng.py
@@ -42,27 +42,94 @@ class RSLVQ_NG(SupervisedPrototypeModel):
 
     Parameters
     ----------
+    sigma : float
+        Bandwidth for RSLVQ Gaussian mixture probability computation.
+    gamma_init : float, optional
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay factor for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    rejection_confidence : float, optional
+        Minimum class probability for confident prediction (0 to 1).
+        Samples below this threshold are rejected (label -1).
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-    sigma : float
-        Bandwidth of Gaussian mixture.
-    gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
-    gamma_final : float
-        Final neighborhood range. Default: 0.01.
-    gamma_decay : float, optional
-        Per-step multiplicative decay. Default: computed from max_iter.
-    rejection_confidence : float, optional
-        Minimum class probability for confident prediction (0 to 1).
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, sigma=1.0, gamma_init=None, gamma_final=0.01,

--- a/prosemble/models/siamese_lvq.py
+++ b/prosemble/models/siamese_lvq.py
@@ -50,25 +50,92 @@ class SiameseGLVQ(SupervisedPrototypeModel):
     latent_dim : int
         Dimension of the embedding space.
     activation : str
-        Activation: 'sigmoid', 'relu', 'tanh', 'leaky_relu', 'selu'.
+        Activation function for the backbone MLP. Supported values:
+        'sigmoid', 'relu', 'tanh', 'leaky_relu', 'selu'.
     beta : float
         Transfer function parameter for GLVQ loss.
     bb_lr : float, optional
-        Separate learning rate for the backbone network. Default: None.
+        Separate learning rate for the backbone network. If None,
+        uses the same lr as prototypes. Default: None.
     both_path_gradients : bool
         If True, compute gradients through both input and prototype
-        paths. Default: True.
+        paths. If False, prototype path gradients are stopped.
+        Default: True.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
@@ -226,31 +293,99 @@ class SiameseGMLVQ(SupervisedPrototypeModel):
     Parameters
     ----------
     hidden_sizes : list of int
-        Hidden layer sizes.
+        Hidden layer sizes for the backbone MLP.
     latent_dim : int
-        Backbone output dimension.
+        Dimension of the backbone output (embedding space).
     omega_dim : int, optional
-        Omega mapping dimension. If None, uses latent_dim.
+        Omega mapping dimension (number of rows in Omega). If None,
+        uses latent_dim (square matrix). Default: None.
     activation : str
-        Backbone activation.
+        Activation function for the backbone MLP. Supported values:
+        'sigmoid', 'relu', 'tanh', 'leaky_relu', 'selu'.
     beta : float
-        GLVQ transfer parameter.
+        Transfer function parameter for GLVQ loss.
     bb_lr : float, optional
-        Separate learning rate for the backbone network. Default: None.
+        Separate learning rate for the backbone network. If None,
+        uses the same lr as prototypes. Default: None.
     both_path_gradients : bool
         If True, compute gradients through both input and prototype
-        paths. Default: True.
+        paths. If False, prototype path gradients are stopped.
+        Default: True.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=2,
@@ -417,31 +552,99 @@ class SiameseGTLVQ(SupervisedPrototypeModel):
     Parameters
     ----------
     hidden_sizes : list of int
-        Hidden layer sizes.
+        Hidden layer sizes for the backbone MLP.
     latent_dim : int
-        Backbone output dimension.
+        Dimension of the backbone output (embedding space).
     subspace_dim : int
-        Tangent subspace dimension per prototype.
+        Tangent subspace dimension per prototype. Each prototype gets a
+        learned orthonormal basis of this rank in latent space.
     activation : str
-        Backbone activation.
+        Activation function for the backbone MLP. Supported values:
+        'sigmoid', 'relu', 'tanh', 'leaky_relu', 'selu'.
     beta : float
-        GLVQ transfer parameter.
+        Transfer function parameter for GLVQ loss.
     bb_lr : float, optional
-        Separate learning rate for the backbone network. Default: None.
+        Separate learning rate for the backbone network. If None,
+        uses the same lr as prototypes. Default: None.
     both_path_gradients : bool
         If True, compute gradients through both input and prototype
-        paths. Default: True.
+        paths. If False, prototype path gradients are stopped.
+        Default: True.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, hidden_sizes=None, latent_dim=4,

--- a/prosemble/models/slng.py
+++ b/prosemble/models/slng.py
@@ -61,30 +61,91 @@ class SLNG(SupervisedPrototypeModel):
     ----------
     latent_dim : int, optional
         Latent space dimensionality per prototype. If None, uses input dim.
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
     beta : float
-        Transfer function steepness parameter.
+        Transfer function steepness parameter for sigmoid shaping.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,

--- a/prosemble/models/smng.py
+++ b/prosemble/models/smng.py
@@ -61,31 +61,92 @@ class SMNG(SupervisedPrototypeModel):
     Parameters
     ----------
     latent_dim : int, optional
-        Dimensionality of the latent space. If None, uses input dim.
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
+        Dimensionality of the Omega projection space. If None, uses input dim.
     beta : float
-        Transfer function steepness parameter.
+        Transfer function steepness parameter for sigmoid shaping.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,

--- a/prosemble/models/srng.py
+++ b/prosemble/models/srng.py
@@ -39,30 +39,91 @@ class SRNG(SupervisedPrototypeModel):
 
     Parameters
     ----------
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
     beta : float
-        Transfer function steepness parameter.
+        Transfer function steepness parameter for sigmoid shaping.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, beta=10.0, gamma_init=None, gamma_final=0.01,

--- a/prosemble/models/stng.py
+++ b/prosemble/models/stng.py
@@ -66,30 +66,91 @@ class STNG(SupervisedPrototypeModel):
     ----------
     subspace_dim : int
         Dimension of each prototype's tangent subspace.
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
     beta : float
-        Transfer function steepness parameter.
+        Transfer function steepness parameter for sigmoid shaping.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, subspace_dim=2, beta=10.0, gamma_init=None,

--- a/prosemble/models/svq_occ.py
+++ b/prosemble/models/svq_occ.py
@@ -55,7 +55,7 @@ class SVQOCC(SupervisedPrototypeModel):
         as the most frequent class.
     alpha : float
         Balance between representation (R) and classification (C) cost.
-        E = α·R + (1−α)·C. Default: 0.5.
+        E = alpha * R + (1 - alpha) * C. Default: 0.5.
     cost_function : str
         Classification cost variant: 'contrastive', 'brier', 'cross_entropy'.
         Default: 'contrastive'.
@@ -74,16 +74,88 @@ class SVQOCC(SupervisedPrototypeModel):
     lambda_final : float
         Final NG neighborhood range. Default: 0.01.
     lambda_decay : float, optional
-        Per-step multiplicative decay for lambda. Default: computed from max_iter.
+        Per-step multiplicative decay for lambda. Default: computed from
+        max_iter.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster,
+        JIT-compiled, but runs all max_iter iterations even after
+        convergence). If False, use a Python for-loop with true early
+        stopping (no wasted compute after convergence, but slower per
+        iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this
+        size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings:
+        'stratified_random' (default), 'class_mean',
+        'class_conditional_mean', 'stratified_noise', 'random_normal',
+        'uniform', 'zeros', 'ones', 'fill_value'. Or pass a callable
+        ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step
+        (epsilon check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default:
+        False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None
+        (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an
+        update. Effective batch size = batch_size *
+        gradient_accumulation_steps. Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters
+        (0 < ema_decay < 1). After training, model parameters are
+        replaced with EMA-smoothed values. Typical values: 0.999,
+        0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train
+        prototypes. Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or
+        'bfloat16'. Master weights stay in float32; forward/backward
+        pass runs in lower precision for ~2x speed and ~half memory on
+        GPU. Float16 uses static loss scaling to prevent gradient
+        underflow. Default: None (disabled).
     """
 
     _valid_costs = ('contrastive', 'brier', 'cross_entropy')

--- a/prosemble/models/svq_occ_lm.py
+++ b/prosemble/models/svq_occ_lm.py
@@ -38,13 +38,111 @@ class SVQOCC_LM(SVQOCC):
     n_prototypes : int
         Number of prototypes for the target class.
     target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
+        Which label is the target (normal) class. Default: auto-detect
+        as the most frequent class.
     alpha : float
-        Balance between representation and classification. Default: 0.5.
+        Balance between representation (R) and classification (C) cost.
+        E = alpha * R + (1 - alpha) * C. Default: 0.5.
     cost_function : str
-        'contrastive', 'brier', or 'cross_entropy'. Default: 'contrastive'.
+        Classification cost variant: 'contrastive', 'brier', 'cross_entropy'.
+        Default: 'contrastive'.
     response_type : str
-        'gaussian', 'student_t', or 'uniform'. Default: 'gaussian'.
+        Response probability model: 'gaussian', 'student_t', 'uniform'.
+        Default: 'gaussian'.
+    sigma : float
+        Sigmoid sharpness for differentiable Heaviside approximation.
+        Smaller = sharper boundary. Default: 0.1.
+    gamma_resp : float
+        Response bandwidth for Gaussian probabilistic assignment. Default: 1.0.
+    nu : float
+        Degrees of freedom for Student-t response. Default: 1.0.
+    lambda_init : float, optional
+        Initial NG neighborhood range. Default: n_prototypes / 2.
+    lambda_final : float
+        Final NG neighborhood range. Default: 0.01.
+    lambda_decay : float, optional
+        Per-step multiplicative decay for lambda. Default: computed from
+        max_iter.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster,
+        JIT-compiled, but runs all max_iter iterations even after
+        convergence). If False, use a Python for-loop with true early
+        stopping (no wasted compute after convergence, but slower per
+        iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this
+        size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings:
+        'stratified_random' (default), 'class_mean',
+        'class_conditional_mean', 'stratified_noise', 'random_normal',
+        'uniform', 'zeros', 'ones', 'fill_value'. Or pass a callable
+        ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step
+        (epsilon check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default:
+        False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None
+        (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an
+        update. Effective batch size = batch_size *
+        gradient_accumulation_steps. Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters
+        (0 < ema_decay < 1). After training, model parameters are
+        replaced with EMA-smoothed values. Typical values: 0.999,
+        0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train
+        prototypes. Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or
+        'bfloat16'. Master weights stay in float32; forward/backward
+        pass runs in lower precision for ~2x speed and ~half memory on
+        GPU. Float16 uses static loss scaling to prevent gradient
+        underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -53,8 +151,7 @@ class SVQOCC_LM(SVQOCC):
 
     See Also
     --------
-    SVQOCC : Full SVQ-OCC parameter documentation.
-    SupervisedPrototypeModel : Full list of base parameters.
+    SVQOCC : Base SVQ-OCC model.
     """
 
     def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,

--- a/prosemble/models/svq_occ_m.py
+++ b/prosemble/models/svq_occ_m.py
@@ -38,13 +38,111 @@ class SVQOCC_M(SVQOCC):
     n_prototypes : int
         Number of prototypes for the target class.
     target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
+        Which label is the target (normal) class. Default: auto-detect
+        as the most frequent class.
     alpha : float
-        Balance between representation and classification. Default: 0.5.
+        Balance between representation (R) and classification (C) cost.
+        E = alpha * R + (1 - alpha) * C. Default: 0.5.
     cost_function : str
-        'contrastive', 'brier', or 'cross_entropy'. Default: 'contrastive'.
+        Classification cost variant: 'contrastive', 'brier', 'cross_entropy'.
+        Default: 'contrastive'.
     response_type : str
-        'gaussian', 'student_t', or 'uniform'. Default: 'gaussian'.
+        Response probability model: 'gaussian', 'student_t', 'uniform'.
+        Default: 'gaussian'.
+    sigma : float
+        Sigmoid sharpness for differentiable Heaviside approximation.
+        Smaller = sharper boundary. Default: 0.1.
+    gamma_resp : float
+        Response bandwidth for Gaussian probabilistic assignment. Default: 1.0.
+    nu : float
+        Degrees of freedom for Student-t response. Default: 1.0.
+    lambda_init : float, optional
+        Initial NG neighborhood range. Default: n_prototypes / 2.
+    lambda_final : float
+        Final NG neighborhood range. Default: 0.01.
+    lambda_decay : float, optional
+        Per-step multiplicative decay for lambda. Default: computed from
+        max_iter.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster,
+        JIT-compiled, but runs all max_iter iterations even after
+        convergence). If False, use a Python for-loop with true early
+        stopping (no wasted compute after convergence, but slower per
+        iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this
+        size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings:
+        'stratified_random' (default), 'class_mean',
+        'class_conditional_mean', 'stratified_noise', 'random_normal',
+        'uniform', 'zeros', 'ones', 'fill_value'. Or pass a callable
+        ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step
+        (epsilon check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default:
+        False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None
+        (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an
+        update. Effective batch size = batch_size *
+        gradient_accumulation_steps. Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters
+        (0 < ema_decay < 1). After training, model parameters are
+        replaced with EMA-smoothed values. Typical values: 0.999,
+        0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train
+        prototypes. Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or
+        'bfloat16'. Master weights stay in float32; forward/backward
+        pass runs in lower precision for ~2x speed and ~half memory on
+        GPU. Float16 uses static loss scaling to prevent gradient
+        underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -53,8 +151,7 @@ class SVQOCC_M(SVQOCC):
 
     See Also
     --------
-    SVQOCC : Full SVQ-OCC parameter documentation.
-    SupervisedPrototypeModel : Full list of base parameters.
+    SVQOCC : Base SVQ-OCC model.
     """
 
     def __init__(self, latent_dim=None, n_prototypes=3, target_label=None,

--- a/prosemble/models/svq_occ_r.py
+++ b/prosemble/models/svq_occ_r.py
@@ -37,25 +37,111 @@ class SVQOCC_R(SVQOCC):
     n_prototypes : int
         Number of prototypes for the target class.
     target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
+        Which label is the target (normal) class. Default: auto-detect
+        as the most frequent class.
     alpha : float
-        Balance between representation and classification. Default: 0.5.
+        Balance between representation (R) and classification (C) cost.
+        E = alpha * R + (1 - alpha) * C. Default: 0.5.
     cost_function : str
-        'contrastive', 'brier', or 'cross_entropy'. Default: 'contrastive'.
+        Classification cost variant: 'contrastive', 'brier', 'cross_entropy'.
+        Default: 'contrastive'.
     response_type : str
-        'gaussian', 'student_t', or 'uniform'. Default: 'gaussian'.
+        Response probability model: 'gaussian', 'student_t', 'uniform'.
+        Default: 'gaussian'.
     sigma : float
-        Sigmoid sharpness. Default: 0.1.
+        Sigmoid sharpness for differentiable Heaviside approximation.
+        Smaller = sharper boundary. Default: 0.1.
     gamma_resp : float
-        Response bandwidth. Default: 1.0.
+        Response bandwidth for Gaussian probabilistic assignment. Default: 1.0.
     nu : float
-        Student-t degrees of freedom. Default: 1.0.
+        Degrees of freedom for Student-t response. Default: 1.0.
     lambda_init : float, optional
-        Initial NG neighborhood range.
+        Initial NG neighborhood range. Default: n_prototypes / 2.
     lambda_final : float
         Final NG neighborhood range. Default: 0.01.
     lambda_decay : float, optional
-        Per-step decay for lambda.
+        Per-step multiplicative decay for lambda. Default: computed from
+        max_iter.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster,
+        JIT-compiled, but runs all max_iter iterations even after
+        convergence). If False, use a Python for-loop with true early
+        stopping (no wasted compute after convergence, but slower per
+        iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this
+        size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings:
+        'stratified_random' (default), 'class_mean',
+        'class_conditional_mean', 'stratified_noise', 'random_normal',
+        'uniform', 'zeros', 'ones', 'fill_value'. Or pass a callable
+        ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step
+        (epsilon check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default:
+        False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None
+        (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an
+        update. Effective batch size = batch_size *
+        gradient_accumulation_steps. Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters
+        (0 < ema_decay < 1). After training, model parameters are
+        replaced with EMA-smoothed values. Typical values: 0.999,
+        0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train
+        prototypes. Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or
+        'bfloat16'. Master weights stay in float32; forward/backward
+        pass runs in lower precision for ~2x speed and ~half memory on
+        GPU. Float16 uses static loss scaling to prevent gradient
+        underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -64,8 +150,7 @@ class SVQOCC_R(SVQOCC):
 
     See Also
     --------
-    SVQOCC : Full SVQ-OCC parameter documentation.
-    SupervisedPrototypeModel : Full list of base parameters.
+    SVQOCC : Base SVQ-OCC model.
     """
 
     def __init__(self, n_prototypes=3, target_label=None, alpha=0.5,

--- a/prosemble/models/svq_occ_t.py
+++ b/prosemble/models/svq_occ_t.py
@@ -42,13 +42,111 @@ class SVQOCC_T(SVQOCC):
     n_prototypes : int
         Number of prototypes for the target class.
     target_label : int, optional
-        Target (normal) class label. Default: auto-detect.
+        Which label is the target (normal) class. Default: auto-detect
+        as the most frequent class.
     alpha : float
-        Balance between representation and classification. Default: 0.5.
+        Balance between representation (R) and classification (C) cost.
+        E = alpha * R + (1 - alpha) * C. Default: 0.5.
     cost_function : str
-        'contrastive', 'brier', or 'cross_entropy'. Default: 'contrastive'.
+        Classification cost variant: 'contrastive', 'brier', 'cross_entropy'.
+        Default: 'contrastive'.
     response_type : str
-        'gaussian', 'student_t', or 'uniform'. Default: 'gaussian'.
+        Response probability model: 'gaussian', 'student_t', 'uniform'.
+        Default: 'gaussian'.
+    sigma : float
+        Sigmoid sharpness for differentiable Heaviside approximation.
+        Smaller = sharper boundary. Default: 0.1.
+    gamma_resp : float
+        Response bandwidth for Gaussian probabilistic assignment. Default: 1.0.
+    nu : float
+        Degrees of freedom for Student-t response. Default: 1.0.
+    lambda_init : float, optional
+        Initial NG neighborhood range. Default: n_prototypes / 2.
+    lambda_final : float
+        Final NG neighborhood range. Default: 0.01.
+    lambda_decay : float, optional
+        Per-step multiplicative decay for lambda. Default: computed from
+        max_iter.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster,
+        JIT-compiled, but runs all max_iter iterations even after
+        convergence). If False, use a Python for-loop with true early
+        stopping (no wasted compute after convergence, but slower per
+        iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this
+        size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings:
+        'stratified_random' (default), 'class_mean',
+        'class_conditional_mean', 'stratified_noise', 'random_normal',
+        'uniform', 'zeros', 'ones', 'fill_value'. Or pass a callable
+        ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step
+        (epsilon check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default:
+        False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None
+        (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an
+        update. Effective batch size = batch_size *
+        gradient_accumulation_steps. Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters
+        (0 < ema_decay < 1). After training, model parameters are
+        replaced with EMA-smoothed values. Typical values: 0.999,
+        0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train
+        prototypes. Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or
+        'bfloat16'. Master weights stay in float32; forward/backward
+        pass runs in lower precision for ~2x speed and ~half memory on
+        GPU. Float16 uses static loss scaling to prevent gradient
+        underflow. Default: None (disabled).
 
     Attributes
     ----------
@@ -57,8 +155,7 @@ class SVQOCC_T(SVQOCC):
 
     See Also
     --------
-    SVQOCC : Full SVQ-OCC parameter documentation.
-    SupervisedPrototypeModel : Full list of base parameters.
+    SVQOCC : Base SVQ-OCC model.
     """
 
     def __init__(self, subspace_dim=2, n_prototypes=3, target_label=None,

--- a/prosemble/models/tangent_lvq.py
+++ b/prosemble/models/tangent_lvq.py
@@ -43,23 +43,83 @@ class GTLVQ(SupervisedPrototypeModel):
     ----------
     subspace_dim : int
         Dimension of each prototype's tangent subspace.
+    beta : float
+        Transfer function steepness.
     n_prototypes_per_class : int
-        Prototypes per class.
+        Number of prototypes per class.
     max_iter : int
         Maximum training iterations.
     lr : float
         Learning rate.
-    beta : float
-        Transfer function steepness.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
     transfer_fn : callable, optional
-        Transfer function for loss shaping. Default: identity.
+        Transfer function for loss shaping (default: identity).
     margin : float
-        Margin added to the loss. Default: 0.0.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) — sync every k steps
+        - 'slow_step_size': float (default 0.5) — interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, subspace_dim=2, beta=10.0,

--- a/prosemble/models/tcelvq_ng.py
+++ b/prosemble/models/tcelvq_ng.py
@@ -68,24 +68,89 @@ class TCELVQ_NG(CELVQNGMixin, CELVQ):
     ----------
     subspace_dim : int
         Dimension of each prototype's tangent subspace.
-    n_prototypes_per_class : int
-        Prototypes per class.
-    max_iter : int
-        Maximum training iterations.
-    lr : float
-        Learning rate.
     gamma_init : float, optional
-        Initial neighborhood range. Default: max prototypes per class / 2.
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
     gamma_final : float
         Final neighborhood range. Default: 0.01.
     gamma_decay : float, optional
         Per-step multiplicative decay factor for gamma.
         Default: computed from max_iter so gamma reaches gamma_final.
-
-    See Also
-    --------
-    SupervisedPrototypeModel : Full list of base parameters (optimizer,
-        distance_fn, lr_scheduler, callbacks, patience, etc.).
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    distance_fn : callable, optional
+        Distance function (default: squared Euclidean).
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training (faster, JIT-compiled,
+        but runs all max_iter iterations even after convergence).
+        If False, use a Python for-loop with true early stopping (no wasted
+        compute after convergence, but slower per iteration).
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+        When set, each epoch iterates over shuffled mini-batches of this size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Supported strings: 'exponential_decay',
+        'cosine_decay', 'warmup_cosine_decay', 'warmup_exponential_decay',
+        'warmup_constant', 'polynomial', 'linear', 'piecewise_constant',
+        'sgdr'. Or pass a custom optax.Schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments passed to the learning rate scheduler
+        (e.g. ``decay_rate``, ``transition_steps``). Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Supported strings: 'stratified_random'
+        (default), 'class_mean', 'class_conditional_mean', 'stratified_noise',
+        'random_normal', 'uniform', 'zeros', 'ones', 'fill_value'.
+        Or pass a callable ``(X, y, n_per_class, key) -> (protos, labels)``.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        If None (default), stops after a single non-improving step (epsilon
+        check). Requires use_scan=False for true early stopping.
+    restore_best : bool
+        If True, restore the parameters that achieved the lowest loss
+        (or validation loss if validation data is provided). Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Dict maps class label to weight, e.g.
+        {0: 1.0, 1: 2.0, 2: 1.5}. 'balanced' auto-computes weights
+        inversely proportional to class frequencies. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps before applying an update.
+        Effective batch size = batch_size * gradient_accumulation_steps.
+        Default: None (no accumulation).
+    ema_decay : float, optional
+        Exponential moving average decay for parameters (0 < ema_decay < 1).
+        After training, model parameters are replaced with EMA-smoothed values.
+        Typical values: 0.999, 0.9999. Default: None (no EMA).
+    freeze_params : list of str, optional
+        List of parameter group names to freeze (zero gradients).
+        E.g. ['backbone'] to freeze the backbone and only train prototypes.
+        Default: None (all parameters trainable).
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Dict with keys:
+        - 'sync_period': int (default 6) -- sync every k steps
+        - 'slow_step_size': float (default 0.5) -- interpolation factor
+        Default: None (no lookahead).
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. 'float16' or 'bfloat16'.
+        Master weights stay in float32; forward/backward pass runs in lower
+        precision for ~2x speed and ~half memory on GPU. Float16 uses static
+        loss scaling to prevent gradient underflow. Default: None (disabled).
     """
 
     def __init__(self, subspace_dim=2, gamma_init=None,


### PR DESCRIPTION
## Summary

- Every parameter in every model's `__init__` signature now has a full description in the class docstring's Parameters section, matching scikit-learn convention
- Covers all 68 model files across supervised LVQ, one-class, NG, SVQ-OCC, fuzzy clustering, and unsupervised topology families
- Removes "See Also" references to base classes since all params are now documented inline

## Test plan

- [x] All 1,144 tests pass
- [x] Sphinx build clean (no new warnings)
- [x] Spot-checked rendered HTML for GLVQ, FCM, OCGLVQ — all params have descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)