### PR TITLE
docs: Convert Unicode math to MathJax rendering

### DIFF
--- a/prosemble/models/afcm.py
+++ b/prosemble/models/afcm.py
@@ -46,7 +46,7 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     with specific parameter combinations.
 
     Key features:
-    - Centroids use a·U^m + b·T (T to power 1, not m!)
+    - Centroids use :math:`a \\cdot U^m + b \\cdot T` (T to power 1, not m!)
     - Gamma computed with Euclidean distance (not squared)
     - Exponential T update with parameter b
     - Standard FCM U update
@@ -60,10 +60,11 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     5. Update centroids using combined fuzzy-possibilistic weights
     6. Repeat until convergence
 
-    Objective function::
+    Objective function:
 
-        J = Σ_i Σ_j [d²_ij · (a·u_ij^m + b·t_ij)] +
-            Σ_j[γ_j · Σ_i(t_ij·log(t_ij) - t_ij)]
+    .. math::
+
+        J = \\sum_i \\sum_j \\left[d_{ij}^2 \\cdot (a \\cdot u_{ij}^m + b \\cdot t_{ij})\\right] + \\sum_j \\left[\\gamma_j \\cdot \\sum_i (t_{ij} \\log t_{ij} - t_{ij})\\right]
 
     Parameters
     ----------
@@ -221,7 +222,9 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute gamma using Euclidean distance (not squared!).
 
-        γ_j = k·Σ_i(u_ij^m · d_ij) / Σ_i(u_ij^m)
+        .. math::
+
+            \\gamma_j = k \\cdot \\frac{\\sum_i u_{ij}^m \\cdot d_{ij}}{\\sum_i u_{ij}^m}
         """
         D_sq = self.distance_fn(X, centroids)
         D = jnp.sqrt(jnp.maximum(D_sq, 1e-10))  # Euclidean distance
@@ -241,7 +244,9 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Update typicality matrix with exponential and parameter b.
 
-        t_ij = exp(-b·d²_ij/γ_j)
+        .. math::
+
+            t_{ij} = \\exp\\left(-\\frac{b \\cdot d_{ij}^2}{\\gamma_j}\\right)
         """
         D_sq = self.distance_fn(X, centroids)
         D_sq = jnp.maximum(D_sq, 1e-10)
@@ -285,13 +290,15 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute cluster centroids.
 
-        v_j = Σ_i[a·u_ij^m + b·t_ij]x_i / Σ_i[a·u_ij^m + b·t_ij]
+        .. math::
+
+            v_j = \\frac{\\sum_i \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}\\right] x_i}{\\sum_i \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}\\right]}
 
         Note: T is NOT raised to a power!
         """
         U_fuzz = jnp.power(U, self.fuzzifier)
 
-        # Combined weights: a·U^m + b·T
+        # Combined weights: a*U^m + b*T
         weights = self.a * U_fuzz + self.b * T
 
         # Compute centroids
@@ -310,17 +317,18 @@ class AFCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute AFCM objective function.
 
-        J = Σ_i Σ_j [d²_ij · (a·u_ij^m + b·t_ij)] +
-            Σ_j[γ_j · Σ_i(t_ij·log(t_ij) - t_ij)]
+        .. math::
+
+            J = \\sum_i \\sum_j \\left[d_{ij}^2 \\cdot (a \\cdot u_{ij}^m + b \\cdot t_{ij})\\right] + \\sum_j \\left[\\gamma_j \\cdot \\sum_i (t_{ij} \\log t_{ij} - t_{ij})\\right]
         """
         D_sq = self.distance_fn(X, centroids)
         U_fuzz = jnp.power(U, self.fuzzifier)
 
-        # First term: Σ_i Σ_j [d²_ij · (a·u_ij^m + b·t_ij)]
+        # First term: sum_i sum_j [d^2_ij * (a*u_ij^m + b*t_ij)]
         weights = self.a * U_fuzz + self.b * T
         term1 = jnp.sum(D_sq * weights)
 
-        # Second term: Σ_j[γ_j · Σ_i(t·log(t) - t)]
+        # Second term: sum_j[gamma_j * sum_i(t*log(t) - t)]
         T_safe = jnp.maximum(T, 1e-10)
         entropy_like = T * jnp.log(T_safe) - T
         inner_sum = jnp.sum(entropy_like, axis=0)

--- a/prosemble/models/bgpc.py
+++ b/prosemble/models/bgpc.py
@@ -95,9 +95,9 @@ class BGPC:
     @partial(jit, static_argnums=(0,))
     def _compute_beta_decay(self, iteration: int) -> float:
         """
-        Compute beta decay: β(t) = 0.1 * (β_f / 0.1)^(t/T)
+        Compute beta decay: :math:`\\beta(t) = 0.1 \\cdot (\\beta_f / 0.1)^{t/T}`.
 
-        β starts at 0.1 and grows to β_f over iterations
+        :math:`\\beta` starts at 0.1 and grows to :math:`\\beta_f` over iterations.
         """
         ratio = iteration / self.max_iter
         beta = self.beta_init * jnp.power(self.beta_final / self.beta_init, ratio)
@@ -106,9 +106,9 @@ class BGPC:
     @partial(jit, static_argnums=(0,))
     def _compute_alpha_decay(self, iteration: int) -> float:
         """
-        Compute alpha decay: α(t) = (1 - β_f) * (1 + exp(t - T) + α_0)
+        Compute alpha decay: :math:`\\alpha(t) = (1 - \\beta_f)(1 + \\exp(t - T) + \\alpha_0)`.
 
-        α decays over iterations
+        :math:`\\alpha` decays over iterations.
         """
         alpha = (1 - self.beta_final) * (1 + jnp.exp(iteration - self.max_iter) + self.alpha_init)
         return alpha
@@ -116,9 +116,9 @@ class BGPC:
     @partial(jit, static_argnums=(0,))
     def _compute_V_matrix(self, X: chex.Array, centroids: chex.Array, beta: float) -> chex.Array:
         """
-        Compute V matrix: V_ij = exp(-d(x_i, v_j) / β)
+        Compute V matrix: :math:`V_{ij} = \\exp(-d(x_i, v_j) / \\beta)`.
 
-        Uses Euclidean distance (not squared)
+        Uses Euclidean distance (not squared).
         """
         D_sq = batch_squared_euclidean(X, centroids)
         D = jnp.sqrt(jnp.maximum(D_sq, 1e-10))
@@ -128,12 +128,13 @@ class BGPC:
     @partial(jit, static_argnums=(0,))
     def _compute_z_value(self, v_i: chex.Array, alpha: float) -> float:
         """
-        Compute Z_i for a single data point based on V_i values
+        Compute :math:`Z_i` for a single data point based on :math:`V_i` values.
 
         Logic from original:
-        - If Σ(v_ik^(1/α)) > 1: z_i = (Σ(v_ik^(1/α)))^α
-        - If Σ(v_ik^α) < 1: z_i = (Σ(v_ik^α))^(1/α)
-        - Otherwise: z_i = 1
+
+        - If :math:`\\sum_k v_{ik}^{1/\\alpha} > 1`: :math:`z_i = (\\sum_k v_{ik}^{1/\\alpha})^\\alpha`
+        - If :math:`\\sum_k v_{ik}^\\alpha < 1`: :math:`z_i = (\\sum_k v_{ik}^\\alpha)^{1/\\alpha}`
+        - Otherwise: :math:`z_i = 1`
         """
         v_pow_inv_alpha = jnp.power(v_i, 1.0 / alpha)
         v_pow_alpha = jnp.power(v_i, alpha)
@@ -164,7 +165,7 @@ class BGPC:
     @partial(jit, static_argnums=(0,))
     def _update_U_matrix(self, V: chex.Array, Z: chex.Array) -> chex.Array:
         """
-        Update U matrix: U_ij = V_ij / Z_i
+        Update U matrix: :math:`U_{ij} = V_{ij} / Z_i`.
         """
         U = V / (Z[:, None] + 1e-10)
         return U
@@ -172,7 +173,7 @@ class BGPC:
     @partial(jit, static_argnums=(0,))
     def _compute_centroids(self, X: chex.Array, U: chex.Array) -> chex.Array:
         """
-        Compute centroids: v_j = Σ_i u_ij·x_i / Σ_i u_ij
+        Compute centroids: :math:`v_j = \\sum_i u_{ij} x_i / \\sum_i u_{ij}`.
         """
         numerator = U.T @ X
         denominator = jnp.sum(U, axis=0, keepdims=True).T

--- a/prosemble/models/fcm.py
+++ b/prosemble/models/fcm.py
@@ -11,21 +11,37 @@ for each cluster. Unlike hard clustering (K-Means), each point can belong to
 multiple clusters with varying degrees.
 
 Objective Function:
-    J(U, V) = Σᵢ Σⱼ uᵢⱼᵐ ||xᵢ - vⱼ||²
+
+.. math::
+
+    J(U, V) = \\sum_i \\sum_j u_{ij}^m \\|x_i - v_j\\|^2
 
 Subject to:
-    Σⱼ uᵢⱼ = 1  ∀i  (membership constraint)
-    uᵢⱼ ∈ [0,1]    (fuzzy membership)
+
+.. math::
+
+    \\sum_j u_{ij} = 1 \\quad \\forall i \\quad \\text{(membership constraint)}
+
+.. math::
+
+    u_{ij} \\in [0, 1] \\quad \\text{(fuzzy membership)}
 
 Update Rules:
-    vⱼ = Σᵢ(uᵢⱼᵐ xᵢ) / Σᵢ uᵢⱼᵐ
-    uᵢⱼ = 1 / Σₖ (dᵢⱼ/dᵢₖ)^(2/(m-1))
+
+.. math::
+
+    v_j = \\frac{\\sum_i u_{ij}^m x_i}{\\sum_i u_{ij}^m}
+
+.. math::
+
+    u_{ij} = \\frac{1}{\\sum_k \\left(\\frac{d_{ij}}{d_{ik}}\\right)^{2/(m-1)}}
 
 where:
-    - U: fuzzy membership matrix (n × c)
-    - V: cluster centroids (c × d)
-    - m: fuzzifier parameter (typically 2.0)
-    - dᵢⱼ: distance from point xᵢ to centroid vⱼ
+
+- :math:`U`: fuzzy membership matrix (n x c)
+- :math:`V`: cluster centroids (c x d)
+- :math:`m`: fuzzifier parameter (typically 2.0)
+- :math:`d_{ij}`: distance from point :math:`x_i` to centroid :math:`v_j`
 
 Author: Prosemble Contributors
 License: MIT
@@ -221,10 +237,13 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
         Initialize fuzzy membership matrix U.
 
         Uses Dirichlet distribution to ensure row sums equal 1:
-        U ~ Dir(α) where α = [1, 1, ..., 1]
+        U ~ Dir(alpha) where alpha = [1, 1, ..., 1]
 
         Mathematical Property:
-            Σⱼ uᵢⱼ = 1  ∀i
+
+        .. math::
+
+            \\sum_j u_{ij} = 1 \\quad \\forall i
 
         Args:
             X: (n, d) data matrix
@@ -250,10 +269,13 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
         Compute cluster centroids from fuzzy membership matrix.
 
         Mathematical Formula:
-            vⱼ = Σᵢ(uᵢⱼᵐ xᵢ) / Σᵢ uᵢⱼᵐ
+
+        .. math::
+
+            v_j = \\frac{\\sum_i u_{ij}^m x_i}{\\sum_i u_{ij}^m}
 
         Vectorized Implementation:
-            V = (Uᵐ)ᵀ @ X / sum((Uᵐ)ᵀ, axis=1, keepdims=True)
+            V = (U^m)^T @ X / sum((U^m)^T, axis=1, keepdims=True)
 
         Old Implementation (NumPy):
             ```python
@@ -320,9 +342,12 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
         Update fuzzy membership matrix.
 
         Mathematical Formula:
-            uᵢⱼ = 1 / Σₖ (dᵢⱼ/dᵢₖ)^(2/(m-1))
 
-        where dᵢⱼ = ||xᵢ - vⱼ|| is Euclidean distance.
+        .. math::
+
+            u_{ij} = \\frac{1}{\\sum_k \\left(\\frac{d_{ij}}{d_{ik}}\\right)^{2/(m-1)}}
+
+        where :math:`d_{ij} = \\|x_i - v_j\\|` is Euclidean distance.
 
         Old Implementation (NumPy):
             ```python
@@ -401,12 +426,15 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
         Compute FCM objective function.
 
         Mathematical Formula:
-            J = Σᵢ Σⱼ uᵢⱼᵐ ||xᵢ - vⱼ||²
+
+        .. math::
+
+            J = \\sum_i \\sum_j u_{ij}^m \\|x_i - v_j\\|^2
 
         Vectorized Implementation:
-            J = sum(Uᵐ ⊙ D²)
+            J = sum(U^m * D^2)
 
-        where ⊙ is element-wise product.
+        where * is element-wise product.
 
         Old Implementation (NumPy):
             ```python
@@ -460,7 +488,7 @@ class FCM(ScanFitMixin, FuzzyClusteringBase):
         """
         Check if centroids have converged.
 
-        Formula: ||V_new - V_old||_F < epsilon
+        Formula: :math:`\\|V_{new} - V_{old}\\|_F < \\epsilon`
 
         Uses Frobenius norm for stability.
 

--- a/prosemble/models/fpcm.py
+++ b/prosemble/models/fpcm.py
@@ -52,9 +52,11 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
     4. Update T with column-normalization
     5. Repeat until convergence
 
-    Objective function::
+    Objective function:
 
-        J = Σ_i Σ_j [u_ij^m + t_ij^η] ||x_i - v_j||²
+    .. math::
+
+        J = \\sum_i \\sum_j \\left[u_{ij}^m + t_{ij}^\\eta\\right] \\|x_i - v_j\\|^2
 
     Reference:
         Pal, N. R., Pal, K., & Bezdek, J. C. (1997).
@@ -224,7 +226,9 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute cluster centroids.
 
-        Centroids: v_j = Σ_i[u_ij^m + t_ij^η]x_i / Σ_i[u_ij^m + t_ij^η]
+        .. math::
+
+            v_j = \\frac{\\sum_i \\left[u_{ij}^m + t_{ij}^\\eta\\right] x_i}{\\sum_i \\left[u_{ij}^m + t_{ij}^\\eta\\right]}
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -255,7 +259,11 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Update fuzzy membership matrix using FCM rule.
 
-        Standard FCM update: u_ij = 1 / Σ_k (d_ij / d_ik)^(2/(m-1))
+        Standard FCM update:
+
+        .. math::
+
+            u_{ij} = \\frac{1}{\\sum_k \\left(\\frac{d_{ij}}{d_{ik}}\\right)^{2/(m-1)}}
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -278,7 +286,7 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
         # For each i,j: sum over k of (D[i,j] / D[i,k])^power
         def compute_membership_row(distances_i):
             # distances_i: (n_clusters,)
-            # For each j, compute: 1 / Σ_k (d_ij / d_ik)^power
+            # For each j, compute: 1 / sum_k (d_ij / d_ik)^power
             ratios = distances_i[:, None] / distances_i[None, :]  # (n_clusters, n_clusters)
             powered_ratios = jnp.power(ratios, power)  # (n_clusters, n_clusters)
             denominators = jnp.sum(powered_ratios, axis=1)  # (n_clusters,)
@@ -299,9 +307,12 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
         """Update typicality matrix with column-sum-to-1 constraint.
 
         Per Pal, Pal & Bezdek (1997):
-            t_ij = (1/d_ij²)^(1/(η-1)) / Σ_i (1/d_ij²)^(1/(η-1))
 
-        Each column j sums to 1 across samples (Σ_i t_ij = 1).
+        .. math::
+
+            t_{ij} = \\frac{(1/d_{ij}^2)^{1/(\\eta-1)}}{\\sum_i (1/d_{ij}^2)^{1/(\\eta-1)}}
+
+        Each column j sums to 1 across samples (:math:`\\sum_i t_{ij} = 1`).
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -328,7 +339,9 @@ class FPCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute FPCM objective function.
 
-        Objective: J = Σ_i Σ_j [u_ij^m + t_ij^η] ||x_i - v_j||²
+        .. math::
+
+            J = \\sum_i \\sum_j \\left[u_{ij}^m + t_{ij}^\\eta\\right] \\|x_i - v_j\\|^2
 
         Args:
             X: Input data, shape (n_samples, n_features)

--- a/prosemble/models/hcm.py
+++ b/prosemble/models/hcm.py
@@ -48,9 +48,11 @@ class HCM(ScanFitMixin, FuzzyClusteringBase):
     3. Update centroids as mean of assigned points
     4. Repeat until convergence
 
-    Objective function::
+    Objective function:
 
-        J = Σ_i ||x_i - v_{label_i}||²
+    .. math::
+
+        J = \\sum_i \\|x_i - v_{l_i}\\|^2
 
     Parameters
     ----------
@@ -263,7 +265,9 @@ class HCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute HCM objective function.
 
-        Objective: J = Σ_i ||x_i - v_{label_i}||²
+        .. math::
+
+            J = \\sum_i \\|x_i - v_{l_i}\\|^2
 
         Args:
             X: Input data, shape (n_samples, n_features)

--- a/prosemble/models/heskes_som.py
+++ b/prosemble/models/heskes_som.py
@@ -6,17 +6,23 @@ Best Matching Unit (BMU) definition that accounts for the neighborhood
 function, and a pure batch update rule (no learning rate). This
 guarantees monotonic decrease of a well-defined energy function.
 
-Energy function::
+Energy function:
 
-    E = Σ_x Σ_k h(k, c*(x)) * ||x - w_k||^2
+.. math::
 
-Modified BMU::
+    E = \\sum_x \\sum_k h(k, c^*(x)) \\cdot \\|x - w_k\\|^2
 
-    c*(x) = argmin_c Σ_k h(k, c) * ||x - w_k||^2
+Modified BMU:
 
-Batch update::
+.. math::
 
-    w_k = Σ_x h(k, c*(x)) * x / Σ_x h(k, c*(x))
+    c^*(x) = \\arg\\min_c \\sum_k h(k, c) \\cdot \\|x - w_k\\|^2
+
+Batch update:
+
+.. math::
+
+    w_k = \\frac{\\sum_x h(k, c^*(x)) \\cdot x}{\\sum_x h(k, c^*(x))}
 
 References
 ----------

--- a/prosemble/models/ipcm.py
+++ b/prosemble/models/ipcm.py
@@ -68,9 +68,11 @@ class IPCM(FuzzyClusteringBase):
     7. Recompute gamma using both U and T
     8. Continue iterations with new gamma
 
-    Objective function::
+    Objective function:
 
-        J = Σ_i Σ_j [u_ij^m_f · t_ij^m_p · d²_ij] + Σ_j[γ_j · Σ_i((1-t_ij)^m_p · u_ij^m_f)]
+    .. math::
+
+        J = \\sum_i \\sum_j u_{ij}^{m_f} \\cdot t_{ij}^{m_p} \\cdot d_{ij}^2 + \\sum_j \\gamma_j \\sum_i (1 - t_{ij})^{m_p} \\cdot u_{ij}^{m_f}
 
     Parameters
     ----------
@@ -229,7 +231,9 @@ class IPCM(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute gamma for phase 0.
 
-        γ_j = Σ_i(u_ij^m_f · d²_ij) / Σ_i(u_ij^m_f)
+        .. math::
+
+            \\gamma_j = \\frac{\\sum_i u_{ij}^{m_f} \\cdot d_{ij}^2}{\\sum_i u_{ij}^{m_f}}
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -259,7 +263,9 @@ class IPCM(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute gamma for phase 1.
 
-        γ_j = k · Σ_i(u_ij^m_f · t_ij^m_p · d²_ij) / Σ_i(u_ij^m_f · t_ij^m_p)
+        .. math::
+
+            \\gamma_j = k \\cdot \\frac{\\sum_i u_{ij}^{m_f} \\cdot t_{ij}^{m_p} \\cdot d_{ij}^2}{\\sum_i u_{ij}^{m_f} \\cdot t_{ij}^{m_p}}
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -294,7 +300,9 @@ class IPCM(FuzzyClusteringBase):
     ) -> chex.Array:
         """Update typicality matrix.
 
-        t_ij = 1 / (1 + (d²_ij/γ_j)^(1/(m_p-1)))
+        .. math::
+
+            t_{ij} = \\frac{1}{1 + \\left(\\frac{d_{ij}^2}{\\gamma_j}\\right)^{1/(m_p-1)}}
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -323,7 +331,9 @@ class IPCM(FuzzyClusteringBase):
     ) -> chex.Array:
         """Update fuzzy membership matrix (IPCM-specific).
 
-        u_ij = (1/d²_ij · t_ij^(m_p-1))^(1/(m_f-1)) / Σ_k(...)
+        .. math::
+
+            u_{ij} = \\frac{\\left(\\frac{1}{d_{ij}^2} \\cdot t_{ij}^{m_p-1}\\right)^{1/(m_f-1)}}{\\sum_k \\left(\\frac{1}{d_{ik}^2} \\cdot t_{ik}^{m_p-1}\\right)^{1/(m_f-1)}}
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -340,7 +350,7 @@ class IPCM(FuzzyClusteringBase):
         # Compute T^(m_p-1)
         T_pow = jnp.power(T, self.tipifier - 1.0)  # (n_samples, n_clusters)
 
-        # Compute base values: (1/d²_ij · t_ij^(m_p-1))
+        # Compute base values: (1/d^2_ij * t_ij^(m_p-1))
         base_values = (1.0 / D_sq) * T_pow  # (n_samples, n_clusters)
 
         # Compute power
@@ -361,7 +371,9 @@ class IPCM(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute cluster centroids.
 
-        v_j = Σ_i[u_ij^m_f · t_ij^m_p]x_i / Σ_i[u_ij^m_f · t_ij^m_p]
+        .. math::
+
+            v_j = \\frac{\\sum_i u_{ij}^{m_f} \\cdot t_{ij}^{m_p} \\cdot x_i}{\\sum_i u_{ij}^{m_f} \\cdot t_{ij}^{m_p}}
 
         Args:
             X: Input data, shape (n_samples, n_features)
@@ -395,7 +407,9 @@ class IPCM(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute IPCM objective function.
 
-        J = Σ_i Σ_j [u_ij^m_f · t_ij^m_p · d²_ij] + Σ_j[γ_j · Σ_i((1-t_ij)^m_p · u_ij^m_f)]
+        .. math::
+
+            J = \\sum_i \\sum_j u_{ij}^{m_f} \\cdot t_{ij}^{m_p} \\cdot d_{ij}^2 + \\sum_j \\gamma_j \\sum_i (1 - t_{ij})^{m_p} \\cdot u_{ij}^{m_f}
 
         Args:
             X: Input data
@@ -414,10 +428,10 @@ class IPCM(FuzzyClusteringBase):
         U_fuzz = jnp.power(U, self.fuzzifier)
         T_fuzz = jnp.power(T, self.tipifier)
 
-        # First term: Σ_i Σ_j [u_ij^m_f · t_ij^m_p · d²_ij]
+        # First term: sum_i sum_j [u_ij^m_f * t_ij^m_p * d^2_ij]
         term1 = jnp.sum(U_fuzz * T_fuzz * D_sq)
 
-        # Second term: Σ_j[γ_j · Σ_i((1-t_ij)^m_p · u_ij^m_f)]
+        # Second term: sum_j[gamma_j * sum_i((1-t_ij)^m_p * u_ij^m_f)]
         one_minus_T = 1.0 - T
         one_minus_T_fuzz = jnp.power(one_minus_T, self.tipifier)
         inner_sum = jnp.sum(one_minus_T_fuzz * U_fuzz, axis=0)  # (n_clusters,)

--- a/prosemble/models/ipcm2.py
+++ b/prosemble/models/ipcm2.py
@@ -46,8 +46,8 @@ class IPCM2(FuzzyClusteringBase):
     Improved Possibilistic C-Means 2 clustering with JAX.
 
     IPCM2 is a variant of IPCM with key differences:
-    - Uses exponential T update: t_ij = exp(-d²_ij/γ_j)
-    - Centroids use U^m_f · T (T without power!)
+    - Uses exponential T update: :math:`t_{ij} = \\exp(-d_{ij}^2 / \\gamma_j)`
+    - Centroids use :math:`U^{m_f} \\cdot T` (T without power!)
     - Modified U update with exponential distance
     - Different objective function
 
@@ -65,10 +65,11 @@ class IPCM2(FuzzyClusteringBase):
     7. Recompute gamma using both U and T
     8. Continue iterations with new gamma
 
-    Objective function::
+    Objective function:
 
-        J = Σ_i Σ_j [u_ij^m_f · t_ij · d²_ij] +
-            Σ_j[γ_j · Σ_i((t_ij·log(t_ij) - t_ij + 1) · u_ij^m_f)]
+    .. math::
+
+        J = \\sum_i \\sum_j u_{ij}^{m_f} \\cdot t_{ij} \\cdot d_{ij}^2 + \\sum_j \\gamma_j \\sum_i (t_{ij} \\log t_{ij} - t_{ij} + 1) \\cdot u_{ij}^{m_f}
 
     Parameters
     ----------
@@ -214,7 +215,9 @@ class IPCM2(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute gamma for phase 0.
 
-        γ_j = Σ_i(u_ij^m_f · d²_ij) / Σ_i(u_ij^m_f)
+        .. math::
+
+            \\gamma_j = \\frac{\\sum_i u_{ij}^{m_f} \\cdot d_{ij}^2}{\\sum_i u_{ij}^{m_f}}
         """
         D_sq = self.distance_fn(X, centroids)
         U_fuzz = jnp.power(U, self.fuzzifier)
@@ -232,7 +235,9 @@ class IPCM2(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute gamma for phase 1.
 
-        γ_j = Σ_i(u_ij^m_f · t_ij^m_p · d²_ij) / Σ_i(u_ij^m_f · t_ij^m_p)
+        .. math::
+
+            \\gamma_j = \\frac{\\sum_i u_{ij}^{m_f} \\cdot t_{ij}^{m_p} \\cdot d_{ij}^2}{\\sum_i u_{ij}^{m_f} \\cdot t_{ij}^{m_p}}
         """
         D_sq = self.distance_fn(X, centroids)
         U_fuzz = jnp.power(U, self.fuzzifier)
@@ -253,7 +258,9 @@ class IPCM2(FuzzyClusteringBase):
     ) -> chex.Array:
         """Update typicality matrix with exponential.
 
-        t_ij = exp(-d²_ij/γ_j)
+        .. math::
+
+            t_{ij} = \\exp\\left(-\\frac{d_{ij}^2}{\\gamma_j}\\right)
         """
         D_sq = self.distance_fn(X, centroids)
         D_sq = jnp.maximum(D_sq, 1e-10)
@@ -270,12 +277,14 @@ class IPCM2(FuzzyClusteringBase):
     ) -> chex.Array:
         """Update fuzzy membership matrix (IPCM2-specific).
 
-        u_ij = (1/[γ_j·(1-exp(-d²_ij/γ_j))])^(2/(m_f-1)) / Σ_k(...)
+        .. math::
+
+            u_{ij} = \\frac{\\left(\\frac{1}{\\gamma_j (1 - \\exp(-d_{ij}^2/\\gamma_j))}\\right)^{2/(m_f-1)}}{\\sum_k \\left(\\frac{1}{\\gamma_k (1 - \\exp(-d_{ik}^2/\\gamma_k))}\\right)^{2/(m_f-1)}}
         """
         D_sq = self.distance_fn(X, centroids)
         D_sq = jnp.maximum(D_sq, 1e-10)
 
-        # Compute modified distance: γ_j·(1-exp(-d²_ij/γ_j))
+        # Compute modified distance: gamma_j*(1-exp(-d^2_ij/gamma_j))
         ratio = D_sq / gamma[None, :]
         exp_term = jnp.exp(-ratio)
         modified_dist = gamma[None, :] * (1.0 - exp_term)
@@ -302,7 +311,9 @@ class IPCM2(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute cluster centroids.
 
-        v_j = Σ_i[u_ij^m_f · t_ij]x_i / Σ_i[u_ij^m_f · t_ij]
+        .. math::
+
+            v_j = \\frac{\\sum_i u_{ij}^{m_f} \\cdot t_{ij} \\cdot x_i}{\\sum_i u_{ij}^{m_f} \\cdot t_{ij}}
 
         Note: T is NOT raised to power m_p here!
         """
@@ -327,16 +338,17 @@ class IPCM2(FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute IPCM2 objective function.
 
-        J = Σ_i Σ_j [u_ij^m_f · t_ij · d²_ij] +
-            Σ_j[γ_j · Σ_i((t_ij·log(t_ij) - t_ij + 1) · u_ij^m_f)]
+        .. math::
+
+            J = \\sum_i \\sum_j u_{ij}^{m_f} \\cdot t_{ij} \\cdot d_{ij}^2 + \\sum_j \\gamma_j \\sum_i (t_{ij} \\log t_{ij} - t_{ij} + 1) \\cdot u_{ij}^{m_f}
         """
         D_sq = self.distance_fn(X, centroids)
         U_fuzz = jnp.power(U, self.fuzzifier)
 
-        # First term: Σ_i Σ_j [u_ij^m_f · t_ij · d²_ij]
+        # First term: sum_i sum_j [u_ij^m_f * t_ij * d^2_ij]
         term1 = jnp.sum(U_fuzz * T * D_sq)
 
-        # Second term: Σ_j[γ_j · Σ_i((t·log(t) - t + 1) · u^m_f)]
+        # Second term: sum_j[gamma_j * sum_i((t*log(t) - t + 1) * u^m_f)]
         # Handle log(0) by clamping T
         T_safe = jnp.maximum(T, 1e-10)
         entropy_like = T * jnp.log(T_safe) - T + 1.0

--- a/prosemble/models/kafcm.py
+++ b/prosemble/models/kafcm.py
@@ -36,7 +36,7 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
     KAFCM extends AFCM to kernel space, combining fuzzy and possibilistic
     approaches with kernel-based distance measures.
 
-    Kernel distance: d_K(x, v) = 2(1 - K(x, v))
+    Kernel distance: :math:`d_K(x, v) = 2(1 - K(x, v))`
 
     Algorithm:
 
@@ -195,7 +195,7 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
     def _update_T(
         self, X: chex.Array, centroids: chex.Array, gamma: chex.Array
     ) -> chex.Array:
-        """Update T: t_ij = exp(-b·d_K(x_i, v_j)/γ_j)"""
+        """Update T: :math:`t_{ij} = \\exp(-b \\cdot d_K(x_i, v_j) / \\gamma_j)`"""
         K = batch_gaussian_kernel(X, centroids, self.sigma)
         kernel_dist = 2.0 * (1.0 - K)
         kernel_dist = jnp.maximum(kernel_dist, 1e-10)
@@ -226,7 +226,7 @@ class KAFCM(ScanFitMixin, FuzzyClusteringBase):
     def _compute_centroids(
         self, X: chex.Array, U: chex.Array, T: chex.Array, centroids: chex.Array
     ) -> chex.Array:
-        """Compute centroids: kernel-weighted with a·U^m + b·T"""
+        """Compute centroids: kernel-weighted with :math:`a \\cdot U^m + b \\cdot T`."""
         K = batch_gaussian_kernel(X, centroids, self.sigma)
         U_fuzz = jnp.power(U, self.fuzzifier)
         weights = (self.a * U_fuzz + self.b * T) * K

--- a/prosemble/models/kfcm.py
+++ b/prosemble/models/kfcm.py
@@ -41,13 +41,17 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
     KFCM uses a Gaussian kernel to map data into a high-dimensional feature space
     where clustering is performed. This allows handling non-linearly separable data.
 
-    Kernel::
+    Kernel:
 
-        K(x, y) = exp(-||x - y||² / σ²)
+    .. math::
 
-    Kernel distance in feature space::
+        K(x, y) = \\exp\\left(-\\frac{\\|x - y\\|^2}{\\sigma^2}\\right)
 
-        ||φ(x) - φ(y)||² = 2(1 - K(x, y))
+    Kernel distance in feature space:
+
+    .. math::
+
+        \\|\\varphi(x) - \\varphi(y)\\|^2 = 2(1 - K(x, y))
 
     Algorithm:
 
@@ -56,9 +60,11 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
     3. Update U using kernel distance
     4. Repeat until convergence
 
-    Objective function::
+    Objective function:
 
-        J = 2·Σ_i Σ_j [u_ij^m · (1 - K(x_i, v_j))]
+    .. math::
+
+        J = 2 \\sum_i \\sum_j u_{ij}^m (1 - K(x_i, v_j))
 
     Parameters
     ----------
@@ -190,7 +196,9 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute kernel-weighted centroids.
 
-        v_j = Σ_i[u_ij^m · K(x_i, v_j) · x_i] / Σ_i[u_ij^m · K(x_i, v_j)]
+        .. math::
+
+            v_j = \\frac{\\sum_i u_{ij}^m \\cdot K(x_i, v_j) \\cdot x_i}{\\sum_i u_{ij}^m \\cdot K(x_i, v_j)}
         """
         # Compute kernel matrix K(X, centroids)
         K = batch_gaussian_kernel(X, centroids, self.sigma)  # (n_samples, n_clusters)
@@ -214,7 +222,9 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
     def _update_U(self, X: chex.Array, centroids: chex.Array) -> chex.Array:
         """Update fuzzy membership matrix using kernel distance.
 
-        u_ij = 1 / Σ_k[(1 - K(x_i, v_j)) / (1 - K(x_i, v_k))]^(1/(m-1))
+        .. math::
+
+            u_{ij} = \\frac{1}{\\sum_k \\left(\\frac{1 - K(x_i, v_j)}{1 - K(x_i, v_k)}\\right)^{1/(m-1)}}
         """
         # Compute kernel matrix
         K = batch_gaussian_kernel(X, centroids, self.sigma)  # (n_samples, n_clusters)
@@ -248,7 +258,9 @@ class KFCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute KFCM objective function.
 
-        J = 2·Σ_i Σ_j [u_ij^m · (1 - K(x_i, v_j))]
+        .. math::
+
+            J = 2 \\sum_i \\sum_j u_{ij}^m (1 - K(x_i, v_j))
         """
         # Compute kernel matrix
         K = batch_gaussian_kernel(X, centroids, self.sigma)

--- a/prosemble/models/kipcm2.py
+++ b/prosemble/models/kipcm2.py
@@ -143,7 +143,7 @@ class KIPCM2(FuzzyClusteringBase):
 
     @partial(jit, static_argnums=(0,))
     def _update_T(self, X: chex.Array, centroids: chex.Array, gamma: chex.Array) -> chex.Array:
-        """Exponential T update: t_ij = exp(-d_K(x_i, v_j)/γ_j)"""
+        """Exponential T update: :math:`t_{ij} = \\exp(-d_K(x_i, v_j) / \\gamma_j)`"""
         K = batch_gaussian_kernel(X, centroids, self.sigma)
         kernel_dist = 2.0 * (1.0 - K)
         kernel_dist = jnp.maximum(kernel_dist, 1e-10)
@@ -168,7 +168,7 @@ class KIPCM2(FuzzyClusteringBase):
 
     @partial(jit, static_argnums=(0,))
     def _compute_centroids(self, X: chex.Array, U: chex.Array, T: chex.Array, centroids: chex.Array) -> chex.Array:
-        """Centroids: kernel-weighted with U^m · T (T not raised to power!)"""
+        """Centroids: kernel-weighted with :math:`U^m \\cdot T` (T not raised to power!)."""
         K = batch_gaussian_kernel(X, centroids, self.sigma)
         U_fuzz = jnp.power(U, self.fuzzifier)
         weights = (U_fuzz * T) * K

--- a/prosemble/models/kpcm.py
+++ b/prosemble/models/kpcm.py
@@ -44,11 +44,15 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     KPCM extends PCM to kernel space using Gaussian kernel, allowing handling
     of non-linearly separable data while maintaining possibilistic properties.
 
-    Kernel::
+    Kernel:
 
-        K(x, y) = exp(-||x - y||² / σ²)
+    .. math::
 
-    Kernel distance::
+        K(x, y) = \\exp\\left(-\\frac{\\|x - y\\|^2}{\\sigma^2}\\right)
+
+    Kernel distance:
+
+    .. math::
 
         d_K(x, v) = 2(1 - K(x, v))
 
@@ -60,9 +64,11 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     4. Update centroids (kernel-weighted)
     5. Repeat until convergence
 
-    Objective function::
+    Objective function:
 
-        J = Σ_i Σ_j [t_ij^m · d_K(x_i, v_j)] + Σ_j[γ_j · Σ_i(1 - t_ij)^m]
+    .. math::
+
+        J = \\sum_i \\sum_j t_{ij}^m \\cdot d_K(x_i, v_j) + \\sum_j \\gamma_j \\sum_i (1 - t_{ij})^m
 
     Parameters
     ----------
@@ -209,7 +215,9 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute scale parameters.
 
-        γ_j = k·Σ_i(u_ij^m · d_K(x_i, v_j)) / Σ_i(u_ij^m)
+        .. math::
+
+            \\gamma_j = k \\cdot \\frac{\\sum_i u_{ij}^m \\cdot d_K(x_i, v_j)}{\\sum_i u_{ij}^m}
         """
         # Compute kernel matrix
         K = batch_gaussian_kernel(X, centroids, self.sigma)
@@ -234,7 +242,9 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Update typicality matrix.
 
-        t_ij = 1 / (1 + (d_K(x_i, v_j)/γ_j)^(1/(m-1)))
+        .. math::
+
+            t_{ij} = \\frac{1}{1 + \\left(\\frac{d_K(x_i, v_j)}{\\gamma_j}\\right)^{1/(m-1)}}
         """
         # Compute kernel distance
         K = batch_gaussian_kernel(X, centroids, self.sigma)
@@ -256,7 +266,9 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute kernel-weighted centroids.
 
-        v_j = Σ_i[t_ij^m · K(x_i, v_j) · x_i] / Σ_i[t_ij^m · K(x_i, v_j)]
+        .. math::
+
+            v_j = \\frac{\\sum_i t_{ij}^m \\cdot K(x_i, v_j) \\cdot x_i}{\\sum_i t_{ij}^m \\cdot K(x_i, v_j)}
         """
         # Compute kernel matrix
         K = batch_gaussian_kernel(X, centroids, self.sigma)
@@ -282,7 +294,9 @@ class KPCM(ScanFitMixin, FuzzyClusteringBase):
     ) -> chex.Array:
         """Compute KPCM objective function.
 
-        J = Σ_i Σ_j [t_ij^m · d_K(x_i, v_j)] + Σ_j[γ_j · Σ_i(1 - t_ij)^m]
+        .. math::
+
+            J = \\sum_i \\sum_j t_{ij}^m \\cdot d_K(x_i, v_j) + \\sum_j \\gamma_j \\sum_i (1 - t_{ij})^m
         """
         # Compute kernel distance
         K = batch_gaussian_kernel(X, centroids, self.sigma)

--- a/prosemble/models/npc.py
+++ b/prosemble/models/npc.py
@@ -33,7 +33,7 @@ class NPC:
     4. If accuracy >= threshold or max_iter reached, stop
     5. Otherwise, recompute prototypes and repeat
 
-    Softmin function: softmin(x_i) = exp(-x_i) / Σ_j exp(-x_j)
+    Softmin function: :math:`\\text{softmin}(x_i) = \\exp(-x_i) / \\sum_j \\exp(-x_j)`
 
     Parameters
     ----------
@@ -174,7 +174,7 @@ class NPC:
     @partial(jit, static_argnums=(0,))
     def _softmin(self, x: chex.Array) -> chex.Array:
         """
-        Softmin function: softmin(x_i) = exp(-x_i) / Σ_j exp(-x_j)
+        Softmin function: :math:`\\text{softmin}(x_i) = \\exp(-x_i) / \\sum_j \\exp(-x_j)`.
 
         Parameters
         ----------

--- a/prosemble/models/oc_glvq.py
+++ b/prosemble/models/oc_glvq.py
@@ -4,23 +4,27 @@ One-Class GLVQ (OC-GLVQ).
 Adapts GLVQ's hypothesis-testing principle for one-class classification.
 In standard GLVQ, the classifier function is:
 
-    μ = (d⁺ - d⁻) / (d⁺ + d⁻)
+.. math::
 
-where d⁺ is distance to nearest same-class prototype and d⁻ is distance
+    \\mu = \\frac{d^+ - d^-}{d^+ + d^-}
+
+where :math:`d^+` is distance to nearest same-class prototype and :math:`d^-` is distance
 to nearest different-class prototype. For one-class classification there
-is no competing class, so we replace d⁻ with a learned per-prototype
-visibility threshold θₖ:
+is no competing class, so we replace :math:`d^-` with a learned per-prototype
+visibility threshold :math:`\\theta_k`:
 
-    μₖ*(xᵢ) = sᵢ · (d(xᵢ, wₖ*) - θₖ*) / (d(xᵢ, wₖ*) + θₖ*)
+.. math::
 
-where k* is the nearest prototype and sᵢ = +1 for target, -1 for outlier.
+    \\mu_{k^*}(x_i) = s_i \\cdot \\frac{d(x_i, w_{k^*}) - \\theta_{k^*}}{d(x_i, w_{k^*}) + \\theta_{k^*}}
 
-- Target with d < θ: μ < 0 → f(μ) ≈ 0 → low cost (correct)
-- Target with d > θ: μ > 0 → f(μ) ≈ 1 → high cost (misclassified)
-- Outlier with d > θ: μ < 0 → f(μ) ≈ 0 → low cost (correct)
-- Outlier with d < θ: μ > 0 → f(μ) ≈ 1 → high cost (misclassified)
+where :math:`k^*` is the nearest prototype and :math:`s_i = +1` for target, :math:`-1` for outlier.
 
-The loss is E = mean(f(μ + margin)) where f is a sigmoid transfer.
+- Target with :math:`d < \\theta`: :math:`\\mu < 0 \\to f(\\mu) \\approx 0` -- low cost (correct)
+- Target with :math:`d > \\theta`: :math:`\\mu > 0 \\to f(\\mu) \\approx 1` -- high cost (misclassified)
+- Outlier with :math:`d > \\theta`: :math:`\\mu < 0 \\to f(\\mu) \\approx 0` -- low cost (correct)
+- Outlier with :math:`d < \\theta`: :math:`\\mu > 0 \\to f(\\mu) \\approx 1` -- high cost (misclassified)
+
+The loss is :math:`E = \\text{mean}(f(\\mu + \\text{margin}))` where :math:`f` is a sigmoid transfer.
 
 References
 ----------
@@ -42,8 +46,8 @@ from prosemble.core.activations import sigmoid_beta
 class OCGLVQ(SupervisedPrototypeModel):
     """One-Class Generalized Learning Vector Quantization.
 
-    Combines GLVQ's μ-based hypothesis testing with per-prototype
-    visibility thresholds θₖ for one-class classification.
+    Combines GLVQ's :math:`\\mu`-based hypothesis testing with per-prototype
+    visibility thresholds :math:`\\theta_k` for one-class classification.
 
     Parameters
     ----------
@@ -264,7 +268,7 @@ class OCGLVQ(SupervisedPrototypeModel):
         """Compute target-likeness scores.
 
         Scores near 1.0 indicate target class, near 0.0 indicate outlier.
-        The decision boundary is at score = 0.5 (where d = θ).
+        The decision boundary is at score = 0.5 (where :math:`d = \\theta`).
 
         Parameters
         ----------
@@ -353,7 +357,7 @@ class OCGLVQ(SupervisedPrototypeModel):
 
     @property
     def visibility_radii(self):
-        """Return the learned visibility radii θₖ for each prototype."""
+        """Return the learned visibility radii :math:`\\theta_k` for each prototype."""
         if self.thetas_ is None:
             raise ValueError("Model not fitted. Call fit() first.")
         return self.thetas_

--- a/prosemble/models/oc_glvq_ng_mixin.py
+++ b/prosemble/models/oc_glvq_ng_mixin.py
@@ -18,10 +18,15 @@ class NGCooperationMixin:
     Instead of only the nearest prototype contributing to the loss, ALL
     prototypes participate weighted by their distance rank:
 
-        h_k = exp(-rank_k / γ)
-        E = mean(Σ_k h̃_k · f(μ_k))
+    .. math::
 
-    γ decays from gamma_init → gamma_final during training.
+        h_k = \\exp(-\\text{rank}_k / \\gamma)
+
+    .. math::
+
+        E = \\text{mean}\\left(\\sum_k \\tilde{h}_k \\cdot f(\\mu_k)\\right)
+
+    :math:`\\gamma` decays from ``gamma_init`` to ``gamma_final`` during training.
 
     Subclasses must override `_compute_distances(params, X)` to return
     a (n_samples, n_prototypes) distance matrix.

--- a/prosemble/models/oc_gmlvq.py
+++ b/prosemble/models/oc_gmlvq.py
@@ -4,10 +4,12 @@ One-Class GMLVQ (OC-GMLVQ).
 Extends OC-GLVQ with a global Omega matrix (GMLVQ-style metric adaptation).
 The distance becomes:
 
-    d_Ω(x, w_k) = ||Ω(x - w_k)||²
+.. math::
 
-where Ω is a learned (d × l) projection matrix. The implicit metric
-Λ = Ω^T Ω captures feature correlations for one-class classification.
+    d_\\Omega(x, w_k) = \\|\\Omega(x - w_k)\\|^2
+
+where :math:`\\Omega` is a learned :math:`(d \\times l)` projection matrix. The implicit metric
+:math:`\\Lambda = \\Omega^T \\Omega` captures feature correlations for one-class classification.
 
 References
 ----------
@@ -29,7 +31,7 @@ from prosemble.core.activations import sigmoid_beta
 class OCGMLVQ(OCGLVQ):
     """One-Class GMLVQ with global Omega projection.
 
-    Learns a global linear projection Ω that captures feature
+    Learns a global linear projection :math:`\\Omega` that captures feature
     correlations for one-class classification.
 
     Parameters
@@ -215,14 +217,14 @@ class OCGMLVQ(OCGLVQ):
 
     @property
     def omega_matrix(self):
-        """Return the learned projection matrix Ω."""
+        """Return the learned projection matrix :math:`\\Omega`."""
         if self.omega_ is None:
             raise ValueError("Model not fitted. Call fit() first.")
         return self.omega_
 
     @property
     def lambda_matrix(self):
-        """Return the implicit metric Λ = Ω^T Ω."""
+        """Return the implicit metric :math:`\\Lambda = \\Omega^T \\Omega`."""
         return self.omega_matrix.T @ self.omega_matrix
 
     def _get_quantizable_attrs(self):

--- a/prosemble/models/oc_grlvq.py
+++ b/prosemble/models/oc_grlvq.py
@@ -4,9 +4,11 @@ One-Class GRLVQ (OC-GRLVQ).
 Extends OC-GLVQ with per-feature adaptive relevance weighting.
 The distance becomes:
 
-    d_λ(x, w_k) = Σ_j λ_j (x_j - w_{k,j})²
+.. math::
 
-where λ = softmax(relevances) are learned per-feature weights.
+    d_\\lambda(x, w_k) = \\sum_j \\lambda_j (x_j - w_{k,j})^2
+
+where :math:`\\lambda = \\text{softmax}(\\text{relevances})` are learned per-feature weights.
 
 References
 ----------

--- a/prosemble/models/oc_gtlvq.py
+++ b/prosemble/models/oc_gtlvq.py
@@ -2,11 +2,13 @@
 One-Class GTLVQ (OC-GTLVQ).
 
 Extends OC-GLVQ with per-prototype tangent subspaces (GTLVQ-style).
-Each prototype w_k learns an orthonormal basis Ω_k defining a local
+Each prototype :math:`w_k` learns an orthonormal basis :math:`\\Omega_k` defining a local
 invariance subspace. The tangent distance measures the orthogonal
 complement:
 
-    d_T(x, w_k) = ||(I - Ω_k Ω_k^T)(x - w_k)||²
+.. math::
+
+    d_T(x, w_k) = \\|(I - \\Omega_k \\Omega_k^T)(x - w_k)\\|^2
 
 References
 ----------
@@ -29,7 +31,7 @@ from prosemble.core.activations import sigmoid_beta
 class OCGTLVQ(OCGLVQ):
     """One-Class GTLVQ with per-prototype tangent subspaces.
 
-    Each prototype learns an orthonormal basis Ω_k that defines
+    Each prototype learns an orthonormal basis :math:`\\Omega_k` that defines
     directions of local invariance. Only the distance orthogonal
     to this subspace is used for classification.
 

--- a/prosemble/models/oc_lgmlvq.py
+++ b/prosemble/models/oc_lgmlvq.py
@@ -2,9 +2,11 @@
 One-Class LGMLVQ (OC-LGMLVQ).
 
 Extends OC-GLVQ with per-prototype Omega matrices (LGMLVQ-style).
-Each prototype w_k learns its own projection Ω_k:
+Each prototype :math:`w_k` learns its own projection :math:`\\Omega_k`:
 
-    d_{Ω_k}(x, w_k) = ||Ω_k(x - w_k)||²
+.. math::
+
+    d_{\\Omega_k}(x, w_k) = \\|\\Omega_k(x - w_k)\\|^2
 
 This allows each prototype to focus on different feature subspaces.
 
@@ -28,7 +30,7 @@ from prosemble.core.activations import sigmoid_beta
 class OCLGMLVQ(OCGLVQ):
     """One-Class LGMLVQ with per-prototype Omega projections.
 
-    Each prototype learns its own local metric via Ω_k, allowing
+    Each prototype learns its own local metric via :math:`\\Omega_k`, allowing
     different prototypes to attend to different feature subspaces.
 
     Parameters

--- a/prosemble/models/oc_mrslvq.py
+++ b/prosemble/models/oc_mrslvq.py
@@ -8,9 +8,17 @@ Extends OC-GLVQ with:
 Instead of using only the nearest prototype (hard argmin like OC-GMLVQ),
 all prototypes contribute to the loss via Gaussian proximity weights:
 
-    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)
-    μ_k = s · (d_k - θ_k) / (d_k + θ_k)
-    loss = mean(Σ_k p(k|x) · sigmoid(μ_k + margin, β))
+.. math::
+
+    p(k|x) = \\frac{\\exp(-d_k / 2\\sigma^2)}{\\sum_j \\exp(-d_j / 2\\sigma^2)}
+
+.. math::
+
+    \\mu_k = s \\cdot \\frac{d_k - \\theta_k}{d_k + \\theta_k}
+
+.. math::
+
+    \\text{loss} = \\text{mean}\\left(\\sum_k p(k|x) \\cdot \\text{sigmoid}(\\mu_k + \\text{margin}, \\beta)\\right)
 
 References
 ----------
@@ -274,7 +282,7 @@ class OCMRSLVQ(OCGLVQ):
 
     @property
     def lambda_matrix(self):
-        """Return the implicit metric Lambda = Omega^T Omega."""
+        """Return the implicit metric :math:`\\Lambda = \\Omega^T \\Omega`."""
         return self.omega_matrix.T @ self.omega_matrix
 
     def _get_quantizable_attrs(self):

--- a/prosemble/models/oc_mrslvq_ng.py
+++ b/prosemble/models/oc_mrslvq_ng.py
@@ -5,13 +5,24 @@ and One-Class Local Matrix RSLVQ with NG (OC-LMRSLVQ-NG).
 Combines OC-MRSLVQ/OC-LMRSLVQ's Omega metric adaptation and Gaussian
 soft-weighting with Neural Gas rank-based neighborhood cooperation:
 
-    p(k|x) = exp(-d_Ω_k / 2σ²) / Σ_j exp(-d_Ω_j / 2σ²)
-    h_k = exp(-rank_k / γ)
-    w_k = p(k|x) · h_k / Σ_j p(j|x) · h_j
-    loss = mean(Σ_k w_k · sigmoid(μ_k + margin, β))
+.. math::
+
+    p(k|x) = \\frac{\\exp(-d_{\\Omega_k} / 2\\sigma^2)}{\\sum_j \\exp(-d_{\\Omega_j} / 2\\sigma^2)}
+
+.. math::
+
+    h_k = \\exp(-\\text{rank}_k / \\gamma)
+
+.. math::
+
+    w_k = \\frac{p(k|x) \\cdot h_k}{\\sum_j p(j|x) \\cdot h_j}
+
+.. math::
+
+    \\text{loss} = \\text{mean}\\left(\\sum_k w_k \\cdot \\text{sigmoid}(\\mu_k + \\text{margin}, \\beta)\\right)
 
 OC-MRSLVQ-NG: global Omega projection matrix (same for all prototypes).
-OC-LMRSLVQ-NG: per-prototype Omega_k matrices (local metric adaptation).
+OC-LMRSLVQ-NG: per-prototype :math:`\\Omega_k` matrices (local metric adaptation).
 
 References
 ----------

--- a/prosemble/models/oc_rslvq.py
+++ b/prosemble/models/oc_rslvq.py
@@ -4,9 +4,17 @@ One-Class Robust Soft LVQ (OC-RSLVQ).
 Extends OC-GLVQ by replacing hard nearest-prototype assignment with
 probabilistic soft-weighting via Gaussian mixture responsibilities:
 
-    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)
-    μ_k = s · (d_k - θ_k) / (d_k + θ_k)
-    loss = mean(Σ_k p(k|x) · sigmoid(μ_k + margin, β))
+.. math::
+
+    p(k|x) = \\frac{\\exp(-d_k / 2\\sigma^2)}{\\sum_j \\exp(-d_j / 2\\sigma^2)}
+
+.. math::
+
+    \\mu_k = s \\cdot \\frac{d_k - \\theta_k}{d_k + \\theta_k}
+
+.. math::
+
+    \\text{loss} = \\text{mean}\\left(\\sum_k p(k|x) \\cdot \\text{sigmoid}(\\mu_k + \\text{margin}, \\beta)\\right)
 
 Unlike OC-GLVQ which uses only the nearest prototype for each sample,
 OC-RSLVQ distributes evidence across all prototypes weighted by Gaussian

--- a/prosemble/models/oc_rslvq_ng.py
+++ b/prosemble/models/oc_rslvq_ng.py
@@ -5,10 +5,21 @@ Combines OC-RSLVQ's probabilistic soft-weighting with Neural Gas
 rank-based neighborhood cooperation. Gaussian mixture responsibilities
 are modulated by NG neighborhood weights:
 
-    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)
-    h_k = exp(-rank_k / γ)
-    w_k = p(k|x) · h_k / Σ_j p(j|x) · h_j
-    loss = mean(Σ_k w_k · sigmoid(μ_k + margin, β))
+.. math::
+
+    p(k|x) = \\frac{\\exp(-d_k / 2\\sigma^2)}{\\sum_j \\exp(-d_j / 2\\sigma^2)}
+
+.. math::
+
+    h_k = \\exp(-\\text{rank}_k / \\gamma)
+
+.. math::
+
+    w_k = \\frac{p(k|x) \\cdot h_k}{\\sum_j p(j|x) \\cdot h_j}
+
+.. math::
+
+    \\text{loss} = \\text{mean}\\left(\\sum_k w_k \\cdot \\text{sigmoid}(\\mu_k + \\text{margin}, \\beta)\\right)
 
 Uses standard Euclidean distance (no metric adaptation).
 

--- a/prosemble/models/oc_rslvq_ng_mixin.py
+++ b/prosemble/models/oc_rslvq_ng_mixin.py
@@ -6,15 +6,23 @@ neighborhood cooperation. Unlike the OC-GLVQ-NG mixin (which replaces
 hard nearest-prototype with NG ranking), this mixin modulates the
 existing Gaussian responsibilities with NG neighborhood weights:
 
-    p(k|x) = exp(-d_k / 2σ²) / Σ_j exp(-d_j / 2σ²)   [Gaussian]
-    h_k = exp(-rank_k / γ)                              [NG neighborhood]
-    w_k = p(k|x) · h_k / Σ_j p(j|x) · h_j             [combined]
+.. math::
 
-When γ → ∞, h_k ≈ const for all k → recovers OC-RSLVQ (pure Gaussian).
-When γ → 0, only the nearest prototype has h_k > 0 → sharpened assignment.
+    p(k|x) = \\frac{\\exp(-d_k / 2\\sigma^2)}{\\sum_j \\exp(-d_j / 2\\sigma^2)} \\quad [\\text{Gaussian}]
 
-Subclasses override `_compute_distances(params, X)` to define the
-metric-specific distance (Euclidean, global Ω, local Ω_k).
+.. math::
+
+    h_k = \\exp(-\\text{rank}_k / \\gamma) \\quad [\\text{NG neighborhood}]
+
+.. math::
+
+    w_k = \\frac{p(k|x) \\cdot h_k}{\\sum_j p(j|x) \\cdot h_j} \\quad [\\text{combined}]
+
+When :math:`\\gamma \\to \\infty`, :math:`h_k \\approx \\text{const}` for all :math:`k` -- recovers OC-RSLVQ (pure Gaussian).
+When :math:`\\gamma \\to 0`, only the nearest prototype has :math:`h_k > 0` -- sharpened assignment.
+
+Subclasses override ``_compute_distances(params, X)`` to define the
+metric-specific distance (Euclidean, global :math:`\\Omega`, local :math:`\\Omega_k`).
 """
 
 import jax.numpy as jnp

--- a/prosemble/models/pcm.py
+++ b/prosemble/models/pcm.py
@@ -10,19 +10,29 @@ less sensitive to outliers and noise compared to FCM.
 
 Mathematical formulation:
 
-Objective function::
+Objective function:
 
-    J = Σ_i Σ_j t_ij^m ||x_i - v_j||² + Σ_j γ_j Σ_i (1 - t_ij)^m
+.. math::
 
-where ``t_ij`` is the typicality of point ``x_i`` to cluster j,
-``v_j`` is the centroid of cluster j, m is the fuzzifier (m > 1),
-and ``γ_j`` is a scale parameter for cluster j.
+    J = \\sum_i \\sum_j t_{ij}^m \\|x_i - v_j\\|^2 + \\sum_j \\gamma_j \\sum_i (1 - t_{ij})^m
 
-Update equations::
+where :math:`t_{ij}` is the typicality of point :math:`x_i` to cluster j,
+:math:`v_j` is the centroid of cluster j, :math:`m` is the fuzzifier (m > 1),
+and :math:`\\gamma_j` is a scale parameter for cluster j.
 
-    Centroids:  v_j = (Σ_i t_ij^m x_i) / (Σ_i t_ij^m)
-    Gamma:      γ_j = k · (Σ_i t_ij^m ||x_i - v_j||²) / (Σ_i t_ij^m)
-    Typicality: t_ij = 1 / (1 + (||x_i - v_j||² / γ_j)^(1/(m-1)))
+Update equations:
+
+.. math::
+
+    v_j = \\frac{\\sum_i t_{ij}^m x_i}{\\sum_i t_{ij}^m}
+
+.. math::
+
+    \\gamma_j = k \\cdot \\frac{\\sum_i t_{ij}^m \\|x_i - v_j\\|^2}{\\sum_i t_{ij}^m}
+
+.. math::
+
+    t_{ij} = \\frac{1}{1 + \\left(\\frac{\\|x_i - v_j\\|^2}{\\gamma_j}\\right)^{1/(m-1)}}
 
 References:
     Krishnapuram, R., & Keller, J. M. (1993).
@@ -273,7 +283,10 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         Compute cluster centroids from typicality matrix.
 
         Vectorized computation:
-            v_j = (Σᵢ tᵢⱼᵐ xᵢ) / (Σᵢ tᵢⱼᵐ)
+
+        .. math::
+
+            v_j = \\frac{\\sum_i t_{ij}^m x_i}{\\sum_i t_{ij}^m}
 
         Using matrix operations:
             V = (T^m)^T @ X / sum(T^m, axis=0)
@@ -305,7 +318,10 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         Compute gamma parameters for each cluster.
 
         Vectorized computation:
-            γⱼ = k · (Σᵢ tᵢⱼᵐ ||xᵢ - vⱼ||²) / (Σᵢ tᵢⱼᵐ)
+
+        .. math::
+
+            \\gamma_j = k \\cdot \\frac{\\sum_i t_{ij}^m \\|x_i - v_j\\|^2}{\\sum_i t_{ij}^m}
 
         Args:
             X: Data matrix of shape (n, d)
@@ -322,10 +338,10 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         T_fuzz = jnp.power(T, self.fuzzifier)
 
         # Weighted distances: element-wise multiply and sum over samples
-        # numerator = Σᵢ tᵢⱼᵐ ||xᵢ - vⱼ||²
+        # numerator = sum_i t_ij^m ||x_i - v_j||^2
         numerator = jnp.sum(T_fuzz * D_sq, axis=0)  # (c,)
 
-        # denominator = Σᵢ tᵢⱼᵐ
+        # denominator = sum_i t_ij^m
         denominator = jnp.sum(T_fuzz, axis=0)  # (c,)
 
         # Compute gamma with numerical stability
@@ -344,7 +360,10 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         Update typicality matrix.
 
         Vectorized computation:
-            tᵢⱼ = 1 / (1 + (||xᵢ - vⱼ||² / γⱼ)^(1/(m-1)))
+
+        .. math::
+
+            t_{ij} = \\frac{1}{1 + \\left(\\frac{\\|x_i - v_j\\|^2}{\\gamma_j}\\right)^{1/(m-1)}}
 
         Args:
             X: Data matrix of shape (n, d)
@@ -360,7 +379,7 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         # Compute exponent
         exponent = 1.0 / (self.fuzzifier - 1.0)
 
-        # Compute denominator: (D²ᵢⱼ / γⱼ)^(1/(m-1))
+        # Compute denominator: (D^2_ij / gamma_j)^(1/(m-1))
         # Add small epsilon to gamma to avoid division by zero
         ratio = D_sq / jnp.maximum(gamma[jnp.newaxis, :], 1e-10)  # (n, c)
         denominator = jnp.power(ratio, exponent)  # (n, c)
@@ -384,7 +403,9 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         """
         Compute PCM objective function.
 
-        J = Σᵢ Σⱼ tᵢⱼᵐ ||xᵢ - vⱼ||² + Σⱼ γⱼ Σᵢ (1 - tᵢⱼ)ᵐ
+        .. math::
+
+            J = \\sum_i \\sum_j t_{ij}^m \\|x_i - v_j\\|^2 + \\sum_j \\gamma_j \\sum_i (1 - t_{ij})^m
 
         Args:
             X: Data matrix of shape (n, d)
@@ -395,12 +416,12 @@ class PCM(ScanFitMixin, FuzzyClusteringBase):
         Returns:
             objective: Scalar objective value
         """
-        # First term: Σᵢ Σⱼ tᵢⱼᵐ ||xᵢ - vⱼ||²
+        # First term: sum_i sum_j t_ij^m ||x_i - v_j||^2
         D_sq = self.distance_fn(X, centroids)  # (n, c)
         T_fuzz = jnp.power(T, self.fuzzifier)  # (n, c)
         term1 = jnp.sum(T_fuzz * D_sq)
 
-        # Second term: Σⱼ γⱼ Σᵢ (1 - tᵢⱼ)ᵐ
+        # Second term: sum_j gamma_j sum_i (1 - t_ij)^m
         one_minus_T = 1.0 - T  # (n, c)
         one_minus_T_fuzz = jnp.power(one_minus_T, self.fuzzifier)  # (n, c)
         sum_per_cluster = jnp.sum(one_minus_T_fuzz, axis=0)  # (c,)

--- a/prosemble/models/pfcm.py
+++ b/prosemble/models/pfcm.py
@@ -9,19 +9,34 @@ Mathematical Background:
 PFCM uses both membership and typicality with weighting parameters a and b.
 
 Objective Function:
-    J = Σᵢ Σⱼ [a·uᵢⱼᵐ + b·tᵢⱼⁿ] ||xᵢ - vⱼ||²
+
+.. math::
+
+    J = \\sum_i \\sum_j \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}^\\eta\\right] \\|x_i - v_j\\|^2
 
 Centroid Update:
-    vⱼ = Σᵢ[a·uᵢⱼᵐ + b·tᵢⱼⁿ]xᵢ / Σᵢ[a·uᵢⱼᵐ + b·tᵢⱼⁿ]
+
+.. math::
+
+    v_j = \\frac{\\sum_i \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}^\\eta\\right] x_i}{\\sum_i \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}^\\eta\\right]}
 
 Membership Update (like FCM):
-    uᵢⱼ = 1 / Σₖ(dᵢⱼ/dᵢₖ)^(2/(m-1))
+
+.. math::
+
+    u_{ij} = \\frac{1}{\\sum_k \\left(\\frac{d_{ij}}{d_{ik}}\\right)^{2/(m-1)}}
 
 Typicality Update (like PCM):
-    tᵢⱼ = 1 / (1 + (b·||xᵢ-vⱼ||²/γⱼ)^(1/(η-1)))
+
+.. math::
+
+    t_{ij} = \\frac{1}{1 + \\left(\\frac{b \\cdot \\|x_i - v_j\\|^2}{\\gamma_j}\\right)^{1/(\\eta-1)}}
 
 Gamma:
-    γⱼ = k·Σᵢ(uᵢⱼᵐ·||xᵢ-vⱼ||²) / Σᵢuᵢⱼᵐ
+
+.. math::
+
+    \\gamma_j = k \\cdot \\frac{\\sum_i u_{ij}^m \\cdot \\|x_i - v_j\\|^2}{\\sum_i u_{ij}^m}
 
 Author: Prosemble Contributors
 License: MIT
@@ -202,7 +217,9 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
         """
         Compute centroids using weighted combination of U and T.
 
-        vⱼ = Σᵢ[a·uᵢⱼᵐ + b·tᵢⱼⁿ]xᵢ / Σᵢ[a·uᵢⱼᵐ + b·tᵢⱼⁿ]
+        .. math::
+
+            v_j = \\frac{\\sum_i \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}^\\eta\\right] x_i}{\\sum_i \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}^\\eta\\right]}
         """
         U_fuzz = jnp.power(U, self.fuzzifier)  # (n, c)
         T_fuzz = jnp.power(T, self.eta)  # (n, c)
@@ -222,7 +239,9 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
         """
         Update fuzzy membership matrix (same as FCM).
 
-        uᵢⱼ = 1 / Σₖ(dᵢⱼ/dᵢₖ)^(2/(m-1))
+        .. math::
+
+            u_{ij} = \\frac{1}{\\sum_k \\left(\\frac{d_{ij}}{d_{ik}}\\right)^{2/(m-1)}}
         """
         D = self.distance_fn(X, centroids)
         D = jnp.maximum(D, 1e-10)
@@ -240,7 +259,9 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
         """
         Compute gamma parameters using fuzzy membership.
 
-        γⱼ = k·Σᵢ(uᵢⱼᵐ·||xᵢ-vⱼ||²) / Σᵢuᵢⱼᵐ
+        .. math::
+
+            \\gamma_j = k \\cdot \\frac{\\sum_i u_{ij}^m \\cdot \\|x_i - v_j\\|^2}{\\sum_i u_{ij}^m}
         """
         D_sq = self.distance_fn(X, centroids)  # (n, c)
         U_fuzz = jnp.power(U, self.fuzzifier)  # (n, c)
@@ -259,7 +280,9 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
         """
         Update typicality matrix.
 
-        tᵢⱼ = 1 / (1 + (b·||xᵢ-vⱼ||²/γⱼ)^(1/(η-1)))
+        .. math::
+
+            t_{ij} = \\frac{1}{1 + \\left(\\frac{b \\cdot \\|x_i - v_j\\|^2}{\\gamma_j}\\right)^{1/(\\eta-1)}}
         """
         D_sq = self.distance_fn(X, centroids)  # (n, c)
 
@@ -282,7 +305,9 @@ class PFCM(ScanFitMixin, FuzzyClusteringBase):
         """
         Compute PFCM objective function.
 
-        J = Σᵢ Σⱼ [a·uᵢⱼᵐ + b·tᵢⱼⁿ] ||xᵢ - vⱼ||²
+        .. math::
+
+            J = \\sum_i \\sum_j \\left[a \\cdot u_{ij}^m + b \\cdot t_{ij}^\\eta\\right] \\|x_i - v_j\\|^2
         """
         D_sq = self.distance_fn(X, centroids)
         U_fuzz = jnp.power(U, self.fuzzifier)

--- a/prosemble/models/plvq.py
+++ b/prosemble/models/plvq.py
@@ -49,9 +49,17 @@ class PLVQ(SupervisedPrototypeModel):
     soft assignment via Gaussian mixtures. The loss is the negative
     log-likelihood of the correct class:
 
-        p(k|x) = exp(-d(f(x), w_k)² / 2σ²) / Z
-        P(class|x) = Σ_{k∈class} p(k|x)
-        loss = -log(P(correct|x) / P(all|x))
+    .. math::
+
+        p(k|x) = \\frac{\\exp(-d(f(x), w_k)^2 / 2\\sigma^2)}{Z}
+
+    .. math::
+
+        P(\\text{class}|x) = \\sum_{k \\in \\text{class}} p(k|x)
+
+    .. math::
+
+        \\text{loss} = -\\log\\frac{P(\\text{correct}|x)}{P(\\text{all}|x)}
 
     Parameters
     ----------

--- a/prosemble/models/probabilistic_lvq.py
+++ b/prosemble/models/probabilistic_lvq.py
@@ -24,12 +24,17 @@ from prosemble.core.losses import nllr_loss, rslvq_loss
 class SLVQ(SupervisedPrototypeModel):
     """Soft Learning Vector Quantization.
 
-    Uses Gaussian mixture probabilities::
+    Uses Gaussian mixture probabilities:
 
-        p(k|x) = exp(-d²/2σ²) / Σ exp(-d²/2σ²)
-        P(class|x) = Σ_{k∈class} p(k|x)
+    .. math::
 
-    Loss: ``-log(P(correct) / P(wrong))``
+        p(k|x) = \\frac{\\exp(-d^2 / 2\\sigma^2)}{\\sum_j \\exp(-d_j^2 / 2\\sigma^2)}
+
+    .. math::
+
+        P(\\text{class}|x) = \\sum_{k \\in \\text{class}} p(k|x)
+
+    Loss: :math:`-\\log(P(\\text{correct}) / P(\\text{wrong}))`
 
     Parameters
     ----------

--- a/prosemble/models/riemannian_neural_gas.py
+++ b/prosemble/models/riemannian_neural_gas.py
@@ -5,17 +5,20 @@ Generalizes the Neural Gas algorithm to Riemannian manifolds by
 replacing Euclidean distance with geodesic distance and using
 exponential/logarithmic maps for prototype updates:
 
-    w_i^new ← Exp_{w_i}(ε · h_λ(k_i(x, W)) · Log_{w_i}(x))
+.. math::
 
-where Exp and Log are the Riemannian exponential and logarithmic maps,
-and h_λ(k) = exp(-k/λ) is the rank-based neighborhood function.
+    w_i^{\\text{new}} \\leftarrow \\text{Exp}_{w_i}\\bigl(\\varepsilon \\cdot h_\\lambda(k_i(x, W)) \\cdot \\text{Log}_{w_i}(x)\\bigr)
+
+where :math:`\\text{Exp}` and :math:`\\text{Log}` are the Riemannian exponential and
+logarithmic maps, and :math:`h_\\lambda(k) = \\exp(-k/\\lambda)` is the rank-based
+neighborhood function.
 
 The algorithm learns prototypes that lie on the manifold, respecting
 its intrinsic geometry and curvature.
 
 References
 ----------
-.. [1] Schwarz, L., Psenickova, M., Villmann, T., & Röhrbein, F. (2026).
+.. [1] Schwarz, L., Psenickova, M., Villmann, T., & Rohrbein, F. (2026).
        Topology-Preserving Prototype Learning on Riemannian Manifolds.
        ESANN 2026.
 .. [2] Martinetz, T., Berkovich, S., & Schulten, K. (1993).

--- a/prosemble/models/svq_occ.py
+++ b/prosemble/models/svq_occ.py
@@ -3,27 +3,38 @@ Supervised Vector Quantization One-Class Classification (SVQ-OCC).
 
 Combines Neural Gas representation learning with one-class classification
 using per-prototype visibility parameters. Each prototype is equipped with
-a local visibility range θ_k — data within θ_k of prototype w_k is
-classified as target.
+a local visibility range :math:`\\theta_k` -- data within :math:`\\theta_k`
+of prototype :math:`w_k` is classified as target.
 
 The overall cost function is:
 
-    E(X, W) = α · R(X⁺, W) + (1 − α) · C(X, W, Θ)
+.. math::
 
-where R is the Neural Gas representation cost over target data X⁺, and
-C is a classification cost using per-prototype responsibilities:
+    E(X, W) = \\alpha \\cdot R(X^+, W) + (1 - \\alpha) \\cdot C(X, W, \\Theta)
 
-    r(x, w_k, γ_k, θ_k) = p(w_k, γ_k | x) · sgd_σ(d(x, w_k), θ_k)
+where :math:`R` is the Neural Gas representation cost over target data
+:math:`X^+`, and :math:`C` is a classification cost using per-prototype
+responsibilities:
+
+.. math::
+
+    r(x, w_k, \\gamma_k, \\theta_k) = p(w_k, \\gamma_k \\mid x) \\cdot
+    \\mathrm{sgd}_{\\sigma}(d(x, w_k), \\theta_k)
 
 Three classification costs are available:
-- Contrastive Score (CS): 1 − (TP·TN − FP·FN) / ((TP+FP)(TN+FN))
-- Brier Score (BS): mean (y − Σ_k r)²
-- Cross Entropy (CE): −mean [y·log(Σr) + (1−y)·log(1−Σr)]
 
-Three response probability models p(w_k|x) are supported:
-- Gaussian: softmax(−γ·d(x, w_k))
-- Student-t: (1 + d/ν)^(−(ν+1)/2), normalized
-- Uniform: 1/K
+- Contrastive Score (CS):
+  :math:`1 - (TP \\cdot TN - FP \\cdot FN) / ((TP + FP)(TN + FN))`
+- Brier Score (BS):
+  :math:`\\mathrm{mean}\\,(y - \\sum_k r)^2`
+- Cross Entropy (CE):
+  :math:`-\\mathrm{mean}\\,[y \\cdot \\log(\\sum r) + (1 - y) \\cdot \\log(1 - \\sum r)]`
+
+Three response probability models :math:`p(w_k \\mid x)` are supported:
+
+- Gaussian: :math:`\\mathrm{softmax}(-\\gamma \\cdot d(x, w_k))`
+- Student-t: :math:`(1 + d / \\nu)^{-(\\nu + 1)/2}`, normalized
+- Uniform: :math:`1 / K`
 
 References
 ----------
@@ -44,7 +55,7 @@ class SVQOCC(SupervisedPrototypeModel):
     """Supervised Vector Quantization One-Class Classification.
 
     Combines Neural Gas representation learning with per-prototype
-    visibility parameters θ_k for one-class classification.
+    visibility parameters :math:`\\theta_k` for one-class classification.
 
     Parameters
     ----------
@@ -510,7 +521,7 @@ class SVQOCC(SupervisedPrototypeModel):
 
     @property
     def visibility_radii(self):
-        """Return the learned visibility radii θ_k for each prototype."""
+        """Return the learned visibility radii :math:`\\theta_k` for each prototype."""
         if self.thetas_ is None:
             raise ValueError("Model not fitted. Call fit() first.")
         return self.thetas_

--- a/prosemble/models/svq_occ_lm.py
+++ b/prosemble/models/svq_occ_lm.py
@@ -2,9 +2,11 @@
 Local Matrix SVQ-OCC (SVQ-OCC-LM).
 
 Extends SVQ-OCC with per-prototype Omega matrices (LGMLVQ-style).
-Each prototype w_k learns its own projection Ω_k:
+Each prototype :math:`w_k` learns its own projection :math:`\\Omega_k`:
 
-    d_{Ω_k}(x, w_k) = ||Ω_k(x - w_k)||²
+.. math::
+
+    d_{\\Omega_k}(x, w_k) = \\|\\Omega_k(x - w_k)\\|^2
 
 This allows each prototype to focus on different feature subspaces,
 enabling more flexible decision boundaries for one-class classification.
@@ -28,7 +30,7 @@ from prosemble.core.initializers import identity_omega_init
 class SVQOCC_LM(SVQOCC):
     """Local Matrix SVQ-OCC with per-prototype Omega projections.
 
-    Each prototype learns its own local metric via Ω_k, allowing
+    Each prototype learns its own local metric via :math:`\\Omega_k`, allowing
     different prototypes to attend to different feature subspaces.
 
     Parameters

--- a/prosemble/models/svq_occ_m.py
+++ b/prosemble/models/svq_occ_m.py
@@ -4,10 +4,13 @@ Matrix SVQ-OCC (SVQ-OCC-M).
 Extends SVQ-OCC with a global Omega matrix (GMLVQ-style metric adaptation).
 The distance becomes:
 
-    d_Ω(x, w_k) = ||Ω(x - w_k)||²
+.. math::
 
-where Ω is a learned (d × l) projection matrix. The implicit metric
-Λ = Ω^T Ω captures feature correlations for one-class classification.
+    d_{\\Omega}(x, w_k) = \\|\\Omega(x - w_k)\\|^2
+
+where :math:`\\Omega` is a learned :math:`(d \\times l)` projection matrix.
+The implicit metric :math:`\\Lambda = \\Omega^T \\Omega` captures feature
+correlations for one-class classification.
 
 References
 ----------
@@ -28,7 +31,7 @@ from prosemble.core.initializers import identity_omega_init
 class SVQOCC_M(SVQOCC):
     """Matrix SVQ-OCC with global Omega projection.
 
-    Learns a global linear projection Ω that captures feature
+    Learns a global linear projection :math:`\\Omega` that captures feature
     correlations for one-class classification.
 
     Parameters
@@ -305,14 +308,14 @@ class SVQOCC_M(SVQOCC):
 
     @property
     def omega_matrix(self):
-        """Return the learned projection matrix Ω."""
+        """Return the learned projection matrix :math:`\\Omega`."""
         if self.omega_ is None:
             raise ValueError("Model not fitted. Call fit() first.")
         return self.omega_
 
     @property
     def lambda_matrix(self):
-        """Return the implicit metric Λ = Ω^T Ω."""
+        """Return the implicit metric :math:`\\Lambda = \\Omega^T \\Omega`."""
         return self.omega_matrix.T @ self.omega_matrix
 
     def _get_quantizable_attrs(self):

--- a/prosemble/models/svq_occ_r.py
+++ b/prosemble/models/svq_occ_r.py
@@ -4,11 +4,13 @@ Relevance-Weighted SVQ-OCC (SVQ-OCC-R).
 Extends SVQ-OCC with per-feature adaptive relevance weighting,
 following the GRLVQ pattern. The distance becomes:
 
-    d_λ(x, w_k) = Σ_j λ_j (x_j - w_{k,j})²
+.. math::
 
-where λ = softmax(relevances) are learned per-feature weights.
-This enables the model to identify which features are most
-discriminative for one-class classification.
+    d_{\\lambda}(x, w_k) = \\sum_j \\lambda_j (x_j - w_{k,j})^2
+
+where :math:`\\lambda = \\mathrm{softmax}(\\text{relevances})` are learned
+per-feature weights. This enables the model to identify which features
+are most discriminative for one-class classification.
 
 References
 ----------

--- a/prosemble/models/svq_occ_t.py
+++ b/prosemble/models/svq_occ_t.py
@@ -2,13 +2,15 @@
 Tangent SVQ-OCC (SVQ-OCC-T).
 
 Extends SVQ-OCC with per-prototype tangent subspaces (GTLVQ-style).
-Each prototype w_k learns an orthonormal basis Ω_k defining a local
-invariance subspace. The tangent distance measures the orthogonal
-complement:
+Each prototype :math:`w_k` learns an orthonormal basis :math:`\\Omega_k`
+defining a local invariance subspace. The tangent distance measures the
+orthogonal complement:
 
-    d_T(x, w_k) = ||(I - Ω_k Ω_k^T)(x - w_k)||²
+.. math::
 
-This captures local invariances — distances within the tangent subspace
+    d_T(x, w_k) = \\|(I - \\Omega_k \\Omega_k^T)(x - w_k)\\|^2
+
+This captures local invariances -- distances within the tangent subspace
 are ignored, only the perpendicular component matters.
 
 References
@@ -31,7 +33,7 @@ from prosemble.core.utils import orthogonalize
 class SVQOCC_T(SVQOCC):
     """Tangent SVQ-OCC with per-prototype tangent subspaces.
 
-    Each prototype learns an orthonormal basis Ω_k that defines
+    Each prototype learns an orthonormal basis :math:`\\Omega_k` that defines
     directions of local invariance. Only the distance orthogonal
     to this subspace is used for classification.
 


### PR DESCRIPTION
## Summary

- Converts raw Unicode math symbols (Σ, μ, θ, subscripts, superscripts) to proper RST `:math:` inline and `.. math::` block directives across 34 model files
- Equations now render beautifully via MathJax in Sphinx HTML docs instead of showing as rough Unicode characters
- Covers fuzzy clustering, one-class, SVQ-OCC, probabilistic LVQ, Riemannian NG, BGPC, NPC, and Heskes SOM

## Test plan

- [x] All 1,144 tests pass
- [x] Sphinx build clean (zero new warnings)
- [x] 33 MathJax math elements rendering in HTML, zero remaining Unicode math symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)