### PR TITLE
feat: Add supervised Riemannian NG, ONNX export, core utilities, and …

### DIFF
--- a/ONNX_COVERAGE.md
+++ b/ONNX_COVERAGE.md
@@ -1,0 +1,148 @@
+# ONNX Export Coverage
+
+Status of ONNX export support across all 71 prosemble models.
+
+## Currently Supported (~68 models)
+
+### Supervised LVQ — squared euclidean (9)
+
+GLVQ, GLVQ1, GLVQ21, LVQ1, LVQ21, MedianLVQ, CELVQ, SLVQ, RSLVQ
+
+### Supervised LVQ — global omega (2)
+
+GMLVQ, MRSLVQ
+
+### Supervised LVQ — local omega (2)
+
+LGMLVQ, LMRSLVQ
+
+### Supervised LVQ — tangent (1)
+
+GTLVQ
+
+### Supervised NG — squared euclidean (3)
+
+SRNG, CELVQ_NG, RSLVQ_NG
+
+### Supervised NG — global omega (3)
+
+SMNG, MCELVQ_NG, MRSLVQ_NG
+
+### Supervised NG — local omega (3)
+
+SLNG, LCELVQ_NG, LMRSLVQ_NG
+
+### Supervised NG — tangent (2)
+
+STNG, TCELVQ_NG
+
+### Unsupervised — squared euclidean (3)
+
+NeuralGas, KohonenSOM, HeskesSOM
+
+### Fuzzy clustering — squared euclidean (8)
+
+FCM, PCM, FPCM, PFCM, AFCM, HCM, IPCM, IPCM2
+
+For FCM and variants with fuzzifier m > 1, membership u_ij is monotonically decreasing in distance d_ij, so `argmax(membership) = argmin(distance)`. The ONNX graph uses `argmin(distance)` which produces identical predictions.
+
+### One-class — hard nearest decision (10)
+
+OCGLVQ, OCGLVQ_NG, OCGRLVQ, OCGRLVQ_NG, OCGMLVQ, OCGMLVQ_NG, OCLGMLVQ, OCLGMLVQ_NG, OCGTLVQ, OCGTLVQ_NG
+
+Decision: `argmin(d) → gather(d, theta) → mu = (d-theta)/(d+theta) → 1 - sigmoid(beta*mu) → threshold 0.5`. Distance varies per model (squared euclidean, relevance-weighted, global omega, local omega, tangent).
+
+### One-class — Gaussian soft decision (3)
+
+OCRSLVQ, OCMRSLVQ, OCLMRSLVQ
+
+Decision: softmax Gaussian weights over all prototypes, weighted mu aggregation, sigmoid threshold.
+
+### One-class — Gaussian+NG soft decision (3)
+
+OCRSLVQ_NG, OCMRSLVQ_NG, OCLMRSLVQ_NG
+
+Decision: combined Gaussian × NG rank weights (using converged gamma), weighted mu aggregation. NG ranks computed via TopK + ScatterElements.
+
+### SVQ-OCC — response model (5)
+
+SVQOCC, SVQOCC_R, SVQOCC_M, SVQOCC_LM, SVQOCC_T
+
+Decision: response probability (Gaussian softmax, Student-t, or uniform) × differentiable Heaviside sigmoid → summed responsibility → threshold 0.5.
+
+### Encoder — MLP backbone + WTAC (4)
+
+SiameseGLVQ, SiameseGMLVQ, SiameseGTLVQ, LVQMLN
+
+Input encoded through MLP layers (MatMul → Add → Activation per layer). Prototypes pre-computed in latent space at export time (Siamese: re-encoded; LVQMLN: already latent). Distance varies per model (squared euclidean, global omega, tangent).
+
+### Encoder — CNN backbone + WTAC (3)
+
+ImageGLVQ, ImageGMLVQ, ImageGTLVQ
+
+Input reshaped to NHWC, transposed to NCHW, then Conv layers (SAME padding) → GlobalAveragePool → Linear head. Prototypes pre-computed in latent space at export time. Distance varies per model (squared euclidean, global omega, tangent).
+
+### Encoder — PLVQ Gaussian mixture (1)
+
+PLVQ
+
+MLP encoder → squared Euclidean distance → Softmax soft assignment → class aggregation via MatMul with binary class mask → ArgMax.
+
+### CBC — reasoning matrices (2)
+
+CBC, ImageCBC
+
+Squared Euclidean distance → Gaussian similarity `exp(-d²/(2σ²))` → CBCC reasoning: `probs = (detections @ (pk - nk) + sum(nk)) / (sum(pk + nk) + eps)` → ArgMax. ImageCBC adds a CNN encoder before distance computation, with components pre-computed in latent space.
+
+### Needs verification (1)
+
+GRLVQ — uses per-feature relevance weights; needs verification on whether predict is handled correctly by the current export.
+
+---
+
+## Not Supported (~3 unique blockers, ~21 models)
+
+### Kernel fuzzy clustering (7) — kernel distance not exportable
+
+KFCM, KPCM, KFPCM, KPFCM, KAFCM, KIPCM, KIPCM2
+
+**Blocker:** Predict uses Gaussian kernel distance (1 - K) computed via `batch_gaussian_kernel()`. Kernel evaluation requires the `sigma` parameter and a different distance computation that has no standard ONNX equivalent.
+
+### Riemannian models (5) — manifold operations
+
+RiemannianSRNG, RiemannianSMNG, RiemannianSLNG, RiemannianSTNG, RiemannianNeuralGas
+
+**Blocker:** Predict uses matrix logarithm/exponential (`logm`, `expm`) which have no ONNX operator equivalent.
+
+### Other (3)
+
+- **GrowingNeuralGas** — dynamic topology (variable number of prototypes)
+- **KNN** — k-nearest-neighbor logic, not prototype-based
+- **NPC** — nearest prototype classifier with different predict pattern
+
+### Utility models not applicable (3)
+
+KMeansPlusPlus, Kmeans, BGPC — don't inherit from prototype model base classes.
+
+---
+
+## Distance Functions Supported
+
+| Distance | ONNX Implementation | Models |
+|----------|-------------------|--------|
+| Squared Euclidean | expansion trick | GLVQ family, NG, NeuralGas, FCM, OCGLVQ, OCRSLVQ, SVQOCC, Siamese/Image/LVQMLN/PLVQ, CBC |
+| Euclidean | sqrt of above | (available) |
+| Manhattan | broadcast + abs + sum | (available) |
+| Global Omega | project then sq. euclidean | GMLVQ, MRSLVQ, SMNG, OCGMLVQ, OCMRSLVQ, SVQOCC_M, SiameseGMLVQ, ImageGMLVQ |
+| Relevance-weighted | element-wise weighted sq. diff | OCGRLVQ, SVQOCC_R |
+| Local Omega | batched MatMul | LGMLVQ, SLNG, LCELVQ_NG, LMRSLVQ, OCLGMLVQ, SVQOCC_LM |
+| Tangent | batched MatMul project-reconstruct | GTLVQ, STNG, TCELVQ_NG, OCGTLVQ, SVQOCC_T, SiameseGTLVQ, ImageGTLVQ |
+
+## Encoder Support
+
+| Encoder | ONNX Implementation | Models |
+|---------|-------------------|--------|
+| MLP | MatMul → Add → Activation per layer | SiameseGLVQ, SiameseGMLVQ, SiameseGTLVQ, LVQMLN, PLVQ |
+| CNN | Reshape → Transpose → Conv(SAME) → GlobalAveragePool → Linear | ImageGLVQ, ImageGMLVQ, ImageGTLVQ, ImageCBC |
+
+Activations supported: Sigmoid, Relu, Tanh, LeakyRelu, Selu.

--- a/examples/large_dataset_training.py
+++ b/examples/large_dataset_training.py
@@ -1,0 +1,169 @@
+"""
+Large dataset training patterns for prosemble.
+
+When datasets are too large to fit in memory, use external data loaders
+(tf.data, grain, webdataset) and feed batches into prosemble via
+partial_fit(). This example demonstrates three patterns:
+
+  1. partial_fit() with simulated streaming data
+  2. batched_iterator() for epoch-based training
+  3. padded_batches() for lax.scan-compatible static batching
+
+For datasets that DO fit in memory, prefer fit(batch_size=32) instead —
+it handles mini-batch training, shuffling, and early stopping internally.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models import GLVQ
+from prosemble.core.data import batched_iterator, padded_batches, shuffle_arrays
+
+# ---------------------------------------------------------------------------
+# Generate synthetic data (stand-in for your real dataset)
+# ---------------------------------------------------------------------------
+
+np.random.seed(42)
+n_samples, n_features, n_classes = 501, 10, 3
+X_all = jnp.array(np.random.randn(n_samples, n_features).astype(np.float32))
+y_all = jnp.array(np.tile(np.arange(n_classes), n_samples // n_classes))
+
+# Split into initial fit set and streaming set
+# (y_all is interleaved [0,1,2,0,1,2,...] so every split has all classes)
+X_init, y_init = X_all[:60], y_all[:60]
+X_stream, y_stream = X_all[60:], y_all[60:]
+
+# ===================================================================
+# Pattern 1: partial_fit() with simulated streaming data
+# ===================================================================
+# Use this when data arrives in batches from an external source
+# (database, file system, network stream, tf.data pipeline, etc.)
+
+print("=" * 60)
+print("Pattern 1: partial_fit() with streaming batches")
+print("=" * 60)
+
+model = GLVQ(
+    n_prototypes_per_class=2,
+    max_iter=10,
+    lr=0.01,
+    random_seed=42,
+)
+
+# Initial fit to initialize prototypes and optimizer
+model.fit(X_init, y_init)
+print(f"After initial fit: {model.n_iter_} iterations, loss={model.loss_:.4f}")
+
+# Simulate streaming batches
+# In practice, replace this loop with your data loader:
+#   for batch in tf_dataset:
+#   for batch in grain.DataLoader(...):
+#   for batch in webdataset.WebLoader(...):
+batch_size = 32
+n_stream = len(X_stream)
+losses = []
+
+for start in range(0, n_stream, batch_size):
+    end = min(start + batch_size, n_stream)
+    X_batch = X_stream[start:end]
+    y_batch = y_stream[start:end]
+
+    model.partial_fit(X_batch, y_batch)
+    losses.append(float(model.loss_))
+
+print(f"After {len(losses)} streaming batches: loss={losses[-1]:.4f}")
+
+preds = model.predict(X_all)
+acc = float(jnp.mean(preds == y_all))
+print(f"Accuracy: {acc:.2%}")
+
+# ===================================================================
+# Pattern 2: batched_iterator() for epoch-based training
+# ===================================================================
+# Use this when all data fits in memory but you want explicit
+# epoch/batch control with partial_fit().
+
+print()
+print("=" * 60)
+print("Pattern 2: batched_iterator() with epoch loop")
+print("=" * 60)
+
+model2 = GLVQ(
+    n_prototypes_per_class=2,
+    max_iter=5,
+    lr=0.01,
+    random_seed=42,
+)
+
+# Initial fit
+model2.fit(X_init, y_init)
+
+key = jax.random.PRNGKey(0)
+n_epochs = 5
+
+for epoch in range(n_epochs):
+    key, subkey = jax.random.split(key)
+    epoch_losses = []
+
+    for X_batch, y_batch in batched_iterator(
+        X_all, y_all, batch_size=64, key=subkey
+    ):
+        model2.partial_fit(X_batch, y_batch)
+        epoch_losses.append(float(model2.loss_))
+
+    mean_loss = sum(epoch_losses) / len(epoch_losses)
+    print(f"Epoch {epoch + 1}/{n_epochs}: mean_loss={mean_loss:.4f}")
+
+preds2 = model2.predict(X_all)
+acc2 = float(jnp.mean(preds2 == y_all))
+print(f"Accuracy: {acc2:.2%}")
+
+# ===================================================================
+# Pattern 3: padded_batches() for lax.scan compatibility
+# ===================================================================
+# Use this when building custom JIT-compiled training loops
+# with jax.lax.scan. The output has static shapes required by XLA.
+
+print()
+print("=" * 60)
+print("Pattern 3: padded_batches() for static-shaped batching")
+print("=" * 60)
+
+key = jax.random.PRNGKey(42)
+X_batches, y_batches = padded_batches(X_all, y_all, batch_size=64, key=key)
+
+print(f"Input:  X={X_all.shape}, y={y_all.shape}")
+print(f"Output: X_batches={X_batches.shape}, y_batches={y_batches.shape}")
+print(f"  {X_batches.shape[0]} batches of {X_batches.shape[1]} samples")
+print(f"  (padded from {n_samples} to {X_batches.shape[0] * X_batches.shape[1]})")
+print()
+print("These static-shaped arrays can be passed directly to jax.lax.scan")
+print("for fully JIT-compiled training loops.")
+
+# ===================================================================
+# Notes
+# ===================================================================
+
+print()
+print("=" * 60)
+print("When to use each pattern")
+print("=" * 60)
+print("""
+  fit(batch_size=32)    Data fits in memory. Handles shuffling, early
+                        stopping, and optimizer state internally.
+
+  partial_fit()         Data too large for memory, or arrives as a
+                        stream. Feed batches from any external loader:
+                        tf.data, grain, webdataset, torch DataLoader.
+                        Requires an initial fit() call to set up
+                        prototypes and optimizer.
+
+  batched_iterator()    Data fits in memory but you want explicit
+                        epoch/batch control. Yields dynamic-sized
+                        batches for Python loops.
+
+  padded_batches()      Static-shaped output for jax.lax.scan.
+                        Advanced: use when building custom JIT-compiled
+                        training loops.
+""")

--- a/prosemble/core/__init__.py
+++ b/prosemble/core/__init__.py
@@ -33,6 +33,13 @@ from .losses import (
 )
 from .pipeline import Pipeline, StandardScaler, MinMaxScaler, PCA, TransformerMixin
 from .model_selection import GridSearchCV, cross_val_score, clone
+from .protocols import (
+    Manifold, CallbackLike,
+    DistanceMatrixFn, DistancePairwiseFn,
+    SupervisedInitFn, UnsupervisedInitFn,
+)
+from .serialization import SerializationMixin
+from .data import shuffle_arrays, padded_batches, batched_iterator
 
 try:
     import jax
@@ -75,4 +82,20 @@ __all__ = _distance_all + [
     'Pipeline', 'StandardScaler', 'MinMaxScaler', 'PCA', 'TransformerMixin',
     # Model Selection
     'GridSearchCV', 'cross_val_score', 'clone',
+    # Protocols & type aliases
+    'Manifold', 'CallbackLike',
+    'DistanceMatrixFn', 'DistancePairwiseFn',
+    'SupervisedInitFn', 'UnsupervisedInitFn',
+    # Serialization
+    'SerializationMixin',
+    # Data loading utilities
+    'shuffle_arrays', 'padded_batches', 'batched_iterator',
+    # ONNX export (optional)
+    'export_onnx',
 ]
+
+# Conditional ONNX export
+try:
+    from .onnx_export import export_onnx
+except ImportError:
+    pass

--- a/prosemble/core/data.py
+++ b/prosemble/core/data.py
@@ -1,0 +1,161 @@
+"""
+Data loading and batching utilities for prosemble.
+
+Provides composable primitives for mini-batch iteration, suitable for
+custom training loops.  The built-in ``fit()`` methods already handle
+batching internally — these utilities are for advanced users who need
+explicit control over data iteration.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+
+def shuffle_arrays(key: jax.Array, *arrays: jnp.ndarray) -> tuple[jnp.ndarray, ...]:
+    """Shuffle multiple arrays with the same random permutation.
+
+    Parameters
+    ----------
+    key : JAX PRNG key
+        Random key for generating the permutation.
+    *arrays : jnp.ndarray
+        Arrays to shuffle.  All must have the same length along axis 0.
+
+    Returns
+    -------
+    tuple of jnp.ndarray
+        Shuffled arrays in the same order as the inputs.
+
+    Examples
+    --------
+    >>> key = jax.random.PRNGKey(0)
+    >>> X = jnp.arange(12).reshape(4, 3)
+    >>> y = jnp.array([0, 1, 0, 1])
+    >>> X_s, y_s = shuffle_arrays(key, X, y)
+    """
+    if len(arrays) == 0:
+        return ()
+    n = arrays[0].shape[0]
+    perm = jax.random.permutation(key, n)
+    return tuple(a[perm] for a in arrays)
+
+
+def padded_batches(
+    X: jnp.ndarray,
+    y: jnp.ndarray | None = None,
+    batch_size: int = 32,
+    key: jax.Array | None = None,
+) -> tuple[jnp.ndarray, jnp.ndarray | None]:
+    """Split data into static-shaped batches, padding the last batch.
+
+    Returns arrays of shape ``(n_batches, batch_size, ...)`` suitable for
+    ``jax.lax.scan``.  If the data length is not divisible by
+    ``batch_size``, the last batch is padded by repeating initial samples.
+
+    Parameters
+    ----------
+    X : jnp.ndarray of shape (n_samples, ...)
+        Feature array.
+    y : jnp.ndarray of shape (n_samples,), optional
+        Label array.
+    batch_size : int
+        Number of samples per batch.
+    key : JAX PRNG key, optional
+        If provided, data is shuffled before batching.
+
+    Returns
+    -------
+    X_batches : jnp.ndarray of shape (n_batches, batch_size, ...)
+    y_batches : jnp.ndarray of shape (n_batches, batch_size) or None
+
+    Examples
+    --------
+    >>> X = jnp.ones((10, 3))
+    >>> y = jnp.arange(10)
+    >>> X_b, y_b = padded_batches(X, y, batch_size=4)
+    >>> X_b.shape  # (3, 4, 3) — 10 samples padded to 12
+    (3, 4, 3)
+    """
+    n_samples = X.shape[0]
+
+    if key is not None:
+        if y is not None:
+            X, y = shuffle_arrays(key, X, y)
+        else:
+            X, = shuffle_arrays(key, X)
+
+    n_batches = (n_samples + batch_size - 1) // batch_size
+    padded_size = n_batches * batch_size
+
+    if padded_size > n_samples:
+        pad_n = padded_size - n_samples
+        X = jnp.concatenate([X, X[:pad_n]], axis=0)
+        if y is not None:
+            y = jnp.concatenate([y, y[:pad_n]], axis=0)
+
+    X_batches = X.reshape(n_batches, batch_size, *X.shape[1:])
+    y_batches = y.reshape(n_batches, batch_size) if y is not None else None
+    return X_batches, y_batches
+
+
+def batched_iterator(
+    X: jnp.ndarray,
+    y: jnp.ndarray | None = None,
+    batch_size: int = 32,
+    shuffle: bool = True,
+    key: jax.Array | None = None,
+    drop_last: bool = False,
+):
+    """Yield mini-batches from data arrays.
+
+    For use in custom Python training loops.
+
+    Parameters
+    ----------
+    X : jnp.ndarray of shape (n_samples, ...)
+        Feature array.
+    y : jnp.ndarray of shape (n_samples,), optional
+        Label array.
+    batch_size : int
+        Number of samples per batch.
+    shuffle : bool
+        If True and *key* is provided, shuffle before iterating.
+    key : JAX PRNG key, optional
+        Required if ``shuffle=True``.
+    drop_last : bool
+        If True, drop the last batch when it is smaller than
+        ``batch_size``.  If False (default), the last batch may be
+        smaller.
+
+    Yields
+    ------
+    X_batch : jnp.ndarray of shape (batch_size, ...) or smaller
+    y_batch : jnp.ndarray of shape (batch_size,) or None
+
+    Examples
+    --------
+    >>> key = jax.random.PRNGKey(0)
+    >>> X = jnp.ones((10, 3))
+    >>> for X_b, y_b in batched_iterator(X, batch_size=4, key=key):
+    ...     print(X_b.shape)
+    (4, 3)
+    (4, 3)
+    (2, 3)
+    """
+    n_samples = X.shape[0]
+
+    if shuffle and key is not None:
+        if y is not None:
+            X, y = shuffle_arrays(key, X, y)
+        else:
+            X, = shuffle_arrays(key, X)
+
+    for start in range(0, n_samples, batch_size):
+        end = min(start + batch_size, n_samples)
+        if drop_last and (end - start) < batch_size:
+            break
+        X_batch = X[start:end]
+        y_batch = y[start:end] if y is not None else None
+        yield X_batch, y_batch

--- a/prosemble/core/distance.py
+++ b/prosemble/core/distance.py
@@ -34,19 +34,16 @@ def euclidean_distance_matrix(X: chex.Array, Y: chex.Array) -> chex.Array:
     """
     Compute pairwise Euclidean distances between rows of X and Y.
 
-    Uses the identity: ||x - y||² = ||x||² + ||y||² - 2⟨x, y⟩
-    This is more efficient than explicit broadcasting for large matrices.
+    Uses the expansion trick: :math:`\|x - y\|^2 = \|x\|^2 + \|y\|^2 - 2 x^T y`.
 
-    Mathematical Formula::
-
-        D[i,j] = ||X[i] - Y[j]|| = sqrt(Σ_k (X[i,k] - Y[j,k])²)
+    Formula: :math:`D_{ij} = \|X_i - Y_j\| = \sqrt{\sum_k (X_{ik} - Y_{jk})^2}`
 
     Args:
         X: Array of shape (n, d) - n samples with d features
         Y: Array of shape (m, d) - m samples with d features
 
     Returns:
-        D: Array of shape (n, m) where ``D[i,j] = ||X[i] - Y[j]||``
+        D: Array of shape (n, m) where :math:`D_{ij} = \|X_i - Y_j\|`
 
     Complexity:
         Time: O(nmd) - single matrix multiplication
@@ -96,16 +93,14 @@ def squared_euclidean_distance_matrix(X: chex.Array, Y: chex.Array) -> chex.Arra
     More efficient than euclidean_distance_matrix(X, Y)**2 because it avoids
     the sqrt operation entirely.
 
-    Mathematical Formula::
-
-        D²[i,j] = ||X[i] - Y[j]||² = Σ_k (X[i,k] - Y[j,k])²
+    Formula: :math:`D^2_{ij} = \|X_i - Y_j\|^2 = \sum_k (X_{ik} - Y_{jk})^2`
 
     Args:
         X: Array of shape (n, d)
         Y: Array of shape (m, d)
 
     Returns:
-        D²: Array of shape (n, m) where ``D²[i,j] = ||X[i] - Y[j]||²``
+        D: Array of shape (n, m) where :math:`D^2_{ij} = \|X_i - Y_j\|^2`
 
     Complexity:
         Time: O(nmd)
@@ -141,9 +136,7 @@ def manhattan_distance_matrix(X: chex.Array, Y: chex.Array) -> chex.Array:
     """
     Compute pairwise Manhattan (L1) distances.
 
-    Mathematical Formula::
-
-        D[i,j] = ||X[i] - Y[j]||₁ = Σ_k |X[i,k] - Y[j,k]|
+    Formula: :math:`D_{ij} = \|X_i - Y_j\|_1 = \sum_k |X_{ik} - Y_{jk}|`
 
     Args:
         X: Array of shape (n, d)
@@ -193,14 +186,12 @@ def lpnorm_distance_matrix(
     """
     Compute pairwise L-p norm distances.
 
-    Mathematical Formula::
-
-        D[i,j] = ||X[i] - Y[j]||_p = (Σ_k |X[i,k] - Y[j,k]|^p)^(1/p)
+    Formula: :math:`D_{ij} = \|X_i - Y_j\|_p = (\sum_k |X_{ik} - Y_{jk}|^p)^{1/p}`
 
     Special Cases:
         p = 1: Manhattan distance
         p = 2: Euclidean distance
-        p = ∞: Chebyshev distance (max absolute difference)
+        p = :math:`\infty`: Chebyshev distance (max absolute difference)
 
     Args:
         X: Array of shape (n, d)
@@ -252,11 +243,8 @@ def omega_distance_matrix(
     """
     Compute distances in projected space using projection matrix Omega.
 
-    Mathematical Formula::
-
-        D[i,j] = ||X[i]Ω - Y[j]Ω||²
-
-    where Ω is a projection matrix that transforms the feature space.
+    Formula: :math:`D_{ij} = \|X_i \Omega - Y_j \Omega\|^2`
+    where :math:`\Omega` is a projection matrix that transforms the feature space.
 
     Args:
         X: Array of shape (n, d)
@@ -264,7 +252,7 @@ def omega_distance_matrix(
         omega: Projection matrix of shape (d, k) where k is projection dimension
 
     Returns:
-        D²: Array of shape (n, m) with squared distances in projected space
+        D: Array of shape (n, m) with squared distances in projected space
 
     Complexity:
         Time: O(ndk + mdk + nmk) = O((n+m)dk + nmk)
@@ -273,7 +261,7 @@ def omega_distance_matrix(
     Use Cases:
         - Dimensionality reduction for distance computation
         - Learning relevance of features (omega learned from data)
-        - Mahalanobis-like distances (when omega = L where Σ = LL^T)
+        - Mahalanobis-like distances (when :math:`\Omega = L` where :math:`\Sigma = LL^T`)
 
     Example:
         >>> X = jnp.array([[1, 2, 3], [4, 5, 6]])
@@ -313,11 +301,8 @@ def lomega_distance_matrix(
     """
     Compute distances using multiple projection matrices (Local Omega).
 
-    Mathematical Formula::
-
-        D[i,j] = Σ_p ||X[i]Ω_p - Y[j]Ω_p||²
-
-    where Ω_p are multiple projection matrices (one per prototype or cluster).
+    Formula: :math:`D_{ij} = \sum_p \|X_i \Omega_p - Y_j \Omega_p\|^2`
+    where :math:`\Omega_p` are multiple projection matrices (one per prototype or cluster).
 
     Args:
         X: Array of shape (n, d) - data points
@@ -326,7 +311,7 @@ def lomega_distance_matrix(
                 Each Y[j] has its own projection matrix omegas[j]
 
     Returns:
-        D²: Array of shape (n, m) with aggregated projected distances
+        D: Array of shape (n, m) with aggregated projected distances
 
     Complexity:
         Time: O(nmdk)
@@ -465,9 +450,7 @@ def gaussian_kernel_matrix(
     """
     Compute Gaussian (RBF) kernel matrix.
 
-    Mathematical Formula::
-
-        K[i,j] = exp(-||X[i] - Y[j]||² / (2σ²))
+    Formula: :math:`K_{ij} = \exp(-\|X_i - Y_j\|^2 / (2\sigma^2))`
 
     The Gaussian kernel maps data to infinite-dimensional Hilbert space,
     enabling non-linear clustering and classification.
@@ -475,12 +458,12 @@ def gaussian_kernel_matrix(
     Args:
         X: Array of shape (n, d)
         Y: Array of shape (m, d)
-        sigma: Bandwidth parameter (σ > 0)
+        sigma: Bandwidth parameter (:math:`\sigma > 0`)
 
     Returns:
-        K: Array of shape (n, m) where K[i,j] ∈ [0, 1]
-           K[i,j] = 1 when X[i] = Y[j]
-           K[i,j] → 0 as ||X[i] - Y[j]|| → ∞
+        K: Array of shape (n, m) where :math:`K_{ij} \in [0, 1]`.
+           :math:`K_{ij} = 1` when :math:`X_i = Y_j`;
+           :math:`K_{ij} \to 0` as :math:`\|X_i - Y_j\| \to \infty`
 
     Complexity:
         Time: O(nmd)
@@ -501,12 +484,9 @@ def gaussian_kernel_matrix(
         True
 
     Kernel Trick:
-        For feature map φ: ℝ^d → ℋ (infinite-dimensional),
-        K(x, y) = ⟨φ(x), φ(y)⟩ in Hilbert space ℋ
-
-        Kernel distance:
-            ||φ(x) - φ(y)||² = K(x,x) - 2K(x,y) + K(y,y)
-                              = 2 - 2K(x,y)  [for normalized kernel]
+        For feature map phi mapping to infinite-dimensional Hilbert space,
+        K(x, y) = <phi(x), phi(y)>. Kernel distance:
+        ||phi(x) - phi(y)||^2 = K(x,x) - 2K(x,y) + K(y,y) = 2 - 2K(x,y) for normalized kernel.
 
     Use Cases:
         - Kernel Fuzzy C-Means (KFCM)
@@ -515,12 +495,12 @@ def gaussian_kernel_matrix(
         - Gaussian Processes
 
     Hyperparameter Tuning:
-        - Small σ: Tight clusters, high sensitivity to noise
-        - Large σ: Smooth clusters, may underfit
-        - Rule of thumb: σ ≈ median(pairwise_distances) / √(2 * n_clusters)
+        - Small :math:`\sigma`: Tight clusters, high sensitivity to noise
+        - Large :math:`\sigma`: Smooth clusters, may underfit
+        - Rule of thumb: :math:`\sigma \approx \text{median}(\text{pairwise\_distances}) / \sqrt{2 \cdot n_\text{clusters}}`
 
     Notes:
-        - sigma is bandwidth, NOT variance (variance = σ²)
+        - sigma is bandwidth, NOT variance (variance = :math:`\sigma^2`)
         - For numerical stability, we use maximum() to ensure non-negative
         - JIT-compiled for GPU acceleration
     """
@@ -547,17 +527,14 @@ def polynomial_kernel_matrix(
     """
     Compute polynomial kernel matrix.
 
-    Mathematical Formula::
-
-        K[i,j] = (⟨X[i], Y[j]⟩ + c)^d
-
-    where d is degree and c is coef0.
+    Formula: :math:`K_{ij} = (X_i^T Y_j + c)^d`
+    where *d* is degree and *c* is coef0.
 
     Args:
         X: Array of shape (n, d)
         Y: Array of shape (m, d)
-        degree: Polynomial degree (d ≥ 1)
-        coef0: Coefficient (c ≥ 0)
+        degree: Polynomial degree (:math:`d \ge 1`)
+        coef0: Coefficient (:math:`c \ge 0`)
 
     Returns:
         K: Array of shape (n, m) with polynomial kernel values
@@ -568,7 +545,7 @@ def polynomial_kernel_matrix(
         >>> K = polynomial_kernel_matrix(X, Y, degree=2, coef0=1.0)
 
     Notes:
-        - degree=1, coef0=0: Linear kernel (⟨x, y⟩)
+        - degree=1, coef0=0: Linear kernel (dot product)
         - Higher degree: More complex decision boundaries
         - coef0: Influences importance of lower vs higher order terms
     """
@@ -728,7 +705,7 @@ def estimate_sigma(X: chex.Array, percentile: float = 50.0) -> float:
         >>> sigma = estimate_sigma(X, percentile=50)
 
     Notes:
-        - Heuristic: sigma = median_distance / √(2 * n_clusters)
+        - Heuristic: :math:`\sigma = \text{median\_distance} / \sqrt{2 \cdot n_\text{clusters}}`
         - For large datasets, use subsample to avoid O(n²) computation
     """
     # For large datasets, subsample

--- a/prosemble/core/kernel.py
+++ b/prosemble/core/kernel.py
@@ -15,7 +15,7 @@ def gaussian_kernel(x: chex.Array, y: chex.Array, sigma: float) -> chex.Array:
     """
     Compute Gaussian (RBF) kernel between two vectors.
 
-    K(x, y) = exp(-||x - y||² / (2σ²))
+    :math:`K(x, y) = \exp(-\|x - y\|^2 / (2\sigma^2))`
 
     Args:
         x: First vector, shape (n_features,)
@@ -50,7 +50,7 @@ def batch_gaussian_kernel(
     X_sq = jnp.sum(X ** 2, axis=1, keepdims=True)  # (n_samples, 1)
     Y_sq = jnp.sum(Y ** 2, axis=1, keepdims=True)  # (m_samples, 1)
 
-    # ||x - y||² = ||x||² + ||y||² - 2⟨x, y⟩
+    # ||x - y||^2 = ||x||^2 + ||y||^2 - 2<x, y>
     sq_distances = X_sq + Y_sq.T - 2.0 * (X @ Y.T)  # (n_samples, m_samples)
 
     # Ensure non-negative (numerical stability)
@@ -67,12 +67,10 @@ def kernel_distance_squared(
     X: chex.Array, Y: chex.Array, sigma: float
 ) -> chex.Array:
     """
-    Compute squared distance in feature space: ||φ(x) - φ(y)||²
+    Compute squared distance in feature space.
 
-    For Gaussian kernel::
-
-        ||φ(x) - φ(y)||² = K(x,x) + K(y,y) - 2K(x,y)
-                          = 2(1 - K(x,y))  [since K(x,x) = 1]
+    For Gaussian kernel: ||phi(x) - phi(y)||^2 = K(x,x) + K(y,y) - 2K(x,y) = 2(1 - K(x,y)),
+    since K(x,x) = 1.
 
     Args:
         X: First set of vectors, shape (n_samples, n_features)
@@ -91,7 +89,7 @@ def kernel_distance(
     X: chex.Array, Y: chex.Array, sigma: float
 ) -> chex.Array:
     """
-    Compute distance in feature space: ||φ(x) - φ(y)||
+    Compute distance in feature space.
 
     Args:
         X: First set of vectors, shape (n_samples, n_features)

--- a/prosemble/core/losses.py
+++ b/prosemble/core/losses.py
@@ -167,8 +167,10 @@ def lvq21_loss(distances, target_labels, prototype_labels):
 def _class_probabilities(distances, target_labels, prototype_labels, sigma):
     """Compute Gaussian mixture class probabilities.
 
-    p(k|x) = exp(-d²/2σ²) / Σexp(-d²/2σ²)
-    P(class|x) = Σ_{k∈class} p(k|x)
+    .. math::
+
+        p(k|x) = \frac{\exp(-d^2 / 2\sigma^2)}{\sum \exp(-d^2 / 2\sigma^2)}, \quad
+        P(\text{class}|x) = \sum_{k \in \text{class}} p(k|x)
 
     Returns
     -------
@@ -246,13 +248,15 @@ def ng_rslvq_loss(distances, target_labels, prototype_labels, sigma=1.0, gamma=1
     """RSLVQ loss with Neural Gas rank-based neighborhood cooperation.
 
     Combines Gaussian mixture prototype probabilities with NG rank weights
-    to create a neighborhood-cooperative probabilistic assignment:
+    to create a neighborhood-cooperative probabilistic assignment.
 
-        p(k|x) = exp(-d_k / 2σ²) / Σ exp(-d_j / 2σ²)   [Gaussian]
-        h_k = exp(-rank_k / γ) / Σ exp(-rank_j / γ)      [NG weights]
-        w_k = p(k|x) · h_k / Σ p(j|x) · h_j             [combined]
+    Gaussian: :math:`p(k|x) = \exp(-d_k / 2\sigma^2) / \sum_j \exp(-d_j / 2\sigma^2)`
 
-    The loss is -log(Σ w_k for correct class / Σ w_k for all).
+    NG weights: :math:`h_k = \exp(-\text{rank}_k / \gamma) / \sum_j \exp(-\text{rank}_j / \gamma)`
+
+    Combined: :math:`w_k = p(k|x) \cdot h_k / \sum_j p(j|x) \cdot h_j`
+
+    The loss is :math:`-\log(\sum_{k \in \text{correct}} w_k)`.
 
     Parameters
     ----------
@@ -284,7 +288,7 @@ def ng_rslvq_loss(distances, target_labels, prototype_labels, sigma=1.0, gamma=1
     h = jnp.exp(-ranks / (gamma + 1e-10))
     h = h / (jnp.sum(h, axis=1, keepdims=True) + 1e-10)
 
-    # 3. Combined weights (Gaussian × NG), renormalized
+    # 3. Combined weights (Gaussian * NG), renormalized
     weighted_probs = h * probs
     weighted_probs = weighted_probs / (jnp.sum(weighted_probs, axis=1, keepdims=True) + 1e-10)
 
@@ -357,8 +361,10 @@ def margin_loss(y_pred, y_true_one_hot, margin=0.3):
 def neural_gas_energy(distances, lam):
     """Neural Gas energy function.
 
-    E = Σ_k h(rank_k, λ) * d(x, w_k)
-    h(rank, λ) = exp(-rank / λ)
+    .. math::
+
+        E = \sum_k h(\text{rank}_k, \lambda) \cdot d(x, w_k), \quad
+        h(\text{rank}, \lambda) = \exp(-\text{rank} / \lambda)
 
     Parameters
     ----------

--- a/prosemble/core/manifolds.py
+++ b/prosemble/core/manifolds.py
@@ -12,9 +12,9 @@ All operations are JIT-compilable and vmap-compatible.
 
 References
 ----------
-.. [1] Schwarz, Psenickova, Villmann, Röhrbein (2026).
-       Topology-Preserving Prototype Learning on Riemannian Manifolds.
-       ESANN 2026.
+Schwarz, Psenickova, Villmann, Röhrbein (2026).
+Topology-Preserving Prototype Learning on Riemannian Manifolds.
+ESANN 2026.
 """
 
 from __future__ import annotations
@@ -49,7 +49,7 @@ def logm_safe(A):
 def sqrt_spd(A):
     """Matrix square root for symmetric positive definite matrices.
 
-    Uses eigendecomposition: A^{1/2} = V diag(sqrt(λ)) V^T.
+    Uses eigendecomposition: :math:`A^{1/2} = V \operatorname{diag}(\sqrt{\lambda}) V^T`.
 
     Parameters
     ----------
@@ -67,7 +67,7 @@ def sqrt_spd(A):
 def inv_sqrt_spd(A):
     """Inverse matrix square root for symmetric positive definite matrices.
 
-    Uses eigendecomposition: A^{-1/2} = V diag(1/sqrt(λ)) V^T.
+    Uses eigendecomposition: :math:`A^{-1/2} = V \operatorname{diag}(1/\sqrt{\lambda}) V^T`.
 
     Parameters
     ----------
@@ -89,7 +89,7 @@ def inv_sqrt_spd(A):
 class SO:
     """Special orthogonal group SO(n): rotation matrices.
 
-    Points are n×n orthogonal matrices with det = +1.
+    Points are :math:`n \times n` orthogonal matrices with det = +1.
     Geodesic distance uses the bi-invariant metric.
 
     Parameters
@@ -140,7 +140,7 @@ class SO:
         return Q
 
     def belongs(self, R):
-        """Check if R is in SO(n): R^T R ≈ I and det(R) ≈ +1."""
+        """Check if R is in SO(n): :math:`R^T R \\approx I` and :math:`\\det(R) \\approx +1`."""
         ortho = jnp.allclose(R.T @ R, jnp.eye(self.n), atol=1e-4)
         det_pos = jnp.abs(jnp.linalg.det(R) - 1.0) < 1e-4
         return ortho & det_pos
@@ -152,7 +152,7 @@ class SO:
         return U
 
     def injectivity_radius(self, R):
-        """Injectivity radius of SO(n) is π."""
+        """Injectivity radius of SO(n) is :math:`\\pi`."""
         return jnp.pi
 
 
@@ -161,7 +161,7 @@ class SO:
 # ---------------------------------------------------------------------------
 
 class SPD:
-    """Manifold of n×n symmetric positive definite matrices.
+    """Manifold of :math:`n \\times n` symmetric positive definite matrices.
 
     Uses the affine-invariant Riemannian metric.
 
@@ -201,7 +201,7 @@ class SPD:
         return A_sqrt @ jsl.expm(inner) @ A_sqrt
 
     def random_point(self, key):
-        """Generate random SPD matrix: A = L L^T + εI."""
+        """Generate random SPD matrix: :math:`A = L L^T + \\epsilon I`."""
         L = jax.random.normal(key, (self.n, self.n))
         return L @ L.T + 0.1 * jnp.eye(self.n)
 
@@ -312,7 +312,7 @@ class Grassmannian:
         return Q
 
     def belongs(self, Q):
-        """Check if Q represents a point on Gr(n, k): Q^T Q ≈ I_k."""
+        """Check if Q represents a point on Gr(n, k): :math:`Q^T Q \\approx I_k`."""
         return jnp.allclose(Q.T @ Q, jnp.eye(self.k), atol=1e-4)
 
     def project(self, Q):
@@ -321,5 +321,5 @@ class Grassmannian:
         return Q_new
 
     def injectivity_radius(self, Q):
-        """Injectivity radius of Gr(n,k) is π/2."""
+        """Injectivity radius of Gr(n,k) is :math:`\\pi/2`."""
         return jnp.pi / 2.0

--- a/prosemble/core/onnx_export.py
+++ b/prosemble/core/onnx_export.py
@@ -1,0 +1,1859 @@
+"""
+ONNX export for prosemble prototype-based models.
+
+Converts a fitted model's predict function into an ONNX graph.
+Only supports models whose distance function can be expressed with
+standard ONNX operators.  Unsupported models raise
+``NotImplementedError`` with a clear message.
+
+Supported distance functions:
+
+- ``squared_euclidean_distance_matrix``
+- ``euclidean_distance_matrix``
+- ``manhattan_distance_matrix``
+- ``omega_distance_matrix`` (global projection matrix)
+- ``lomega_distance_matrix`` (per-prototype local matrices)
+- ``tangent_distance_matrix`` (per-prototype tangent subspace)
+- ``relevance_weighted`` (per-feature relevance weighting)
+
+Supported decision patterns:
+
+- WTAC (supervised classification)
+- ArgMin (unsupervised clustering)
+- One-class hard nearest (OCGLVQ family)
+- One-class Gaussian soft (OCRSLVQ family)
+- One-class Gaussian+NG soft (OCRSLVQ_NG family)
+- SVQ-OCC response model (SVQOCC family)
+- CBC reasoning (CBC, ImageCBC)
+- PLVQ Gaussian mixture soft assignment
+
+Supported encoder models:
+
+- MLP encoder (SiameseGLVQ, SiameseGMLVQ, SiameseGTLVQ, LVQMLN, PLVQ)
+- CNN encoder (ImageGLVQ, ImageGMLVQ, ImageGTLVQ, ImageCBC)
+
+Not supported:
+
+- ``gaussian_kernel_matrix``, ``polynomial_kernel_matrix``
+- Riemannian manifold distances (logm, expm have no ONNX equivalent)
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any
+
+import numpy as np
+
+
+def _check_onnx_installed():
+    """Raise ImportError with clear message if onnx is not installed."""
+    try:
+        import onnx  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "ONNX export requires the 'onnx' package. "
+            "Install with: pip install prosemble[onnx]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Numpy forward functions (for pre-computing latent prototypes at export time)
+# ---------------------------------------------------------------------------
+
+def _get_activation_np(name):
+    """Return a numpy activation function by name."""
+    if name == 'sigmoid':
+        return lambda z: 1.0 / (1.0 + np.exp(-np.clip(z, -500, 500)))
+    elif name == 'relu':
+        return lambda z: np.maximum(0, z)
+    elif name == 'tanh':
+        return np.tanh
+    elif name == 'leaky_relu':
+        return lambda z: np.where(z > 0, z, 0.01 * z)
+    elif name == 'selu':
+        alpha = 1.6732632423543772
+        scale = 1.0507009873554805
+        return lambda z: scale * np.where(z > 0, z, alpha * (np.exp(z) - 1))
+    else:
+        raise ValueError(f"Unknown activation: {name}")
+
+
+def _mlp_forward_np(params, x, activation='sigmoid'):
+    """Numpy MLP forward pass (for pre-computing latent prototypes).
+
+    Parameters
+    ----------
+    params : list of (weight, bias) tuples
+        MLP parameters (JAX or numpy arrays).
+    x : array of shape (n, d_in)
+    activation : str
+
+    Returns
+    -------
+    numpy array of shape (n, d_out)
+    """
+    act_fn = _get_activation_np(activation)
+    x = np.asarray(x, dtype=np.float32)
+    for w, b in params:
+        x = act_fn(x @ np.asarray(w, dtype=np.float32)
+                    + np.asarray(b, dtype=np.float32))
+    return x
+
+
+def _cnn_forward_np(params, x, activation='relu'):
+    """Numpy CNN forward pass (for pre-computing latent prototypes).
+
+    Parameters
+    ----------
+    params : dict with 'conv_layers' and 'linear'
+    x : array of shape (N, H, W, C) — NHWC format
+    activation : str
+
+    Returns
+    -------
+    numpy array of shape (N, latent_dim)
+    """
+    act_fn = _get_activation_np(activation)
+    x = np.asarray(x, dtype=np.float32)
+
+    for kernel, bias in params['conv_layers']:
+        kernel = np.asarray(kernel, dtype=np.float32)  # (kH, kW, C_in, C_out)
+        bias = np.asarray(bias, dtype=np.float32)       # (C_out,)
+        N, H, W, C_in = x.shape
+        kH, kW = kernel.shape[:2]
+        pH, pW = kH // 2, kW // 2
+        # SAME padding
+        x_pad = np.pad(x, ((0, 0), (pH, kH - 1 - pH),
+                            (pW, kW - 1 - pW), (0, 0)))
+        out = np.zeros((N, H, W, kernel.shape[3]), dtype=np.float32)
+        for i in range(kH):
+            for j in range(kW):
+                out += np.einsum('nhwi,io->nhwo',
+                                 x_pad[:, i:i + H, j:j + W, :],
+                                 kernel[i, j])
+        out += bias
+        x = act_fn(out)
+
+    # Global average pooling: (N, H, W, C) -> (N, C)
+    x = np.mean(x, axis=(1, 2))
+
+    # Linear head
+    w, b = params['linear']
+    x = act_fn(x @ np.asarray(w, dtype=np.float32)
+               + np.asarray(b, dtype=np.float32))
+    return x
+
+
+# ---------------------------------------------------------------------------
+# ONNX encoder builders
+# ---------------------------------------------------------------------------
+
+def _activation_node(input_name, output_name, activation):
+    """Create a single ONNX activation node."""
+    import onnx.helper as oh
+
+    if activation == 'sigmoid':
+        return oh.make_node('Sigmoid', [input_name], [output_name])
+    elif activation == 'relu':
+        return oh.make_node('Relu', [input_name], [output_name])
+    elif activation == 'tanh':
+        return oh.make_node('Tanh', [input_name], [output_name])
+    elif activation == 'leaky_relu':
+        return oh.make_node('LeakyRelu', [input_name], [output_name],
+                            alpha=0.01)
+    elif activation == 'selu':
+        return oh.make_node('Selu', [input_name], [output_name])
+    else:
+        raise ValueError(f"Unknown activation for ONNX: {activation}")
+
+
+def _mlp_encoder_onnx(input_name, params, activation):
+    """Build ONNX nodes for an MLP encoder.
+
+    Parameters
+    ----------
+    input_name : str
+        Name of the input tensor (e.g. 'X').
+    params : list of (weight, bias) tuples
+    activation : str
+
+    Returns
+    -------
+    nodes : list of onnx.NodeProto
+    initializers : list of onnx.TensorProto
+    output_name : str
+        Name of the encoder's output tensor.
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+    prev = input_name
+
+    for i, (w, b) in enumerate(params):
+        w_np = np.asarray(w, dtype=np.float32)
+        b_np = np.asarray(b, dtype=np.float32)
+        w_name = f'_enc_w_{i}'
+        b_name = f'_enc_b_{i}'
+        mm_name = f'_enc_mm_{i}'
+        add_name = f'_enc_add_{i}'
+        is_last = (i == len(params) - 1)
+        act_name = '_enc_out' if is_last else f'_enc_act_{i}'
+
+        inits.append(oh.make_tensor(
+            w_name, TensorProto.FLOAT, list(w_np.shape),
+            w_np.flatten().tolist(),
+        ))
+        inits.append(oh.make_tensor(
+            b_name, TensorProto.FLOAT, list(b_np.shape),
+            b_np.flatten().tolist(),
+        ))
+        nodes.append(oh.make_node('MatMul', [prev, w_name], [mm_name]))
+        nodes.append(oh.make_node('Add', [mm_name, b_name], [add_name]))
+        nodes.append(_activation_node(add_name, act_name, activation))
+        prev = act_name
+
+    return nodes, inits, '_enc_out'
+
+
+def _cnn_encoder_onnx(input_name, params, input_shape, activation):
+    """Build ONNX nodes for a CNN encoder.
+
+    Parameters
+    ----------
+    input_name : str
+        Name of the flat input tensor (batch, H*W*C).
+    params : dict with 'conv_layers' and 'linear'
+    input_shape : tuple
+        (H, W, C) of the original images.
+    activation : str
+
+    Returns
+    -------
+    nodes : list of onnx.NodeProto
+    initializers : list of onnx.TensorProto
+    output_name : str
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    H, W, C = input_shape
+
+    # Reshape flat input to (batch, H, W, C)
+    nhwc_shape = np.array([-1, H, W, C], dtype=np.int64)
+    inits.append(oh.make_tensor(
+        '_enc_nhwc_shape', TensorProto.INT64, [4], nhwc_shape.tolist(),
+    ))
+    nodes.append(oh.make_node(
+        'Reshape', [input_name, '_enc_nhwc_shape'], ['_enc_nhwc'],
+    ))
+
+    # Transpose NHWC -> NCHW for ONNX Conv
+    nodes.append(oh.make_node(
+        'Transpose', ['_enc_nhwc'], ['_enc_nchw'],
+        perm=[0, 3, 1, 2],
+    ))
+
+    prev = '_enc_nchw'
+    for i, (kernel, bias) in enumerate(params['conv_layers']):
+        # JAX kernel: (kH, kW, C_in, C_out) -> ONNX: (C_out, C_in, kH, kW)
+        k_np = np.asarray(kernel, dtype=np.float32).transpose(3, 2, 0, 1)
+        b_np = np.asarray(bias, dtype=np.float32)
+        k_name = f'_enc_ck_{i}'
+        b_name = f'_enc_cb_{i}'
+        conv_name = f'_enc_conv_{i}'
+        act_name = f'_enc_conv_act_{i}'
+
+        inits.append(oh.make_tensor(
+            k_name, TensorProto.FLOAT, list(k_np.shape),
+            k_np.flatten().tolist(),
+        ))
+        inits.append(oh.make_tensor(
+            b_name, TensorProto.FLOAT, list(b_np.shape),
+            b_np.flatten().tolist(),
+        ))
+        nodes.append(oh.make_node(
+            'Conv', [prev, k_name, b_name], [conv_name],
+            auto_pad='SAME_UPPER', strides=[1, 1],
+        ))
+        nodes.append(_activation_node(conv_name, act_name, activation))
+        prev = act_name
+
+    # GlobalAveragePool -> (N, C_last, 1, 1)
+    nodes.append(oh.make_node(
+        'GlobalAveragePool', [prev], ['_enc_gap'],
+    ))
+
+    # Flatten -> (N, C_last)
+    nodes.append(oh.make_node(
+        'Flatten', ['_enc_gap'], ['_enc_flat'],
+        axis=1,
+    ))
+
+    # Linear head: MatMul + Add + Activation
+    w_lin, b_lin = params['linear']
+    w_np = np.asarray(w_lin, dtype=np.float32)
+    b_np = np.asarray(b_lin, dtype=np.float32)
+    inits.append(oh.make_tensor(
+        '_enc_lin_w', TensorProto.FLOAT, list(w_np.shape),
+        w_np.flatten().tolist(),
+    ))
+    inits.append(oh.make_tensor(
+        '_enc_lin_b', TensorProto.FLOAT, list(b_np.shape),
+        b_np.flatten().tolist(),
+    ))
+    nodes.append(oh.make_node('MatMul', ['_enc_flat', '_enc_lin_w'],
+                              ['_enc_lin_mm']))
+    nodes.append(oh.make_node('Add', ['_enc_lin_mm', '_enc_lin_b'],
+                              ['_enc_lin_add']))
+    nodes.append(_activation_node('_enc_lin_add', '_enc_out', activation))
+
+    return nodes, inits, '_enc_out'
+
+
+# ---------------------------------------------------------------------------
+# Distance function -> ONNX subgraph builders
+# ---------------------------------------------------------------------------
+
+def _squared_euclidean_onnx(builder, X_name, proto_name):
+    """Add squared Euclidean distance nodes: ||X - W||^2.
+
+    Uses the expansion: ||x-y||^2 = ||x||^2 + ||y||^2 - 2*x*y^T
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # X_sq = sum(X**2, axis=1, keepdims=True)  -> (batch, 1)
+    nodes.append(oh.make_node('Mul', [X_name, X_name], ['_x_sq_full']))
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_x_sq_full', '_axis1_const'],
+        ['_x_sq'], keepdims=1,
+    ))
+
+    # W_sq = sum(W**2, axis=1, keepdims=True)  -> (n_proto, 1)
+    nodes.append(oh.make_node('Mul', [proto_name, proto_name], ['_w_sq_full']))
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_w_sq_full', '_axis1_const'],
+        ['_w_sq'], keepdims=1,
+    ))
+
+    # W_sq_T -> (1, n_proto)
+    nodes.append(oh.make_node('Transpose', ['_w_sq'], ['_w_sq_t']))
+
+    # XW = X @ W^T -> (batch, n_proto)
+    nodes.append(oh.make_node('MatMul', [X_name, '_w_t'], ['_xw']))
+
+    # D = X_sq + W_sq_T - 2*XW
+    nodes.append(oh.make_node('Mul', ['_xw', '_two_const'], ['_2xw']))
+    nodes.append(oh.make_node('Add', ['_x_sq', '_w_sq_t'], ['_xsq_wsq']))
+    nodes.append(oh.make_node('Sub', ['_xsq_wsq', '_2xw'], ['_dist_raw']))
+
+    # Clip to >= 0
+    nodes.append(oh.make_node('Relu', ['_dist_raw'], ['distances']))
+
+    # Need: W^T, constants
+    extra_initializers = [
+        oh.make_tensor('_two_const', TensorProto.FLOAT, [], [2.0]),
+        oh.make_tensor('_axis1_const', TensorProto.INT64, [1], [1]),
+    ]
+    # W^T computed as a Transpose node
+    nodes.insert(0, oh.make_node('Transpose', [proto_name], ['_w_t']))
+
+    return nodes, extra_initializers, 'distances'
+
+
+def _euclidean_onnx(builder, X_name, proto_name):
+    """Euclidean distance = sqrt(squared_euclidean)."""
+    import onnx.helper as oh
+
+    nodes, inits, dist_name = _squared_euclidean_onnx(builder, X_name, proto_name)
+    nodes.append(oh.make_node('Sqrt', [dist_name], ['distances_eucl']))
+    return nodes, inits, 'distances_eucl'
+
+
+def _manhattan_onnx(builder, X_name, proto_name):
+    """Manhattan distance: sum(|X - W|, axis=-1)."""
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Unsqueeze X -> (batch, 1, features)
+    nodes.append(oh.make_node('Unsqueeze', [X_name, '_axis1_const'], ['_x_exp']))
+    # Unsqueeze W -> (1, n_proto, features)
+    nodes.append(oh.make_node('Unsqueeze', [proto_name, '_axis0_const'], ['_w_exp']))
+
+    # |X - W|
+    nodes.append(oh.make_node('Sub', ['_x_exp', '_w_exp'], ['_diff']))
+    nodes.append(oh.make_node('Abs', ['_diff'], ['_abs_diff']))
+
+    # Sum over features axis=2
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_abs_diff', '_axis2_const'],
+        ['distances_manh'], keepdims=0,
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_axis0_const', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_axis1_const', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_axis2_const', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_manh'
+
+
+def _omega_onnx(builder, X_name, proto_name, omega_name):
+    """Omega distance: ||X@omega - W@omega||^2."""
+    import onnx.helper as oh
+
+    nodes = []
+    # Project: X_proj = X @ omega, W_proj = W @ omega
+    x_proj = '_om_x_proj'
+    w_proj = '_om_w_proj'
+    nodes.append(oh.make_node('MatMul', [X_name, omega_name], [x_proj]))
+    nodes.append(oh.make_node('MatMul', [proto_name, omega_name], [w_proj]))
+
+    # Squared euclidean on projected space
+    sq_nodes, sq_inits, sq_dist = _squared_euclidean_onnx(
+        builder, x_proj, w_proj
+    )
+    # Rename all internal names to avoid collision with top-level graph,
+    # but preserve references to the projection outputs.
+    preserve = {x_proj, w_proj}
+    for n in sq_nodes:
+        for i, out in enumerate(n.output):
+            n.output[i] = '_om' + out
+        for i, inp in enumerate(n.input):
+            if inp in preserve:
+                pass  # keep as-is
+            elif inp.startswith('_'):
+                n.input[i] = '_om' + inp
+
+    # Rename initializer tensor names to match renamed node inputs
+    renamed_inits = []
+    for init in sq_inits:
+        new_name = '_om' + init.name
+        renamed_inits.append(oh.make_tensor(
+            new_name, init.data_type, list(init.dims),
+            list(init.int64_data or init.float_data),
+        ))
+
+    nodes.extend(sq_nodes)
+    out_name = '_om' + sq_dist
+
+    return nodes, renamed_inits, out_name
+
+
+def _relevance_weighted_onnx(builder, X_name, proto_name, relevances_name):
+    r"""Relevance-weighted squared Euclidean: sum(lambda_j * (x_j - w_j)^2).
+
+    Parameters
+    ----------
+    relevances_name : str
+        Name of the (d,) relevance vector initializer.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+        Output shape: (batch, n_proto)
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Unsqueeze X -> (batch, 1, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [X_name, '_rw_axis1'], ['_rw_x_exp'],
+    ))
+    # Unsqueeze W -> (1, n_proto, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [proto_name, '_rw_axis0'], ['_rw_w_exp'],
+    ))
+
+    # diff = X - W -> (batch, n_proto, features)
+    nodes.append(oh.make_node('Sub', ['_rw_x_exp', '_rw_w_exp'], ['_rw_diff']))
+
+    # diff^2
+    nodes.append(oh.make_node('Mul', ['_rw_diff', '_rw_diff'], ['_rw_diff_sq']))
+
+    # weighted = relevances * diff^2  (relevances broadcasts as (1, 1, d))
+    nodes.append(oh.make_node(
+        'Mul', [relevances_name, '_rw_diff_sq'], ['_rw_weighted'],
+    ))
+
+    # sum over features axis=2
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_rw_weighted', '_rw_axis2'],
+        ['distances_rw'], keepdims=0,
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_rw_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_rw_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_rw_axis2', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_rw'
+
+
+def _local_omega_onnx(builder, X_name, proto_name, omegas_name):
+    r"""Local omega distance: ||Omega_k (x - w_k)||^2 for each prototype k.
+
+    Uses ONNX batched MatMul: (p, n, d) @ (p, d, l) -> (p, n, l).
+
+    Parameters
+    ----------
+    omegas_name : str
+        Name of the (p, d, l) per-prototype omega matrices initializer.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+        Output shape: (batch, n_proto)
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Unsqueeze X -> (batch, 1, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [X_name, '_lo_axis1'], ['_lo_x_exp'],
+    ))
+    # Unsqueeze W -> (1, n_proto, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [proto_name, '_lo_axis0'], ['_lo_w_exp'],
+    ))
+
+    # diff = X - W -> (batch, n_proto, features)
+    nodes.append(oh.make_node(
+        'Sub', ['_lo_x_exp', '_lo_w_exp'], ['_lo_diff'],
+    ))
+
+    # Transpose diff -> (n_proto, batch, features) for batched MatMul
+    nodes.append(oh.make_node(
+        'Transpose', ['_lo_diff'], ['_lo_diff_t'],
+        perm=[1, 0, 2],
+    ))
+
+    # Batched MatMul: (p, n, d) @ (p, d, l) -> (p, n, l)
+    nodes.append(oh.make_node(
+        'MatMul', ['_lo_diff_t', omegas_name], ['_lo_projected'],
+    ))
+
+    # projected^2
+    nodes.append(oh.make_node(
+        'Mul', ['_lo_projected', '_lo_projected'], ['_lo_proj_sq'],
+    ))
+
+    # ReduceSum over latent axis=2 -> (p, n)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_lo_proj_sq', '_lo_axis2'],
+        ['_lo_dist_t'], keepdims=0,
+    ))
+
+    # Transpose -> (n, p) = (batch, n_proto)
+    nodes.append(oh.make_node(
+        'Transpose', ['_lo_dist_t'], ['distances_lo'],
+        perm=[1, 0],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_lo_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_lo_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_lo_axis2', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_lo'
+
+
+def _tangent_onnx(builder, X_name, proto_name, omegas_name):
+    r"""Tangent distance: ||(I - Omega_k Omega_k^T)(x - w_k)||^2.
+
+    Computes the squared norm of the component of (x - w_k) orthogonal
+    to prototype k's tangent subspace.
+
+    Uses ONNX batched MatMul:
+      proj = (p,n,d) @ (p,d,s) -> (p,n,s)
+      recon = (p,n,s) @ (p,s,d) -> (p,n,d)
+      tang_diff = diff - recon
+
+    Parameters
+    ----------
+    omegas_name : str
+        Name of the (p, d, s) per-prototype orthonormal subspace bases.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+        Output shape: (batch, n_proto)
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Unsqueeze X -> (batch, 1, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [X_name, '_tg_axis1'], ['_tg_x_exp'],
+    ))
+    # Unsqueeze W -> (1, n_proto, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [proto_name, '_tg_axis0'], ['_tg_w_exp'],
+    ))
+
+    # diff = X - W -> (batch, n_proto, features)
+    nodes.append(oh.make_node(
+        'Sub', ['_tg_x_exp', '_tg_w_exp'], ['_tg_diff'],
+    ))
+
+    # Transpose diff -> (n_proto, batch, features)
+    nodes.append(oh.make_node(
+        'Transpose', ['_tg_diff'], ['_tg_diff_t'],
+        perm=[1, 0, 2],
+    ))
+
+    # Step 1: Project onto subspace
+    # proj = (p, n, d) @ (p, d, s) -> (p, n, s)
+    nodes.append(oh.make_node(
+        'MatMul', ['_tg_diff_t', omegas_name], ['_tg_proj'],
+    ))
+
+    # Step 2: Transpose omegas -> (p, s, d) for reconstruction
+    nodes.append(oh.make_node(
+        'Transpose', [omegas_name], ['_tg_omegas_T'],
+        perm=[0, 2, 1],
+    ))
+
+    # recon = (p, n, s) @ (p, s, d) -> (p, n, d)
+    nodes.append(oh.make_node(
+        'MatMul', ['_tg_proj', '_tg_omegas_T'], ['_tg_recon'],
+    ))
+
+    # Step 3: tang_diff = diff - recon (orthogonal complement)
+    nodes.append(oh.make_node(
+        'Sub', ['_tg_diff_t', '_tg_recon'], ['_tg_tang_diff'],
+    ))
+
+    # tang_diff^2
+    nodes.append(oh.make_node(
+        'Mul', ['_tg_tang_diff', '_tg_tang_diff'], ['_tg_tang_sq'],
+    ))
+
+    # ReduceSum over features axis=2 -> (p, n)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_tg_tang_sq', '_tg_axis2'],
+        ['_tg_dist_t'], keepdims=0,
+    ))
+
+    # Transpose -> (n, p) = (batch, n_proto)
+    nodes.append(oh.make_node(
+        'Transpose', ['_tg_dist_t'], ['distances_tg'],
+        perm=[1, 0],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_tg_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_tg_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_tg_axis2', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_tg'
+
+
+# ---------------------------------------------------------------------------
+# Competition / decision builders
+# ---------------------------------------------------------------------------
+
+def _wtac_onnx_nodes(dist_name, proto_labels_name):
+    """WTAC: predictions = proto_labels[argmin(distances, axis=1)]."""
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    # ArgMin over prototypes axis
+    nodes.append(oh.make_node(
+        'ArgMin', [dist_name], ['_winners'],
+        axis=1, keepdims=0,
+    ))
+    # Flatten winners for Gather
+    nodes.append(oh.make_node('Cast', ['_winners'], ['_winners_i64'], to=TensorProto.INT64))
+    # Gather labels
+    nodes.append(oh.make_node(
+        'Gather', [proto_labels_name, '_winners_i64'], ['predictions'],
+        axis=0,
+    ))
+    return nodes, []
+
+
+def _argmin_onnx_nodes(dist_name):
+    """Unsupervised: predictions = argmin(distances, axis=1)."""
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    nodes.append(oh.make_node(
+        'ArgMin', [dist_name], ['_predictions_raw'],
+        axis=1, keepdims=0,
+    ))
+    nodes.append(oh.make_node(
+        'Cast', ['_predictions_raw'], ['predictions'],
+        to=TensorProto.INT64,
+    ))
+    return nodes, []
+
+
+def _oc_hard_nearest_onnx(dist_name, model):
+    """One-class hard nearest decision.
+
+    decision_function:
+        nearest_idx = argmin(distances)
+        d_nearest = distances[nearest_idx]
+        theta_nearest = thetas[nearest_idx]
+        mu = (d - theta) / (d + theta + eps)
+        score = 1 - sigmoid(beta * mu)
+    predict:
+        score >= 0.5 -> target_label, else non_target_label
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    beta = float(model.beta)
+    target = int(model._target_label)
+    non_target = int(model._non_target_label)
+    thetas = np.asarray(model.thetas_).astype(np.float32)
+
+    # Constants
+    inits.extend([
+        oh.make_tensor('_oc_thetas', TensorProto.FLOAT,
+                        list(thetas.shape), thetas.flatten().tolist()),
+        oh.make_tensor('_oc_beta', TensorProto.FLOAT, [], [beta]),
+        oh.make_tensor('_oc_eps', TensorProto.FLOAT, [], [1e-10]),
+        oh.make_tensor('_oc_one', TensorProto.FLOAT, [], [1.0]),
+        oh.make_tensor('_oc_half', TensorProto.FLOAT, [], [0.5]),
+        oh.make_tensor('_oc_target', TensorProto.INT32, [], [target]),
+        oh.make_tensor('_oc_non_target', TensorProto.INT32, [], [non_target]),
+        oh.make_tensor('_oc_axis1', TensorProto.INT64, [1], [1]),
+    ])
+
+    # nearest_idx = ArgMin(distances, axis=1)  -> (n,)
+    nodes.append(oh.make_node(
+        'ArgMin', [dist_name], ['_oc_nearest_idx'],
+        axis=1, keepdims=0,
+    ))
+
+    # Cast to int64 for indexing
+    nodes.append(oh.make_node(
+        'Cast', ['_oc_nearest_idx'], ['_oc_nearest_i64'],
+        to=TensorProto.INT64,
+    ))
+
+    # d_nearest via GatherElements: need indices as (n, 1) for axis=1
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_oc_nearest_i64', '_oc_axis1'], ['_oc_idx_2d'],
+    ))
+    nodes.append(oh.make_node(
+        'GatherElements', [dist_name, '_oc_idx_2d'], ['_oc_d_2d'],
+        axis=1,
+    ))
+    # Squeeze back to (n,)
+    nodes.append(oh.make_node(
+        'Squeeze', ['_oc_d_2d', '_oc_axis1'], ['_oc_d_nearest'],
+    ))
+
+    # theta_nearest = Gather(thetas, nearest_idx)  -> (n,)
+    nodes.append(oh.make_node(
+        'Gather', ['_oc_thetas', '_oc_nearest_i64'], ['_oc_theta_nearest'],
+        axis=0,
+    ))
+
+    # mu = (d - theta) / (d + theta + eps)
+    nodes.append(oh.make_node(
+        'Sub', ['_oc_d_nearest', '_oc_theta_nearest'], ['_oc_num'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_oc_d_nearest', '_oc_theta_nearest'], ['_oc_den_raw'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_oc_den_raw', '_oc_eps'], ['_oc_den'],
+    ))
+    nodes.append(oh.make_node(
+        'Div', ['_oc_num', '_oc_den'], ['_oc_mu'],
+    ))
+
+    # score = 1 - sigmoid(beta * mu)
+    nodes.append(oh.make_node(
+        'Mul', ['_oc_beta', '_oc_mu'], ['_oc_beta_mu'],
+    ))
+    nodes.append(oh.make_node(
+        'Sigmoid', ['_oc_beta_mu'], ['_oc_sig'],
+    ))
+    nodes.append(oh.make_node(
+        'Sub', ['_oc_one', '_oc_sig'], ['_oc_score'],
+    ))
+
+    # predictions = Where(score >= 0.5, target, non_target)
+    nodes.append(oh.make_node(
+        'GreaterOrEqual', ['_oc_score', '_oc_half'], ['_oc_mask'],
+    ))
+    nodes.append(oh.make_node(
+        'Where', ['_oc_mask', '_oc_target', '_oc_non_target'], ['predictions'],
+    ))
+
+    return nodes, inits
+
+
+def _oc_gaussian_soft_onnx(dist_name, model):
+    """One-class Gaussian soft-weighted decision.
+
+    decision_function:
+        weights = softmax(-distances / (2*sigma^2))
+        mu_k = (distances - thetas) / (distances + thetas + eps)
+        weighted_mu = sum(weights * mu_k, axis=1)
+        score = 1 - sigmoid(beta * weighted_mu)
+    predict:
+        score >= 0.5 -> target_label, else non_target_label
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    beta = float(model.beta)
+    sigma = float(model.sigma)
+    target = int(model._target_label)
+    non_target = int(model._non_target_label)
+    thetas = np.asarray(model.thetas_).astype(np.float32)
+    two_sigma_sq = 2.0 * sigma * sigma
+
+    inits.extend([
+        oh.make_tensor('_gs_thetas', TensorProto.FLOAT,
+                        list(thetas.shape), thetas.flatten().tolist()),
+        oh.make_tensor('_gs_beta', TensorProto.FLOAT, [], [beta]),
+        oh.make_tensor('_gs_eps', TensorProto.FLOAT, [], [1e-10]),
+        oh.make_tensor('_gs_one', TensorProto.FLOAT, [], [1.0]),
+        oh.make_tensor('_gs_half', TensorProto.FLOAT, [], [0.5]),
+        oh.make_tensor('_gs_neg_inv_2s2', TensorProto.FLOAT, [],
+                        [-1.0 / two_sigma_sq]),
+        oh.make_tensor('_gs_target', TensorProto.INT32, [], [target]),
+        oh.make_tensor('_gs_non_target', TensorProto.INT32, [], [non_target]),
+        oh.make_tensor('_gs_axis1', TensorProto.INT64, [1], [1]),
+    ])
+
+    # Gaussian weights = softmax(-d / (2*sigma^2), axis=1)
+    nodes.append(oh.make_node(
+        'Mul', [dist_name, '_gs_neg_inv_2s2'], ['_gs_logits'],
+    ))
+    nodes.append(oh.make_node(
+        'Softmax', ['_gs_logits'], ['_gs_weights'],
+        axis=1,
+    ))
+
+    # Per-prototype mu_k = (d - theta) / (d + theta + eps)
+    # thetas broadcast: (K,) -> (1, K) via Unsqueeze
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_gs_thetas', '_gs_axis1'], ['_gs_thetas_r1'],
+    ))
+    # Reshape to row: remove batch dim from Unsqueeze result
+    # Actually Unsqueeze at axis=0 gives (1, K) — let's use axis=0
+    # We need (1, K) for broadcasting with (n, K) distances
+    # Fix: Unsqueeze thetas at axis=0 instead
+    inits.append(
+        oh.make_tensor('_gs_axis0', TensorProto.INT64, [1], [0]),
+    )
+    # Remove the axis=1 unsqueeze for thetas, use axis=0
+    nodes.pop()  # remove the wrong Unsqueeze
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_gs_thetas', '_gs_axis0'], ['_gs_thetas_2d'],
+    ))
+
+    nodes.append(oh.make_node(
+        'Sub', [dist_name, '_gs_thetas_2d'], ['_gs_num'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', [dist_name, '_gs_thetas_2d'], ['_gs_den_raw'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_gs_den_raw', '_gs_eps'], ['_gs_den'],
+    ))
+    nodes.append(oh.make_node(
+        'Div', ['_gs_num', '_gs_den'], ['_gs_mu_k'],
+    ))
+
+    # weighted_mu = sum(weights * mu_k, axis=1)
+    nodes.append(oh.make_node(
+        'Mul', ['_gs_weights', '_gs_mu_k'], ['_gs_w_mu'],
+    ))
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_gs_w_mu', '_gs_axis1'], ['_gs_weighted_mu'],
+        keepdims=0,
+    ))
+
+    # score = 1 - sigmoid(beta * weighted_mu)
+    nodes.append(oh.make_node(
+        'Mul', ['_gs_beta', '_gs_weighted_mu'], ['_gs_beta_mu'],
+    ))
+    nodes.append(oh.make_node(
+        'Sigmoid', ['_gs_beta_mu'], ['_gs_sig'],
+    ))
+    nodes.append(oh.make_node(
+        'Sub', ['_gs_one', '_gs_sig'], ['_gs_score'],
+    ))
+
+    # predictions
+    nodes.append(oh.make_node(
+        'GreaterOrEqual', ['_gs_score', '_gs_half'], ['_gs_mask'],
+    ))
+    nodes.append(oh.make_node(
+        'Where', ['_gs_mask', '_gs_target', '_gs_non_target'], ['predictions'],
+    ))
+
+    return nodes, inits
+
+
+def _oc_gaussian_ng_onnx(dist_name, model, n_proto):
+    """One-class Gaussian+NG soft-weighted decision.
+
+    Same as Gaussian Soft, but weights = Gaussian × NG rank weights
+    (normalized), using the converged gamma_.
+
+    NG rank weights:
+        order = argsort(distances)
+        ranks = argsort(order)  # inverse permutation
+        h = exp(-ranks / gamma)
+        h_norm = h / sum(h)
+    Combined: combined = gauss * h_norm (re-normalized)
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    beta = float(model.beta)
+    sigma = float(model.sigma)
+    gamma = float(model.gamma_)
+    target = int(model._target_label)
+    non_target = int(model._non_target_label)
+    thetas = np.asarray(model.thetas_).astype(np.float32)
+    two_sigma_sq = 2.0 * sigma * sigma
+    K = n_proto
+
+    # Range [0, 1, ..., K-1] for ScatterElements
+    range_K = np.arange(K, dtype=np.int64)
+
+    inits.extend([
+        oh.make_tensor('_gn_thetas', TensorProto.FLOAT,
+                        list(thetas.shape), thetas.flatten().tolist()),
+        oh.make_tensor('_gn_beta', TensorProto.FLOAT, [], [beta]),
+        oh.make_tensor('_gn_eps', TensorProto.FLOAT, [], [1e-10]),
+        oh.make_tensor('_gn_one', TensorProto.FLOAT, [], [1.0]),
+        oh.make_tensor('_gn_half', TensorProto.FLOAT, [], [0.5]),
+        oh.make_tensor('_gn_neg_inv_2s2', TensorProto.FLOAT, [],
+                        [-1.0 / two_sigma_sq]),
+        oh.make_tensor('_gn_neg_inv_gamma', TensorProto.FLOAT, [],
+                        [-1.0 / (gamma + 1e-10)]),
+        oh.make_tensor('_gn_target', TensorProto.INT32, [], [target]),
+        oh.make_tensor('_gn_non_target', TensorProto.INT32, [], [non_target]),
+        oh.make_tensor('_gn_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_gn_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_gn_K', TensorProto.INT64, [1], [K]),
+        oh.make_tensor('_gn_range_K', TensorProto.INT64, [K],
+                        range_K.tolist()),
+    ])
+
+    # --- Gaussian weights ---
+    nodes.append(oh.make_node(
+        'Mul', [dist_name, '_gn_neg_inv_2s2'], ['_gn_logits'],
+    ))
+    nodes.append(oh.make_node(
+        'Softmax', ['_gn_logits'], ['_gn_gauss'],
+        axis=1,
+    ))
+
+    # --- NG rank weights ---
+    # TopK to get argsort (ascending = smallest first)
+    nodes.append(oh.make_node(
+        'TopK', [dist_name, '_gn_K'], ['_gn_sorted_vals', '_gn_sorted_idx'],
+        largest=0, sorted=1,
+    ))
+
+    # Compute ranks via ScatterElements:
+    # ranks[i, sorted_idx[i,j]] = j
+    # Create (n, K) of zeros, then scatter range_K into it
+    # First, get the shape of distances for creating zeros
+    nodes.append(oh.make_node(
+        'Shape', [dist_name], ['_gn_dist_shape'],
+    ))
+    nodes.append(oh.make_node(
+        'ConstantOfShape', ['_gn_dist_shape'], ['_gn_zeros'],
+        value=oh.make_tensor('', TensorProto.INT64, [1], [0]),
+    ))
+
+    # Expand range_K to (n, K): first Unsqueeze to (1, K), then Expand
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_gn_range_K', '_gn_axis0'], ['_gn_range_2d'],
+    ))
+    nodes.append(oh.make_node(
+        'Expand', ['_gn_range_2d', '_gn_dist_shape'], ['_gn_range_expanded'],
+    ))
+
+    # ScatterElements: zeros[i, sorted_idx[i,j]] = range_expanded[i,j] = j
+    nodes.append(oh.make_node(
+        'ScatterElements', ['_gn_zeros', '_gn_sorted_idx', '_gn_range_expanded'],
+        ['_gn_ranks_i64'],
+        axis=1,
+    ))
+
+    # Cast ranks to float
+    nodes.append(oh.make_node(
+        'Cast', ['_gn_ranks_i64'], ['_gn_ranks'],
+        to=TensorProto.FLOAT,
+    ))
+
+    # h = exp(-ranks / gamma) = exp(ranks * neg_inv_gamma)
+    nodes.append(oh.make_node(
+        'Mul', ['_gn_ranks', '_gn_neg_inv_gamma'], ['_gn_h_logits'],
+    ))
+    nodes.append(oh.make_node(
+        'Exp', ['_gn_h_logits'], ['_gn_h'],
+    ))
+
+    # h_norm = h / sum(h, axis=1, keepdims=1)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_gn_h', '_gn_axis1'], ['_gn_h_sum'],
+        keepdims=1,
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_gn_h_sum', '_gn_eps'], ['_gn_h_sum_eps'],
+    ))
+    nodes.append(oh.make_node(
+        'Div', ['_gn_h', '_gn_h_sum_eps'], ['_gn_h_norm'],
+    ))
+
+    # --- Combined weights ---
+    nodes.append(oh.make_node(
+        'Mul', ['_gn_gauss', '_gn_h_norm'], ['_gn_combined_raw'],
+    ))
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_gn_combined_raw', '_gn_axis1'], ['_gn_comb_sum'],
+        keepdims=1,
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_gn_comb_sum', '_gn_eps'], ['_gn_comb_sum_eps'],
+    ))
+    nodes.append(oh.make_node(
+        'Div', ['_gn_combined_raw', '_gn_comb_sum_eps'], ['_gn_combined'],
+    ))
+
+    # --- Per-prototype mu_k ---
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_gn_thetas', '_gn_axis0'], ['_gn_thetas_2d'],
+    ))
+    nodes.append(oh.make_node(
+        'Sub', [dist_name, '_gn_thetas_2d'], ['_gn_num'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', [dist_name, '_gn_thetas_2d'], ['_gn_den_raw'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_gn_den_raw', '_gn_eps'], ['_gn_den'],
+    ))
+    nodes.append(oh.make_node(
+        'Div', ['_gn_num', '_gn_den'], ['_gn_mu_k'],
+    ))
+
+    # weighted_mu = sum(combined * mu_k, axis=1)
+    nodes.append(oh.make_node(
+        'Mul', ['_gn_combined', '_gn_mu_k'], ['_gn_w_mu'],
+    ))
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_gn_w_mu', '_gn_axis1'], ['_gn_weighted_mu'],
+        keepdims=0,
+    ))
+
+    # score = 1 - sigmoid(beta * weighted_mu)
+    nodes.append(oh.make_node(
+        'Mul', ['_gn_beta', '_gn_weighted_mu'], ['_gn_beta_mu'],
+    ))
+    nodes.append(oh.make_node(
+        'Sigmoid', ['_gn_beta_mu'], ['_gn_sig'],
+    ))
+    nodes.append(oh.make_node(
+        'Sub', ['_gn_one', '_gn_sig'], ['_gn_score'],
+    ))
+
+    # predictions
+    nodes.append(oh.make_node(
+        'GreaterOrEqual', ['_gn_score', '_gn_half'], ['_gn_mask'],
+    ))
+    nodes.append(oh.make_node(
+        'Where', ['_gn_mask', '_gn_target', '_gn_non_target'], ['predictions'],
+    ))
+
+    return nodes, inits
+
+
+def _svqocc_onnx(dist_name, model, n_proto):
+    """SVQ-OCC decision: response probability × Heaviside sigmoid.
+
+    decision_function:
+        if gaussian: p_k = softmax(-gamma_resp * distances)
+        elif student_t: p_k = normalize((1 + d/nu)^(-(nu+1)/2))
+        else: p_k = 1/K
+        heaviside = sigmoid((thetas - distances) / sigma)
+        score = clip(sum(p_k * heaviside), 0, 1)
+    predict:
+        score >= 0.5 -> target_label, else non_target_label
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    sigma = float(model.sigma)
+    target = int(model._target_label)
+    non_target = int(model._non_target_label)
+    thetas = np.asarray(model.thetas_).astype(np.float32)
+    response_type = model.response_type
+    K = n_proto
+
+    inits.extend([
+        oh.make_tensor('_sv_thetas', TensorProto.FLOAT,
+                        list(thetas.shape), thetas.flatten().tolist()),
+        oh.make_tensor('_sv_inv_sigma', TensorProto.FLOAT, [],
+                        [1.0 / (sigma + 1e-10)]),
+        oh.make_tensor('_sv_zero', TensorProto.FLOAT, [], [0.0]),
+        oh.make_tensor('_sv_one', TensorProto.FLOAT, [], [1.0]),
+        oh.make_tensor('_sv_half', TensorProto.FLOAT, [], [0.5]),
+        oh.make_tensor('_sv_target', TensorProto.INT32, [], [target]),
+        oh.make_tensor('_sv_non_target', TensorProto.INT32, [], [non_target]),
+        oh.make_tensor('_sv_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_sv_axis1', TensorProto.INT64, [1], [1]),
+    ])
+
+    # --- Response probability p_k ---
+    if response_type == 'gaussian':
+        gamma_resp = float(model.gamma_resp)
+        inits.append(
+            oh.make_tensor('_sv_neg_gamma', TensorProto.FLOAT, [],
+                            [-gamma_resp]),
+        )
+        nodes.append(oh.make_node(
+            'Mul', [dist_name, '_sv_neg_gamma'], ['_sv_resp_logits'],
+        ))
+        nodes.append(oh.make_node(
+            'Softmax', ['_sv_resp_logits'], ['_sv_p_k'],
+            axis=1,
+        ))
+    elif response_type == 'student_t':
+        nu = float(model.nu)
+        exponent = -(nu + 1.0) / 2.0
+        inits.extend([
+            oh.make_tensor('_sv_inv_nu', TensorProto.FLOAT, [], [1.0 / nu]),
+            oh.make_tensor('_sv_exponent', TensorProto.FLOAT, [], [exponent]),
+            oh.make_tensor('_sv_eps', TensorProto.FLOAT, [], [1e-10]),
+        ])
+        # (1 + d/nu)
+        nodes.append(oh.make_node(
+            'Mul', [dist_name, '_sv_inv_nu'], ['_sv_d_over_nu'],
+        ))
+        nodes.append(oh.make_node(
+            'Add', ['_sv_one', '_sv_d_over_nu'], ['_sv_base'],
+        ))
+        # base^exponent
+        nodes.append(oh.make_node(
+            'Pow', ['_sv_base', '_sv_exponent'], ['_sv_p_unnorm'],
+        ))
+        # normalize
+        nodes.append(oh.make_node(
+            'ReduceSum', ['_sv_p_unnorm', '_sv_axis1'], ['_sv_p_sum'],
+            keepdims=1,
+        ))
+        nodes.append(oh.make_node(
+            'Add', ['_sv_p_sum', '_sv_eps'], ['_sv_p_sum_eps'],
+        ))
+        nodes.append(oh.make_node(
+            'Div', ['_sv_p_unnorm', '_sv_p_sum_eps'], ['_sv_p_k'],
+        ))
+    else:  # uniform
+        inv_K = 1.0 / K
+        inits.append(
+            oh.make_tensor('_sv_inv_K', TensorProto.FLOAT, [], [inv_K]),
+        )
+        # Broadcast scalar to (n, K) via Mul with ones-like distances
+        # Use: p_k = distances * 0 + inv_K (broadcasts correctly)
+        nodes.append(oh.make_node(
+            'Mul', [dist_name, '_sv_zero'], ['_sv_zeros_nk'],
+        ))
+        nodes.append(oh.make_node(
+            'Add', ['_sv_zeros_nk', '_sv_inv_K'], ['_sv_p_k'],
+        ))
+
+    # --- Heaviside sigmoid ---
+    # heaviside = sigmoid((thetas - distances) / sigma)
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_sv_thetas', '_sv_axis0'], ['_sv_thetas_2d'],
+    ))
+    nodes.append(oh.make_node(
+        'Sub', ['_sv_thetas_2d', dist_name], ['_sv_theta_minus_d'],
+    ))
+    nodes.append(oh.make_node(
+        'Mul', ['_sv_theta_minus_d', '_sv_inv_sigma'], ['_sv_heav_input'],
+    ))
+    nodes.append(oh.make_node(
+        'Sigmoid', ['_sv_heav_input'], ['_sv_heaviside'],
+    ))
+
+    # --- Responsibility = p_k * heaviside ---
+    nodes.append(oh.make_node(
+        'Mul', ['_sv_p_k', '_sv_heaviside'], ['_sv_responsibility'],
+    ))
+
+    # --- Score = clip(sum(responsibility, axis=1), 0, 1) ---
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_sv_responsibility', '_sv_axis1'], ['_sv_raw_score'],
+        keepdims=0,
+    ))
+    nodes.append(oh.make_node(
+        'Clip', ['_sv_raw_score', '_sv_zero', '_sv_one'], ['_sv_score'],
+    ))
+
+    # --- Predictions ---
+    nodes.append(oh.make_node(
+        'GreaterOrEqual', ['_sv_score', '_sv_half'], ['_sv_mask'],
+    ))
+    nodes.append(oh.make_node(
+        'Where', ['_sv_mask', '_sv_target', '_sv_non_target'], ['predictions'],
+    ))
+
+    return nodes, inits
+
+
+def _cbc_onnx(dist_name, model):
+    """CBC reasoning decision.
+
+    decision:
+        detections = exp(-distances / (2 * sigma^2))
+        A = clip(reasonings[:, :, 0], 0, 1)
+        B = clip(reasonings[:, :, 1], 0, 1)
+        pk = A, nk = (1 - A) * B
+        probs = (detections @ (pk - nk) + sum(nk)) / (sum(pk + nk) + eps)
+        predictions = argmax(probs, axis=1)
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    sigma_sq = float(model.sigma) ** 2
+
+    # Pre-compute CBC reasoning constants
+    reasonings = np.asarray(model.reasonings_, dtype=np.float32)
+    A = np.clip(reasonings[:, :, 0], 0, 1)
+    B = np.clip(reasonings[:, :, 1], 0, 1)
+    pk = A
+    nk = (1.0 - A) * B
+    pk_minus_nk = (pk - nk).astype(np.float32)      # (n_comp, n_classes)
+    sum_nk = np.sum(nk, axis=0).astype(np.float32)   # (n_classes,)
+    denom = (np.sum(pk + nk, axis=0) + 1e-8).astype(np.float32)
+
+    inits.extend([
+        oh.make_tensor('_cbc_scale', TensorProto.FLOAT, [],
+                        [-1.0 / (2.0 * sigma_sq)]),
+        oh.make_tensor('_cbc_pk_nk', TensorProto.FLOAT,
+                        list(pk_minus_nk.shape),
+                        pk_minus_nk.flatten().tolist()),
+        oh.make_tensor('_cbc_sum_nk', TensorProto.FLOAT,
+                        list(sum_nk.shape), sum_nk.flatten().tolist()),
+        oh.make_tensor('_cbc_denom', TensorProto.FLOAT,
+                        list(denom.shape), denom.flatten().tolist()),
+    ])
+
+    # Gaussian similarity: detections = exp(-d / (2*sigma^2))
+    nodes.append(oh.make_node(
+        'Mul', [dist_name, '_cbc_scale'], ['_cbc_logits'],
+    ))
+    nodes.append(oh.make_node(
+        'Exp', ['_cbc_logits'], ['_cbc_detections'],
+    ))
+
+    # numerator = detections @ (pk - nk) + sum(nk)
+    nodes.append(oh.make_node(
+        'MatMul', ['_cbc_detections', '_cbc_pk_nk'], ['_cbc_matmul'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_cbc_matmul', '_cbc_sum_nk'], ['_cbc_numerator'],
+    ))
+
+    # probs = numerator / denominator
+    nodes.append(oh.make_node(
+        'Div', ['_cbc_numerator', '_cbc_denom'], ['_cbc_probs'],
+    ))
+
+    # predictions = argmax(probs, axis=1)
+    nodes.append(oh.make_node(
+        'ArgMax', ['_cbc_probs'], ['_cbc_preds_raw'],
+        axis=1, keepdims=0,
+    ))
+    nodes.append(oh.make_node(
+        'Cast', ['_cbc_preds_raw'], ['predictions'],
+        to=TensorProto.INT64,
+    ))
+
+    return nodes, inits
+
+
+def _plvq_onnx(dist_name, model):
+    """PLVQ Gaussian mixture soft assignment decision.
+
+    decision:
+        logits = -distances / (2 * sigma^2)
+        probs = softmax(logits, axis=1)
+        class_probs = probs @ class_mask   (aggregate per class)
+        predictions = argmax(class_probs, axis=1)
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    sigma_sq = float(model.sigma) ** 2
+    proto_labels = np.asarray(model.prototype_labels_, dtype=np.int64)
+    n_proto = len(proto_labels)
+    n_classes = int(model.n_classes_)
+
+    # Pre-compute class mask: M[j, c] = 1 if prototype j belongs to class c
+    class_mask = np.zeros((n_proto, n_classes), dtype=np.float32)
+    for j, c in enumerate(proto_labels):
+        class_mask[j, int(c)] = 1.0
+
+    inits.extend([
+        oh.make_tensor('_plvq_scale', TensorProto.FLOAT, [],
+                        [-1.0 / (2.0 * sigma_sq)]),
+        oh.make_tensor('_plvq_mask', TensorProto.FLOAT,
+                        list(class_mask.shape),
+                        class_mask.flatten().tolist()),
+    ])
+
+    # logits = -d / (2*sigma^2)
+    nodes.append(oh.make_node(
+        'Mul', [dist_name, '_plvq_scale'], ['_plvq_logits'],
+    ))
+
+    # probs = softmax(logits, axis=1)
+    nodes.append(oh.make_node(
+        'Softmax', ['_plvq_logits'], ['_plvq_probs'],
+        axis=1,
+    ))
+
+    # class_probs = probs @ class_mask  -> (batch, n_classes)
+    nodes.append(oh.make_node(
+        'MatMul', ['_plvq_probs', '_plvq_mask'], ['_plvq_class_probs'],
+    ))
+
+    # predictions = argmax(class_probs, axis=1)
+    nodes.append(oh.make_node(
+        'ArgMax', ['_plvq_class_probs'], ['_plvq_preds_raw'],
+        axis=1, keepdims=0,
+    ))
+    nodes.append(oh.make_node(
+        'Cast', ['_plvq_preds_raw'], ['predictions'],
+        to=TensorProto.INT64,
+    ))
+
+    return nodes, inits
+
+
+# ---------------------------------------------------------------------------
+# Model type and distance identification
+# ---------------------------------------------------------------------------
+
+def _identify_model_type(model):
+    """Identify the model type and distance function for ONNX export.
+
+    Returns
+    -------
+    model_type : str
+        One of 'supervised', 'unsupervised', 'oc_hard_nearest',
+        'oc_gaussian_soft', 'oc_gaussian_ng', 'svqocc', 'cbc', 'plvq'.
+    dist_type : str
+        One of 'squared_euclidean', 'euclidean', 'manhattan', 'omega',
+        'relevance', 'local_omega', 'tangent'.
+    """
+    # --- Determine model type ---
+
+    has_encoder = (
+        hasattr(model, 'backbone_params_')
+        and model.backbone_params_ is not None
+    )
+
+    # Encoder models: detect first (before OC/supervised checks)
+    if has_encoder:
+        # ImageCBC: encoder + CBC reasoning
+        if (hasattr(model, 'components_') and model.components_ is not None
+                and hasattr(model, 'reasonings_')
+                and model.reasonings_ is not None):
+            model_type = 'cbc'
+        # PLVQ: encoder + Gaussian mixture (unique: has loss_type)
+        elif hasattr(model, 'loss_type'):
+            model_type = 'plvq'
+        # Siamese*, Image*, LVQMLN: encoder + WTAC
+        else:
+            model_type = 'supervised'
+        dist_type = _identify_distance_fn(model, model_type)
+        return model_type, dist_type
+
+    # CBC (non-encoder): has reasonings_ but no backbone_params_
+    if (hasattr(model, 'reasonings_') and model.reasonings_ is not None
+            and hasattr(model, 'components_')
+            and model.components_ is not None):
+        dist_type = _identify_distance_fn(model, 'cbc')
+        return 'cbc', dist_type
+
+    # SVQ-OCC: unique response_type attribute
+    is_svqocc = hasattr(model, 'response_type') and hasattr(model, 'gamma_resp')
+
+    # One-class models: all have thetas_ (learned thresholds)
+    has_thetas = (
+        hasattr(model, 'thetas_') and model.thetas_ is not None
+    )
+
+    if is_svqocc:
+        model_type = 'svqocc'
+    elif has_thetas:
+        # Distinguish OC decision patterns by sigma and gamma_
+        has_sigma = hasattr(model, 'sigma') and not is_svqocc
+        has_gamma = hasattr(model, 'gamma_') and model.gamma_ is not None
+        if has_sigma and has_gamma:
+            model_type = 'oc_gaussian_ng'
+        elif has_sigma:
+            model_type = 'oc_gaussian_soft'
+        else:
+            model_type = 'oc_hard_nearest'
+    else:
+        # Supervised or unsupervised (existing logic)
+        has_labels = (
+            hasattr(model, 'prototype_labels_')
+            and model.prototype_labels_ is not None
+        )
+        model_type = 'supervised' if has_labels else 'unsupervised'
+
+    # --- Determine distance type ---
+    dist_type = _identify_distance_fn(model, model_type)
+
+    return model_type, dist_type
+
+
+def _identify_distance_fn(model, model_type='supervised') -> str:
+    """Identify which distance function a model uses.
+
+    For OC and SVQ-OCC models, distance is detected from learned
+    metric parameters (omega_, omegas_, relevances_).  For supervised
+    and unsupervised models, distance is detected from the distance_fn
+    attribute.
+    """
+    # --- Attribute-based detection (OC, SVQ-OCC, and supervised metric models) ---
+
+    # Tangent vs local omega: tangent models have subspace_dim
+    has_omegas = hasattr(model, 'omegas_') and model.omegas_ is not None
+    is_tangent = has_omegas and hasattr(model, 'subspace_dim')
+
+    if is_tangent:
+        return 'tangent'
+    if has_omegas:
+        return 'local_omega'
+
+    # Global omega
+    if hasattr(model, 'omega_') and model.omega_ is not None:
+        return 'omega'
+
+    # Relevance-weighted (GRLVQ family)
+    if hasattr(model, 'relevances_') and model.relevances_ is not None:
+        return 'relevance'
+
+    # For OC/SVQ-OCC/CBC/PLVQ models without metric params,
+    # default to squared_euclidean
+    if model_type in ('oc_hard_nearest', 'oc_gaussian_soft',
+                       'oc_gaussian_ng', 'svqocc', 'cbc', 'plvq'):
+        return 'squared_euclidean'
+
+    # Encoder models without explicit distance_fn: default to squared_euclidean
+    if (hasattr(model, 'backbone_params_')
+            and model.backbone_params_ is not None):
+        return 'squared_euclidean'
+
+    # --- Function-based detection (supervised/unsupervised models) ---
+    from prosemble.core.distance import (
+        squared_euclidean_distance_matrix,
+        euclidean_distance_matrix,
+        manhattan_distance_matrix,
+    )
+
+    fn = model.distance_fn
+
+    _known = {
+        squared_euclidean_distance_matrix: 'squared_euclidean',
+        euclidean_distance_matrix: 'euclidean',
+        manhattan_distance_matrix: 'manhattan',
+    }
+
+    for known_fn, name in _known.items():
+        if fn is known_fn:
+            return name
+
+    if hasattr(fn, 'func'):
+        from prosemble.core.distance import omega_distance_matrix
+        if fn.func is omega_distance_matrix:
+            return 'omega'
+
+    fn_name = getattr(fn, '__name__', '') or getattr(fn, '__wrapped__', '')
+    if 'squared_euclidean' in str(fn_name):
+        return 'squared_euclidean'
+    if 'euclidean' in str(fn_name) and 'squared' not in str(fn_name):
+        return 'euclidean'
+    if 'manhattan' in str(fn_name):
+        return 'manhattan'
+    if 'omega_distance_matrix' in str(fn_name):
+        return 'omega'
+
+    raise NotImplementedError(
+        f"ONNX export is not supported for distance function "
+        f"'{fn_name or fn}'. Supported: squared_euclidean, euclidean, "
+        f"manhattan, omega, relevance, local_omega, tangent."
+    )
+
+
+def _check_model_exportable(model):
+    """Check if a model can be exported to ONNX.
+
+    Raises NotImplementedError for models that cannot be converted.
+    """
+    # Riemannian models: manifold ops have no ONNX equivalent
+    from prosemble.models.riemannian_srng import RiemannianSRNG
+    if isinstance(model, RiemannianSRNG):
+        raise NotImplementedError(
+            "ONNX export is not supported for Riemannian models. "
+            "Manifold operations (logm, expm) have no ONNX equivalent."
+        )
+
+    try:
+        from prosemble.models.riemannian_neural_gas import RiemannianNeuralGas
+        if isinstance(model, RiemannianNeuralGas):
+            raise NotImplementedError(
+                "ONNX export is not supported for RiemannianNeuralGas. "
+                "Manifold operations have no ONNX equivalent."
+            )
+    except ImportError:
+        pass
+
+    # Kernel fuzzy clustering models
+    if hasattr(model, 'sigma') and hasattr(model, 'centroids_'):
+        raise NotImplementedError(
+            "ONNX export is not supported for kernel fuzzy clustering "
+            "models. Kernel distance (Gaussian kernel) has no standard "
+            "ONNX equivalent."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def export_onnx(
+    model: Any,
+    batch_size: int = 1,
+    opset_version: int = 17,
+    path: str | None = None,
+):
+    """Export a fitted model's predict function to ONNX format.
+
+    Builds an ONNX graph that reproduces the model's ``predict()``
+    output.  Supports supervised (WTAC), unsupervised (ArgMin),
+    one-class (threshold-based), SVQ-OCC (response model), CBC
+    (reasoning matrices), PLVQ (Gaussian mixture), and encoder
+    models (MLP/CNN backbone).
+
+    Parameters
+    ----------
+    model : SupervisedPrototypeModel or UnsupervisedPrototypeModel
+        A fitted prosemble model.
+    batch_size : int
+        Fixed batch dimension for the input.  Use ``-1`` for dynamic
+        batch size (ONNX symbolic dimension).
+    opset_version : int
+        ONNX opset version.  Default: 17.
+    path : str, optional
+        If provided, save the ONNX model to this file path.
+
+    Returns
+    -------
+    onnx.ModelProto
+        The exported ONNX model.
+
+    Raises
+    ------
+    NotImplementedError
+        If the model's distance function or decision pattern is not
+        supported.
+    ImportError
+        If the ``onnx`` package is not installed.
+    """
+    _check_onnx_installed()
+    import onnx
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    model._check_fitted()
+    _check_model_exportable(model)
+
+    # Identify model type and distance
+    model_type, dist_type = _identify_model_type(model)
+
+    # Check for encoder (MLP/CNN backbone)
+    has_encoder = (
+        hasattr(model, 'backbone_params_')
+        and model.backbone_params_ is not None
+    )
+    is_cnn = has_encoder and isinstance(model.backbone_params_, dict)
+
+    # Input shape
+    batch_dim = batch_size if batch_size > 0 else 'batch'
+
+    all_nodes = []
+    initializers = []
+
+    if has_encoder:
+        # --- Encoder model path ---
+
+        # Determine input dimension
+        if is_cnn:
+            n_input_features = int(np.prod(model.input_shape))
+        else:
+            n_input_features = int(
+                np.asarray(model.backbone_params_[0][0]).shape[0]
+            )
+        input_shape = [batch_dim, n_input_features]
+
+        # Build encoder ONNX nodes
+        if is_cnn:
+            enc_nodes, enc_inits, enc_out = _cnn_encoder_onnx(
+                'X', model.backbone_params_, model.input_shape,
+                model.activation,
+            )
+        else:
+            enc_nodes, enc_inits, enc_out = _mlp_encoder_onnx(
+                'X', model.backbone_params_, model.activation,
+            )
+        all_nodes.extend(enc_nodes)
+        initializers.extend(enc_inits)
+
+        # Pre-compute latent prototypes/components
+        model_name = type(model).__name__
+        proto_need_encoding = (
+            model_name.startswith('Siamese')
+            or model_name.startswith('Image')
+        )
+
+        if model_type == 'cbc':
+            # CBC models use components_
+            comps = np.asarray(model.components_, dtype=np.float32)
+            if proto_need_encoding:
+                if is_cnn:
+                    comps_img = comps.reshape(-1, *model.input_shape)
+                    latent_protos = _cnn_forward_np(
+                        model.backbone_params_, comps_img, model.activation,
+                    )
+                else:
+                    latent_protos = _mlp_forward_np(
+                        model.backbone_params_, comps, model.activation,
+                    )
+            else:
+                latent_protos = comps
+        elif proto_need_encoding:
+            protos = np.asarray(model.prototypes_, dtype=np.float32)
+            if is_cnn:
+                protos_img = protos.reshape(-1, *model.input_shape)
+                latent_protos = _cnn_forward_np(
+                    model.backbone_params_, protos_img, model.activation,
+                )
+            else:
+                latent_protos = _mlp_forward_np(
+                    model.backbone_params_, protos, model.activation,
+                )
+        else:
+            # LVQMLN/PLVQ: prototypes already in latent space
+            latent_protos = np.asarray(model.prototypes_, dtype=np.float32)
+
+        latent_protos = latent_protos.astype(np.float32)
+        n_proto = latent_protos.shape[0]
+        X_for_distance = enc_out
+
+    else:
+        # --- Non-encoder model path ---
+        prototypes = np.asarray(model.prototypes_, dtype=np.float32)
+        n_proto, n_features = prototypes.shape
+        input_shape = [batch_dim, n_features]
+        latent_protos = prototypes
+        X_for_distance = 'X'
+
+    # --- Prototypes initializer ---
+    initializers.append(
+        oh.make_tensor(
+            'prototypes', TensorProto.FLOAT,
+            list(latent_protos.shape), latent_protos.flatten().tolist(),
+        ),
+    )
+
+    # Prototype labels for supervised models
+    has_labels = (
+        model_type == 'supervised'
+        and hasattr(model, 'prototype_labels_')
+        and model.prototype_labels_ is not None
+    )
+    if has_labels:
+        proto_labels = np.asarray(model.prototype_labels_).astype(np.int64)
+        initializers.append(
+            oh.make_tensor(
+                'proto_labels', TensorProto.INT64,
+                list(proto_labels.shape), proto_labels.flatten().tolist(),
+            ),
+        )
+
+    # --- Distance nodes ---
+    if dist_type == 'squared_euclidean':
+        nodes, extra_inits, dist_out = _squared_euclidean_onnx(
+            None, X_for_distance, 'prototypes',
+        )
+    elif dist_type == 'euclidean':
+        nodes, extra_inits, dist_out = _euclidean_onnx(
+            None, X_for_distance, 'prototypes',
+        )
+    elif dist_type == 'manhattan':
+        nodes, extra_inits, dist_out = _manhattan_onnx(
+            None, X_for_distance, 'prototypes',
+        )
+    elif dist_type == 'omega':
+        omega = np.asarray(model.omega_, dtype=np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'omega', TensorProto.FLOAT,
+                list(omega.shape), omega.flatten().tolist(),
+            ),
+        )
+        nodes, extra_inits, dist_out = _omega_onnx(
+            None, X_for_distance, 'prototypes', 'omega',
+        )
+    elif dist_type == 'relevance':
+        relevances = np.asarray(model.relevances_).astype(np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'relevances', TensorProto.FLOAT,
+                list(relevances.shape), relevances.flatten().tolist(),
+            ),
+        )
+        nodes, extra_inits, dist_out = _relevance_weighted_onnx(
+            None, X_for_distance, 'prototypes', 'relevances',
+        )
+    elif dist_type == 'local_omega':
+        omegas = np.asarray(model.omegas_).astype(np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'omegas', TensorProto.FLOAT,
+                list(omegas.shape), omegas.flatten().tolist(),
+            ),
+        )
+        nodes, extra_inits, dist_out = _local_omega_onnx(
+            None, X_for_distance, 'prototypes', 'omegas',
+        )
+    elif dist_type == 'tangent':
+        omegas = np.asarray(model.omegas_).astype(np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'omegas', TensorProto.FLOAT,
+                list(omegas.shape), omegas.flatten().tolist(),
+            ),
+        )
+        nodes, extra_inits, dist_out = _tangent_onnx(
+            None, X_for_distance, 'prototypes', 'omegas',
+        )
+    else:
+        raise NotImplementedError(f"Unknown distance type: {dist_type}")
+
+    all_nodes.extend(nodes)
+    initializers.extend(extra_inits)
+
+    # --- Decision / competition nodes ---
+    if model_type == 'supervised':
+        comp_nodes, comp_inits = _wtac_onnx_nodes(dist_out, 'proto_labels')
+    elif model_type == 'unsupervised':
+        comp_nodes, comp_inits = _argmin_onnx_nodes(dist_out)
+    elif model_type == 'oc_hard_nearest':
+        comp_nodes, comp_inits = _oc_hard_nearest_onnx(dist_out, model)
+    elif model_type == 'oc_gaussian_soft':
+        comp_nodes, comp_inits = _oc_gaussian_soft_onnx(dist_out, model)
+    elif model_type == 'oc_gaussian_ng':
+        comp_nodes, comp_inits = _oc_gaussian_ng_onnx(
+            dist_out, model, n_proto,
+        )
+    elif model_type == 'svqocc':
+        comp_nodes, comp_inits = _svqocc_onnx(dist_out, model, n_proto)
+    elif model_type == 'cbc':
+        comp_nodes, comp_inits = _cbc_onnx(dist_out, model)
+    elif model_type == 'plvq':
+        comp_nodes, comp_inits = _plvq_onnx(dist_out, model)
+    else:
+        raise NotImplementedError(f"Unknown model type: {model_type}")
+
+    all_nodes.extend(comp_nodes)
+    initializers.extend(comp_inits)
+
+    # --- Output dtype ---
+    # OC and SVQ-OCC models output int32 (matching JAX astype(jnp.int32))
+    if model_type in ('oc_hard_nearest', 'oc_gaussian_soft',
+                       'oc_gaussian_ng', 'svqocc'):
+        output_dtype = TensorProto.INT32
+    else:
+        output_dtype = TensorProto.INT64
+
+    # --- Build graph ---
+    X_input = oh.make_tensor_value_info('X', TensorProto.FLOAT, input_shape)
+    Y_output = oh.make_tensor_value_info(
+        'predictions', output_dtype, [batch_dim],
+    )
+
+    graph = oh.make_graph(
+        all_nodes,
+        'prosemble_predict',
+        [X_input],
+        [Y_output],
+        initializer=initializers,
+    )
+
+    onnx_model = oh.make_model(graph, opset_imports=[
+        oh.make_opsetid('', opset_version),
+    ])
+    onnx_model.ir_version = 8
+
+    onnx_model.doc_string = (
+        f"Prosemble {type(model).__name__} predict function. "
+        f"Distance: {dist_type}, decision: {model_type}."
+    )
+
+    onnx.checker.check_model(onnx_model)
+
+    if path is not None:
+        onnx.save(onnx_model, path)
+
+    return onnx_model

--- a/prosemble/core/protocols.py
+++ b/prosemble/core/protocols.py
@@ -1,0 +1,216 @@
+"""
+Structural typing protocols for prosemble interfaces.
+
+Defines ``typing.Protocol`` contracts for duck-typed interfaces used
+across the library.  These enable static type checking (mypy / pyright)
+and IDE auto-completion without requiring inheritance.
+
+.. note::
+
+   Runtime-checkable protocols (``Manifold``, ``CallbackLike``) support
+   ``isinstance()`` checks.  Type aliases (``DistanceMatrixFn``, etc.)
+   are for annotation only.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    Any,
+    Callable,
+    Protocol,
+    Tuple,
+    runtime_checkable,
+)
+
+import jax
+import jax.numpy as jnp
+
+
+# ---------------------------------------------------------------------------
+# Manifold protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class Manifold(Protocol):
+    """Protocol for Riemannian manifold implementations.
+
+    Any object exposing the methods below can be used wherever a manifold
+    is expected (e.g. ``RiemannianNeuralGas``, ``RiemannianSRNG``).
+
+    The concrete implementations :class:`~prosemble.core.manifolds.SO`,
+    :class:`~prosemble.core.manifolds.SPD`, and
+    :class:`~prosemble.core.manifolds.Grassmannian` all satisfy this
+    protocol structurally — no explicit subclassing is required.
+    """
+
+    @property
+    def point_shape(self) -> Tuple[int, ...]:
+        """Shape of a single point on the manifold."""
+        ...
+
+    def distance(self, p: jnp.ndarray, q: jnp.ndarray) -> jnp.ndarray:
+        """Geodesic distance between two points.
+
+        Parameters
+        ----------
+        p, q : arrays of shape ``point_shape``
+
+        Returns
+        -------
+        scalar
+        """
+        ...
+
+    def distance_squared(self, p: jnp.ndarray, q: jnp.ndarray) -> jnp.ndarray:
+        """Squared geodesic distance between two points.
+
+        Parameters
+        ----------
+        p, q : arrays of shape ``point_shape``
+
+        Returns
+        -------
+        scalar
+        """
+        ...
+
+    def log_map(self, base: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
+        """Logarithmic map: tangent vector at *base* pointing toward *target*.
+
+        Parameters
+        ----------
+        base : array of shape ``point_shape``
+            Base point on the manifold.
+        target : array of shape ``point_shape``
+            Target point on the manifold.
+
+        Returns
+        -------
+        tangent : array of shape ``point_shape``
+            Tangent vector in :math:`T_{\\text{base}} M`.
+        """
+        ...
+
+    def exp_map(self, base: jnp.ndarray, tangent: jnp.ndarray) -> jnp.ndarray:
+        """Exponential map: move along *tangent* from *base* back to the manifold.
+
+        Parameters
+        ----------
+        base : array of shape ``point_shape``
+        tangent : array of shape ``point_shape``
+
+        Returns
+        -------
+        point : array of shape ``point_shape``
+        """
+        ...
+
+    def random_point(self, key: jax.Array) -> jnp.ndarray:
+        """Sample a random point on the manifold.
+
+        Parameters
+        ----------
+        key : JAX PRNG key
+
+        Returns
+        -------
+        point : array of shape ``point_shape``
+        """
+        ...
+
+    def belongs(self, point: jnp.ndarray) -> jnp.ndarray:
+        """Check whether *point* lies on the manifold.
+
+        Parameters
+        ----------
+        point : array of shape ``point_shape``
+
+        Returns
+        -------
+        bool or bool-valued array
+        """
+        ...
+
+    def project(self, point: jnp.ndarray) -> jnp.ndarray:
+        """Project an off-manifold point to the nearest point on the manifold.
+
+        Parameters
+        ----------
+        point : array of shape ``point_shape``
+
+        Returns
+        -------
+        projected : array of shape ``point_shape``
+        """
+        ...
+
+    def injectivity_radius(self, point: jnp.ndarray) -> float:
+        """Injectivity radius at *point*.
+
+        The maximum geodesic distance for which the logarithmic map
+        is injective.
+
+        Parameters
+        ----------
+        point : array of shape ``point_shape``
+
+        Returns
+        -------
+        radius : float or scalar array
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Callback protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class CallbackLike(Protocol):
+    """Protocol for training callbacks.
+
+    Any object with the three hook methods below can be passed in the
+    ``callbacks`` list of a model's constructor.  The existing
+    :class:`~prosemble.core.callbacks.Callback` base class already
+    satisfies this protocol.
+    """
+
+    def on_fit_start(self, model: Any, X: jnp.ndarray) -> None:
+        """Called once before training begins."""
+        ...
+
+    def on_iteration_end(self, model: Any, info: dict) -> None:
+        """Called after each training iteration / epoch."""
+        ...
+
+    def on_fit_end(self, model: Any, info: dict) -> None:
+        """Called once after training ends."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Type aliases for callable interfaces
+# ---------------------------------------------------------------------------
+
+#: Distance-matrix function: ``(X, Y) -> distances``.
+#: ``X`` has shape ``(n_samples, n_features)``,
+#: ``Y`` has shape ``(n_prototypes, n_features)``,
+#: result has shape ``(n_samples, n_prototypes)``.
+DistanceMatrixFn = Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
+
+#: Pairwise distance function: ``(x, y) -> scalar``.
+DistancePairwiseFn = Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
+
+#: Supervised prototype initializer:
+#: ``(X, y, n_per_class, key) -> (prototypes, prototype_labels)``.
+SupervisedInitFn = Callable[
+    [jnp.ndarray, jnp.ndarray, int, jax.Array],
+    Tuple[jnp.ndarray, jnp.ndarray],
+]
+
+#: Unsupervised prototype initializer:
+#: ``(X, n_prototypes, key) -> prototypes``.
+UnsupervisedInitFn = Callable[
+    [jnp.ndarray, int, jax.Array],
+    jnp.ndarray,
+]

--- a/prosemble/core/serialization.py
+++ b/prosemble/core/serialization.py
@@ -1,0 +1,188 @@
+"""
+Unified save/load serialization for all prosemble model families.
+
+Provides :class:`SerializationMixin` — a mixin that consolidates the
+save/load logic previously duplicated across ``SupervisedPrototypeModel``,
+``UnsupervisedPrototypeModel``, and ``FuzzyClusteringBase``.
+
+Model-family-specific differences are handled via hook methods that
+subclasses override.
+"""
+
+from __future__ import annotations
+
+import json
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+#: Current schema version stamped into new save files.
+_SCHEMA_VERSION = 1
+
+
+class SerializationMixin:
+    """Mixin providing unified save/load for all model families.
+
+    Subclasses customise behaviour by overriding the hook methods below.
+    The ``_get_fitted_arrays`` / ``_set_fitted_arrays`` interface used by
+    36+ model subclasses is **not** changed.
+    """
+
+    # ------------------------------------------------------------------
+    # Hooks — override in subclasses
+    # ------------------------------------------------------------------
+
+    def _get_save_metadata(self) -> dict:
+        """Return model-family-specific metadata fields.
+
+        Returned dict is merged into the JSON metadata blob.
+        Override in each base class (Supervised, Unsupervised, Fuzzy).
+        """
+        return {}
+
+    def _restore_metadata(self, metadata: dict) -> None:
+        """Restore model-family-specific fields from *metadata*.
+
+        Called after the model is constructed and fitted arrays are set.
+        """
+
+    def _save_optimizer_state(self, arrays: dict, metadata: dict) -> None:
+        """Serialize optimizer state into *arrays* / *metadata*.
+
+        Only ``SupervisedPrototypeModel`` overrides this.
+        """
+
+    def _load_optimizer_state(self, data, metadata: dict) -> None:
+        """Restore optimizer state from *data* and *metadata*.
+
+        Only ``SupervisedPrototypeModel`` overrides this.
+        """
+
+    @classmethod
+    def _pre_load_construct(cls, hyperparams: dict, metadata: dict) -> dict:
+        """Modify *hyperparams* before model construction.
+
+        Riemannian models override this to reconstruct the manifold object
+        and remove manifold-specific keys from the dict.
+
+        Must return the (possibly modified) hyperparams dict.
+        """
+        return hyperparams
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def save(self, path: str, quantize: str | None = None) -> None:
+        """Save fitted model to an NPZ file.
+
+        Parameters
+        ----------
+        path : str
+            File path (``.npz`` extension added if not present).
+        quantize : str, optional
+            Quantize before saving: ``'float16'``, ``'bfloat16'``, or
+            ``'int8'``.  The model in memory is unchanged.
+        """
+        self._check_fitted()
+
+        # Temporarily quantize if requested
+        originals: dict = {}
+        if quantize is not None and not self.is_quantized:
+            for attr in self._get_quantizable_attrs():
+                originals[attr] = getattr(self, attr)
+            self.quantize(quantize)
+
+        arrays = self._get_fitted_arrays()
+        hyperparams = self._get_hyperparams()
+
+        metadata = {
+            'schema_version': _SCHEMA_VERSION,
+            'class_name': type(self).__name__,
+            'module': type(self).__module__,
+            'hyperparams': hyperparams,
+            'fitted_array_names': list(arrays.keys()),
+            'quantized_dtype': self.quantized_dtype,
+        }
+
+        # Merge family-specific metadata
+        metadata.update(self._get_save_metadata())
+
+        # int8 scale factors
+        if self.quantized_dtype == 'int8' and hasattr(self, '_int8_scales'):
+            for attr, scale in self._int8_scales.items():
+                arrays[f'__scale__{attr}'] = np.asarray(scale)
+            metadata['int8_scale_keys'] = list(self._int8_scales.keys())
+
+        # Optimizer state (supervised only)
+        self._save_optimizer_state(arrays, metadata)
+
+        save_dict = {'__metadata__': np.array(json.dumps(metadata))}
+        save_dict.update(arrays)
+        np.savez_compressed(path, **save_dict)
+
+        # Restore originals (no precision loss in memory)
+        if originals:
+            for attr, val in originals.items():
+                setattr(self, attr, val)
+            self._quantized_dtype = None
+            if hasattr(self, '_int8_scales'):
+                self._int8_scales = {}
+
+    @classmethod
+    def load(cls, path: str):
+        """Load a fitted model from an NPZ file.
+
+        Parameters
+        ----------
+        path : str
+            Path to the ``.npz`` file.
+
+        Returns
+        -------
+        model
+            Reconstructed fitted model.
+        """
+        from prosemble.models import _MODEL_REGISTRY
+
+        if not path.endswith('.npz'):
+            path = path + '.npz'
+
+        data = np.load(path, allow_pickle=False)
+        metadata = json.loads(str(data['__metadata__']))
+
+        class_name = metadata['class_name']
+        if class_name not in _MODEL_REGISTRY:
+            raise ValueError(f"Unknown model class: {class_name}")
+
+        model_cls = _MODEL_REGISTRY[class_name]
+        hyperparams = dict(metadata['hyperparams'])
+
+        # Allow subclasses to modify hyperparams (e.g. manifold reconstruction)
+        hyperparams = model_cls._pre_load_construct(hyperparams, metadata)
+
+        model = model_cls(**hyperparams)
+
+        # Restore fitted arrays
+        arrays = {name: data[name] for name in metadata['fitted_array_names']}
+        model._set_fitted_arrays(arrays)
+
+        # Restore family-specific metadata
+        model._restore_metadata(metadata)
+
+        # Restore quantization state
+        q_dtype = metadata.get('quantized_dtype')
+        if q_dtype:
+            model._quantized_dtype = q_dtype
+            if q_dtype == 'int8':
+                model._int8_scales = {}
+                for attr in metadata.get('int8_scale_keys', []):
+                    scale_key = f'__scale__{attr}'
+                    if scale_key in data:
+                        model._int8_scales[attr] = jnp.asarray(data[scale_key])
+
+        # Restore optimizer state (supervised only)
+        model._load_optimizer_state(data, metadata)
+
+        return model

--- a/prosemble/core/similarities.py
+++ b/prosemble/core/similarities.py
@@ -91,9 +91,11 @@ def rank_scaled_gaussian(distances, lambd=1.0):
     (lower rank) receive a stronger signal, while farther ones are
     exponentially suppressed.
 
-        s(d, r) = exp(-exp(-r / λ) * d)
+    .. math::
 
-    where r is the rank of each distance (0 = closest).
+        s(d, r) = \exp(-\exp(-r / \lambda) \cdot d)
+
+    where *r* is the rank of each distance (0 = closest).
 
     Parameters
     ----------

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -58,6 +58,12 @@ try:
     from .image_lvq import ImageGLVQ, ImageGMLVQ, ImageGTLVQ
     from .image_cbc import ImageCBC
 
+    # Supervised Riemannian Neural Gas
+    from .riemannian_srng import RiemannianSRNG
+    from .riemannian_smng import RiemannianSMNG
+    from .riemannian_slng import RiemannianSLNG
+    from .riemannian_stng import RiemannianSTNG
+
     # One-class models
     from .oc_glvq import OCGLVQ
     from .oc_grlvq import OCGRLVQ
@@ -84,6 +90,7 @@ try:
     from .growing_neural_gas import GrowingNeuralGas
     from .kohonen_som import KohonenSOM
     from .heskes_som import HeskesSOM
+    from .riemannian_neural_gas import RiemannianNeuralGas
 
     _MODEL_REGISTRY = {
         # Unsupervised clustering
@@ -107,6 +114,9 @@ try:
         'SiameseGTLVQ': SiameseGTLVQ,
         'ImageGLVQ': ImageGLVQ, 'ImageGMLVQ': ImageGMLVQ,
         'ImageGTLVQ': ImageGTLVQ, 'ImageCBC': ImageCBC,
+        # Supervised Riemannian NG
+        'RiemannianSRNG': RiemannianSRNG, 'RiemannianSMNG': RiemannianSMNG,
+        'RiemannianSLNG': RiemannianSLNG, 'RiemannianSTNG': RiemannianSTNG,
         # One-class GLVQ
         'OCGLVQ': OCGLVQ, 'OCGRLVQ': OCGRLVQ, 'OCGMLVQ': OCGMLVQ,
         'OCLGMLVQ': OCLGMLVQ, 'OCGTLVQ': OCGTLVQ,
@@ -123,6 +133,7 @@ try:
         # Unsupervised topology
         'NeuralGas': NeuralGas, 'GrowingNeuralGas': GrowingNeuralGas,
         'KohonenSOM': KohonenSOM, 'HeskesSOM': HeskesSOM,
+        'RiemannianNeuralGas': RiemannianNeuralGas,
     }
 
     JAX_AVAILABLE = True
@@ -156,6 +167,8 @@ __all__ = [
     'LVQMLN', 'PLVQ',
     'SiameseGLVQ', 'SiameseGMLVQ', 'SiameseGTLVQ',
     'ImageGLVQ', 'ImageGMLVQ', 'ImageGTLVQ', 'ImageCBC',
+    # Supervised Riemannian NG
+    'RiemannianSRNG', 'RiemannianSMNG', 'RiemannianSLNG', 'RiemannianSTNG',
     # One-class GLVQ
     'OCGLVQ', 'OCGRLVQ', 'OCGMLVQ', 'OCLGMLVQ', 'OCGTLVQ',
     'OCGLVQ_NG', 'OCGRLVQ_NG', 'OCGMLVQ_NG', 'OCLGMLVQ_NG', 'OCGTLVQ_NG',
@@ -166,6 +179,7 @@ __all__ = [
     'SVQOCC', 'SVQOCC_R', 'SVQOCC_M', 'SVQOCC_LM', 'SVQOCC_T',
     # Unsupervised topology
     'NeuralGas', 'GrowingNeuralGas', 'KohonenSOM', 'HeskesSOM',
+    'RiemannianNeuralGas',
     # Status
     'JAX_AVAILABLE',
 ]

--- a/prosemble/models/base.py
+++ b/prosemble/models/base.py
@@ -4,6 +4,7 @@ import json
 from abc import ABC, abstractmethod
 
 from prosemble.core.quantization import MetadataCollectorMixin, QuantizationMixin
+from prosemble.core.serialization import SerializationMixin
 from functools import partial
 from typing import Self
 
@@ -22,7 +23,7 @@ class NotFittedError(ValueError, RuntimeError):
     pass
 
 
-class FuzzyClusteringBase(MetadataCollectorMixin, QuantizationMixin, ABC):
+class FuzzyClusteringBase(SerializationMixin, MetadataCollectorMixin, QuantizationMixin, ABC):
     """Base class providing shared boilerplate for clustering models.
 
     Provides common parameter handling, input validation, fitted-state
@@ -163,6 +164,11 @@ class FuzzyClusteringBase(MetadataCollectorMixin, QuantizationMixin, ABC):
 
         return X
 
+    @property
+    def prototypes_(self):
+        """Alias for ``centroids_`` for ONNX export compatibility."""
+        return self.centroids_
+
     def _check_fitted(self, attr='centroids_'):
         """Raise NotFittedError if model has not been fitted.
 
@@ -190,6 +196,34 @@ class FuzzyClusteringBase(MetadataCollectorMixin, QuantizationMixin, ABC):
     def predict(self, X):
         """Predict cluster labels for new data."""
         ...
+
+    def export_onnx(self, batch_size=1, opset_version=17, path=None):
+        """Export predict function to ONNX format.
+
+        Builds an ONNX graph that computes:
+        ``predictions = argmin(distance(X, centroids))``.
+
+        Parameters
+        ----------
+        batch_size : int
+            Fixed input batch size. Use ``-1`` for dynamic batch.
+        opset_version : int
+            ONNX opset version. Default: 17.
+        path : str, optional
+            If provided, save ONNX model to this file path.
+
+        Returns
+        -------
+        onnx.ModelProto
+            The exported ONNX model.
+
+        Raises
+        ------
+        NotImplementedError
+            If the model uses kernel distances.
+        """
+        from prosemble.core.onnx_export import export_onnx
+        return export_onnx(self, batch_size, opset_version, path)
 
     @abstractmethod
     def _build_info(self, state, iteration) -> dict:
@@ -285,107 +319,19 @@ class FuzzyClusteringBase(MetadataCollectorMixin, QuantizationMixin, ABC):
             if name in arrays:
                 setattr(self, name, jnp.asarray(arrays[name]))
 
-    def save(self, path, quantize=None):
-        """Save fitted model to an NPZ file.
+    # --- SerializationMixin hooks ---
 
-        Parameters
-        ----------
-        path : str
-            File path (`.npz` extension added if not present)
-        quantize : str, optional
-            Quantize before saving: 'float16', 'bfloat16', or 'int8'.
-            Model in memory is unchanged; only the saved file is quantized.
-        """
-        self._check_fitted()
-
-        # Save originals and temporarily quantize if needed
-        originals = {}
-        if quantize is not None and not self.is_quantized:
-            for attr in self._get_quantizable_attrs():
-                originals[attr] = getattr(self, attr)
-            self.quantize(quantize)
-
-        arrays = self._get_fitted_arrays()
-        hyperparams = self._get_hyperparams()
-
-        metadata = {
-            'class_name': type(self).__name__,
-            'module': type(self).__module__,
-            'hyperparams': hyperparams,
-            'fitted_array_names': list(arrays.keys()),
+    def _get_save_metadata(self):
+        return {
             'n_iter_': int(self.n_iter_) if self.n_iter_ is not None else None,
             'objective_': float(self.objective_) if self.objective_ is not None else None,
-            'quantized_dtype': self.quantized_dtype,
         }
 
-        if self.quantized_dtype == 'int8' and hasattr(self, '_int8_scales'):
-            for attr, scale in self._int8_scales.items():
-                arrays[f'__scale__{attr}'] = np.asarray(scale)
-            metadata['int8_scale_keys'] = list(self._int8_scales.keys())
-
-        save_dict = {'__metadata__': np.array(json.dumps(metadata))}
-        save_dict.update(arrays)
-
-        np.savez_compressed(path, **save_dict)
-
-        # Restore originals exactly (no precision loss)
-        if originals:
-            for attr, val in originals.items():
-                setattr(self, attr, val)
-            self._quantized_dtype = None
-            if hasattr(self, '_int8_scales'):
-                self._int8_scales = {}
-
-    @classmethod
-    def load(cls, path):
-        """Load a fitted model from an NPZ file.
-
-        Parameters
-        ----------
-        path : str
-            Path to the `.npz` file
-
-        Returns
-        -------
-        model : FuzzyClusteringBase
-            Reconstructed fitted model
-        """
-        from prosemble.models import _MODEL_REGISTRY
-
-        if not path.endswith('.npz'):
-            path = path + '.npz'
-
-        data = np.load(path, allow_pickle=False)
-        metadata = json.loads(str(data['__metadata__']))
-
-        class_name = metadata['class_name']
-        if class_name not in _MODEL_REGISTRY:
-            raise ValueError(f"Unknown model class: {class_name}")
-
-        model_cls = _MODEL_REGISTRY[class_name]
-        hyperparams = metadata['hyperparams']
-
-        model = model_cls(**hyperparams)
-
-        arrays = {name: data[name] for name in metadata['fitted_array_names']}
-        model._set_fitted_arrays(arrays)
-
+    def _restore_metadata(self, metadata):
         if metadata.get('n_iter_') is not None:
-            model.n_iter_ = metadata['n_iter_']
+            self.n_iter_ = metadata['n_iter_']
         if metadata.get('objective_') is not None:
-            model.objective_ = metadata['objective_']
-
-        q_dtype = metadata.get('quantized_dtype')
-        if q_dtype:
-            model._quantized_dtype = q_dtype
-            if q_dtype == 'int8':
-                model._int8_scales = {}
-                for attr in metadata.get('int8_scale_keys', []):
-                    scale_key = f'__scale__{attr}'
-                    if scale_key in data:
-                        model._int8_scales[attr] = jnp.asarray(data[scale_key])
-
-        return model
+            self.objective_ = metadata['objective_']
 
     # --- Patience-based early stopping ---
 

--- a/prosemble/models/prototype_base.py
+++ b/prosemble/models/prototype_base.py
@@ -23,6 +23,7 @@ from functools import partial
 
 from prosemble.models.base import NotFittedError
 from prosemble.core.quantization import MetadataCollectorMixin, QuantizationMixin
+from prosemble.core.serialization import SerializationMixin
 from prosemble.core.distance import squared_euclidean_distance_matrix
 from prosemble.core.competitions import wtac
 from prosemble.core.pooling import stratified_min_pooling
@@ -160,7 +161,7 @@ class ScanTrainState(NamedTuple):
     converged: jnp.ndarray        # boolean convergence flag
 
 
-class SupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC):
+class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, QuantizationMixin, ABC):
     """Base class for supervised prototype-based learning models.
 
     Provides the fit/predict/save/load infrastructure. Subclasses implement:
@@ -1492,6 +1493,31 @@ class SupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC):
         )
         return jax_export.export(predict_fn)(input_spec)
 
+    def export_onnx(self, batch_size=1, opset_version=17, path=None):
+        """Export predict function to ONNX format.
+
+        Parameters
+        ----------
+        batch_size : int
+            Fixed input batch size. Use -1 for dynamic batch.
+        opset_version : int
+            ONNX opset version. Default: 17.
+        path : str, optional
+            If provided, save ONNX model to this file path.
+
+        Returns
+        -------
+        onnx.ModelProto
+            The exported ONNX model.
+
+        Raises
+        ------
+        NotImplementedError
+            If the model's distance function is not supported.
+        """
+        from prosemble.core.onnx_export import export_onnx
+        return export_onnx(self, batch_size, opset_version, path)
+
     def _check_fitted(self):
         if self.prototypes_ is None:
             raise NotFittedError("Model not fitted yet. Call fit() first.")
@@ -1541,126 +1567,46 @@ class SupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC):
             if name in arrays:
                 setattr(self, name, jnp.asarray(arrays[name]))
 
-    def save(self, path, quantize=None):
-        """Save fitted model to NPZ file.
+    # --- SerializationMixin hooks ---
 
-        Parameters
-        ----------
-        path : str
-            File path (.npz extension added if not present).
-        quantize : str, optional
-            Quantize before saving: 'float16', 'bfloat16', or 'int8'.
-            Model in memory is unchanged; only the saved file is quantized.
-        """
-        self._check_fitted()
-
-        # Save originals and temporarily quantize if needed
-        originals = {}
-        if quantize is not None and not self.is_quantized:
-            for attr in self._get_quantizable_attrs():
-                originals[attr] = getattr(self, attr)
-            self.quantize(quantize)
-
-        arrays = self._get_fitted_arrays()
-        hyperparams = self._get_hyperparams()
-
-        metadata = {
-            'class_name': type(self).__name__,
-            'module': type(self).__module__,
-            'hyperparams': hyperparams,
-            'fitted_array_names': list(arrays.keys()),
+    def _get_save_metadata(self):
+        return {
             'n_iter_': self.n_iter_,
             'loss_': self.loss_,
             'n_classes_': self.n_classes_,
-            'quantized_dtype': self.quantized_dtype,
         }
 
-        # Store int8 scale factors
-        if self.quantized_dtype == 'int8' and hasattr(self, '_int8_scales'):
-            for attr, scale in self._int8_scales.items():
-                arrays[f'__scale__{attr}'] = np.asarray(scale)
-            metadata['int8_scale_keys'] = list(self._int8_scales.keys())
+    def _restore_metadata(self, metadata):
+        self.n_iter_ = metadata.get('n_iter_')
+        self.loss_ = metadata.get('loss_')
+        self.n_classes_ = metadata.get('n_classes_')
+        if self.prototype_labels_ is not None:
+            self.classes_ = jnp.unique(self.prototype_labels_)
 
-        # Serialize optimizer state if available
+    def _save_optimizer_state(self, arrays, metadata):
         if hasattr(self, '_opt_state') and self._opt_state is not None:
             opt_leaves = jax.tree.leaves(self._opt_state)
             for i, leaf in enumerate(opt_leaves):
                 arrays[f'__opt_state_{i}__'] = np.asarray(leaf)
             metadata['opt_state_n_leaves'] = len(opt_leaves)
 
-        save_dict = {'__metadata__': np.array(json.dumps(metadata))}
-        save_dict.update(arrays)
-        np.savez_compressed(path, **save_dict)
-
-        # Restore originals exactly (no precision loss)
-        if originals:
-            for attr, val in originals.items():
-                setattr(self, attr, val)
-            self._quantized_dtype = None
-            if hasattr(self, '_int8_scales'):
-                self._int8_scales = {}
-
-    @classmethod
-    def load(cls, path):
-        """Load a fitted model from NPZ file."""
-        from prosemble.models import _MODEL_REGISTRY
-
-        if not path.endswith('.npz'):
-            path = path + '.npz'
-
-        data = np.load(path, allow_pickle=False)
-        metadata = json.loads(str(data['__metadata__']))
-
-        class_name = metadata['class_name']
-        if class_name not in _MODEL_REGISTRY:
-            raise ValueError(f"Unknown model class: {class_name}")
-
-        model_cls = _MODEL_REGISTRY[class_name]
-        hyperparams = metadata['hyperparams']
-        model = model_cls(**hyperparams)
-
-        arrays = {name: data[name] for name in metadata['fitted_array_names']}
-        model._set_fitted_arrays(arrays)
-
-        model.n_iter_ = metadata.get('n_iter_')
-        model.loss_ = metadata.get('loss_')
-        model.n_classes_ = metadata.get('n_classes_')
-        if model.prototype_labels_ is not None:
-            model.classes_ = jnp.unique(model.prototype_labels_)
-
-        # Restore quantization state
-        q_dtype = metadata.get('quantized_dtype')
-        if q_dtype:
-            model._quantized_dtype = q_dtype
-            if q_dtype == 'int8':
-                model._int8_scales = {}
-                for attr in metadata.get('int8_scale_keys', []):
-                    scale_key = f'__scale__{attr}'
-                    if scale_key in data:
-                        model._int8_scales[attr] = jnp.asarray(data[scale_key])
-
-        # Restore optimizer state if saved
+    def _load_optimizer_state(self, data, metadata):
         n_leaves = metadata.get('opt_state_n_leaves')
         if n_leaves is not None and n_leaves > 0:
             saved_leaves = [
                 jnp.asarray(data[f'__opt_state_{i}__'])
                 for i in range(n_leaves)
             ]
-            # Get tree structure from a fresh init, then replace leaves
-            params = model._get_resume_params({'prototypes': model.prototypes_})
-            optimizer = model._optimizer
-            # Apply freeze_params masking to match the optimizer used during training
-            if model.freeze_params is not None:
-                freeze_set = set(model.freeze_params)
+            params = self._get_resume_params({'prototypes': self.prototypes_})
+            optimizer = self._optimizer
+            if self.freeze_params is not None:
+                freeze_set = set(self.freeze_params)
                 mask = {k: (k not in freeze_set) for k in params}
                 optimizer = optax.masked(optimizer, mask)
             skeleton = optimizer.init(params)
             treedef = jax.tree.structure(skeleton)
             if len(saved_leaves) == len(jax.tree.leaves(skeleton)):
-                model._opt_state = jax.tree.unflatten(treedef, saved_leaves)
-            # else: leaf count mismatch, skip restore (fresh init on next fit)
-
-        return model
+                self._opt_state = jax.tree.unflatten(treedef, saved_leaves)
 
     # --- Callback notifications ---
 
@@ -1679,7 +1625,7 @@ class SupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC):
 
 # --- Unsupervised Base ---
 
-class UnsupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC):
+class UnsupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, QuantizationMixin, ABC):
     """Base class for unsupervised prototype-based topology models.
 
     For NeuralGas, GrowingNeuralGas, KohonenSOM.
@@ -1827,6 +1773,25 @@ class UnsupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC)
         )
         return jax_export.export(predict_fn)(input_spec)
 
+    def export_onnx(self, batch_size=1, opset_version=17, path=None):
+        """Export predict function to ONNX format.
+
+        Parameters
+        ----------
+        batch_size : int
+            Fixed input batch size. Use -1 for dynamic batch.
+        opset_version : int
+            ONNX opset version. Default: 17.
+        path : str, optional
+            If provided, save ONNX model to this file path.
+
+        Returns
+        -------
+        onnx.ModelProto
+        """
+        from prosemble.core.onnx_export import export_onnx
+        return export_onnx(self, batch_size, opset_version, path)
+
     # --- Serialization ---
 
     def _get_hyperparams(self):
@@ -1863,90 +1828,17 @@ class UnsupervisedPrototypeModel(MetadataCollectorMixin, QuantizationMixin, ABC)
             if name in arrays:
                 setattr(self, name, jnp.asarray(arrays[name]))
 
-    def save(self, path, quantize=None):
-        """Save fitted model to NPZ file.
+    # --- SerializationMixin hooks ---
 
-        Parameters
-        ----------
-        path : str
-            File path (.npz extension added if not present).
-        quantize : str, optional
-            Quantize before saving: 'float16', 'bfloat16', or 'int8'.
-            Model in memory is unchanged; only the saved file is quantized.
-        """
-        self._check_fitted()
-
-        originals = {}
-        if quantize is not None and not self.is_quantized:
-            for attr in self._get_quantizable_attrs():
-                originals[attr] = getattr(self, attr)
-            self.quantize(quantize)
-
-        arrays = self._get_fitted_arrays()
-        hyperparams = self._get_hyperparams()
-
-        metadata = {
-            'class_name': type(self).__name__,
-            'module': type(self).__module__,
-            'hyperparams': hyperparams,
-            'fitted_array_names': list(arrays.keys()),
+    def _get_save_metadata(self):
+        return {
             'n_iter_': self.n_iter_,
             'loss_': self.loss_,
-            'quantized_dtype': self.quantized_dtype,
         }
 
-        if self.quantized_dtype == 'int8' and hasattr(self, '_int8_scales'):
-            for attr, scale in self._int8_scales.items():
-                arrays[f'__scale__{attr}'] = np.asarray(scale)
-            metadata['int8_scale_keys'] = list(self._int8_scales.keys())
-
-        save_dict = {'__metadata__': np.array(json.dumps(metadata))}
-        save_dict.update(arrays)
-        np.savez_compressed(path, **save_dict)
-
-        if originals:
-            for attr, val in originals.items():
-                setattr(self, attr, val)
-            self._quantized_dtype = None
-            if hasattr(self, '_int8_scales'):
-                self._int8_scales = {}
-
-    @classmethod
-    def load(cls, path):
-        """Load a fitted model from NPZ file."""
-        from prosemble.models import _MODEL_REGISTRY
-
-        if not path.endswith('.npz'):
-            path = path + '.npz'
-
-        data = np.load(path, allow_pickle=False)
-        metadata = json.loads(str(data['__metadata__']))
-
-        class_name = metadata['class_name']
-        if class_name not in _MODEL_REGISTRY:
-            raise ValueError(f"Unknown model class: {class_name}")
-
-        model_cls = _MODEL_REGISTRY[class_name]
-        hyperparams = metadata['hyperparams']
-        model = model_cls(**hyperparams)
-
-        arrays = {name: data[name] for name in metadata['fitted_array_names']}
-        model._set_fitted_arrays(arrays)
-
-        model.n_iter_ = metadata.get('n_iter_')
-        model.loss_ = metadata.get('loss_')
-
-        q_dtype = metadata.get('quantized_dtype')
-        if q_dtype:
-            model._quantized_dtype = q_dtype
-            if q_dtype == 'int8':
-                model._int8_scales = {}
-                for attr in metadata.get('int8_scale_keys', []):
-                    scale_key = f'__scale__{attr}'
-                    if scale_key in data:
-                        model._int8_scales[attr] = jnp.asarray(data[scale_key])
-
-        return model
+    def _restore_metadata(self, metadata):
+        self.n_iter_ = metadata.get('n_iter_')
+        self.loss_ = metadata.get('loss_')
 
     # --- Callback notifications ---
 

--- a/prosemble/models/riemannian_neural_gas.py
+++ b/prosemble/models/riemannian_neural_gas.py
@@ -30,6 +30,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from prosemble.models.prototype_base import UnsupervisedPrototypeModel
+from prosemble.core.protocols import Manifold
 
 
 class RiemannianNeuralGas(UnsupervisedPrototypeModel):
@@ -40,11 +41,10 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
 
     Parameters
     ----------
-    manifold : object
+    manifold : Manifold
         Manifold instance (SO, SPD, or Grassmannian from
-        ``prosemble.core.manifolds``). Must implement ``distance``,
-        ``log_map``, ``exp_map``, ``random_point``, ``project``,
-        and ``injectivity_radius``.
+        ``prosemble.core.manifolds``). Must satisfy the
+        :class:`~prosemble.core.protocols.Manifold` protocol.
     n_prototypes : int
         Number of prototypes/nodes.
     lr_init : float
@@ -75,7 +75,7 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
         If True, restore parameters from the lowest-loss epoch. Default: False.
     """
 
-    def __init__(self, manifold, n_prototypes, lr_init=0.3, lr_final=0.01,
+    def __init__(self, manifold: Manifold, n_prototypes, lr_init=0.3, lr_final=0.01,
                  lambda_init=None, lambda_final=0.01,
                  tau=0.9, max_iter=100, lr=0.01, epsilon=1e-6,
                  random_seed=42, distance_fn=None, callbacks=None,
@@ -181,7 +181,7 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
 
         Parameters
         ----------
-        X : array of shape (n_samples, *point_shape)
+        X : array of shape ``(n_samples, *point_shape)``
             Data points on the manifold.
 
         Returns
@@ -240,7 +240,7 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
 
         Parameters
         ----------
-        X : array of shape (n_samples, *point_shape)
+        X : array of shape ``(n_samples, *point_shape)``
 
         Returns
         -------
@@ -256,7 +256,7 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
 
         Parameters
         ----------
-        X : array of shape (n_samples, *point_shape)
+        X : array of shape ``(n_samples, *point_shape)``
 
         Returns
         -------
@@ -315,28 +315,10 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
             raise ValueError(f"Unknown manifold type: {mtype}")
 
     @classmethod
-    def load(cls, path):
-        """Load a saved RiemannianNeuralGas model."""
-        import json
-        data = np.load(path, allow_pickle=True)
-        metadata = json.loads(str(data['__metadata__']))
-        hp = dict(metadata['hyperparams'])  # copy to avoid mutation
-
-        manifold = cls._reconstruct_manifold(hp)
-
-        # Remove manifold-specific keys
-        hp.pop('manifold_type', None)
-        hp.pop('manifold_n', None)
-        hp.pop('manifold_k', None)
-
-        model = cls(manifold=manifold, **hp)
-
-        # Restore fitted arrays
-        fitted_keys = metadata.get('fitted_array_names', [])
-        arrays = {k: data[k] for k in fitted_keys if k in data.files}
-        model._set_fitted_arrays(arrays)
-
-        model.n_iter_ = metadata.get('n_iter_', 0)
-        model.loss_ = metadata.get('loss_', None)
-
-        return model
+    def _pre_load_construct(cls, hyperparams, metadata):
+        manifold = cls._reconstruct_manifold(hyperparams)
+        hyperparams.pop('manifold_type', None)
+        hyperparams.pop('manifold_n', None)
+        hyperparams.pop('manifold_k', None)
+        hyperparams['manifold'] = manifold
+        return hyperparams

--- a/prosemble/models/riemannian_slng.py
+++ b/prosemble/models/riemannian_slng.py
@@ -1,0 +1,242 @@
+"""
+Supervised Riemannian Localized Matrix Neural Gas (RiemannianSLNG).
+
+Extends RiemannianSRNG with per-prototype metric adaptation in the
+tangent space. Each prototype has its own :math:`\\Omega_k` matrix
+applied to tangent vectors at that prototype.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_smng import RiemannianSMNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+
+
+class RiemannianSLNG(RiemannianSMNG):
+    """Supervised Riemannian Localized Matrix Neural Gas.
+
+    Extends RiemannianSRNG with per-prototype metric adaptation. Each
+    prototype :math:`w_k` has its own matrix :math:`\\Omega_k` applied
+    in the tangent space:
+
+    .. math::
+
+        d(x, w_k) = \\|\\Omega_k \\cdot \\text{Log}_{w_k}(x)_{\\text{flat}}\\|^2
+
+    Since each :math:`\\Omega_k` operates on tangent vectors at :math:`w_k`
+    (all in the same tangent space :math:`T_{w_k}M`), this is geometrically
+    well-defined.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    latent_dim : int, optional
+        Projection dimensionality for each omega. Default: n_features.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor for gamma.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping.
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True, use jax.lax.scan. Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation steps.
+    ema_decay : float, optional
+        EMA decay for parameters.
+    freeze_params : list of str, optional
+        Parameter groups to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+    """
+
+    def __init__(self, manifold, latent_dim=None, beta=10.0,
+                 gamma_init=None, gamma_final=0.01, gamma_decay=None,
+                 tau=0.95, n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=False, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, latent_dim=latent_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.omegas_ = None
+
+    def _get_resume_params(self, params):
+        gamma = params.get('gamma', jnp.array(self.gamma_final))
+        omegas = params.get('omegas', self.omegas_) if self.omegas_ is not None else params.get('omegas')
+        return {
+            'prototypes': params['prototypes'],
+            'omegas': omegas,
+            'gamma': gamma,
+        }
+
+    def _init_state(self, X, y, key):
+        # Call RiemannianSRNG._init_state (skip RiemannianSMNG)
+        state, params, proto_labels = RiemannianSMNG.__bases__[0]._init_state(self, X, y, key)
+
+        d_flat = X.shape[1]
+        n_protos = params['prototypes'].shape[0]
+        latent_dim = self.latent_dim if self.latent_dim is not None else d_flat
+        omega_one = identity_omega_init(d_flat, latent_dim)
+        omegas = jnp.tile(omega_one[None, :, :], (n_protos, 1, 1))
+
+        params = {**params, 'omegas': omegas}
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']  # (p, d_flat, l)
+        gamma = params['gamma']
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Per-prototype omega distance in tangent space
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)  # (n, p, d_flat)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, omegas)  # (n, p, l)
+        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+
+        # 2-8: NG+GLVQ (identical pattern)
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        # Call RiemannianSRNG._extract_results (skip RiemannianSMNG)
+        RiemannianSMNG.__bases__[0]._extract_results(
+            self, params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omegas_ = params['omegas']
+
+    def predict(self, X):
+        """Predict using per-prototype tangent-space omega metric.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, self.omegas_)
+        distances = jnp.sum(projected ** 2, axis=2)
+
+        from prosemble.core.competitions import wtac
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        return {'prototypes_': self.prototypes_, 'omegas_': self.omegas_}
+
+    def _get_fitted_arrays(self):
+        arrays = RiemannianSMNG.__bases__[0]._get_fitted_arrays(self)
+        if self.omegas_ is not None:
+            arrays['omegas_'] = np.asarray(self.omegas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        RiemannianSMNG.__bases__[0]._set_fitted_arrays(self, arrays)
+        if 'omegas_' in arrays:
+            self.omegas_ = jnp.asarray(arrays['omegas_'])

--- a/prosemble/models/riemannian_smng.py
+++ b/prosemble/models/riemannian_smng.py
@@ -1,0 +1,303 @@
+"""
+Supervised Riemannian Matrix Neural Gas (RiemannianSMNG).
+
+Extends RiemannianSRNG with a global learned metric in the tangent space.
+For each prototype, the tangent vector from prototype to data point is
+computed via the manifold's logarithmic map, then projected through a
+shared matrix :math:`\\Omega` before computing distances.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_srng import RiemannianSRNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+
+
+class RiemannianSMNG(RiemannianSRNG):
+    """Supervised Riemannian Matrix Neural Gas.
+
+    Extends RiemannianSRNG with a global metric adaptation matrix
+    :math:`\\Omega` applied in the tangent space. The distance is:
+
+    .. math::
+
+        d(x, w_k) = \\|\\Omega \\cdot \\text{Log}_{w_k}(x)_{\\text{flat}}\\|^2
+
+    where :math:`\\text{Log}_{w_k}(x)` is the logarithmic map at prototype
+    :math:`w_k`, flattened to a vector.
+
+    The learned relevance matrix :math:`\\Lambda = \\Omega^T \\Omega`
+    captures feature correlations in the tangent space.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    latent_dim : int, optional
+        Projection dimensionality for omega. Default: n_features (square).
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor for gamma.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping.
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True, use jax.lax.scan. Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation steps.
+    ema_decay : float, optional
+        EMA decay for parameters.
+    freeze_params : list of str, optional
+        Parameter groups to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+    """
+
+    def __init__(self, manifold, latent_dim=None, beta=10.0,
+                 gamma_init=None, gamma_final=0.01, gamma_decay=None,
+                 tau=0.95, n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=False, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.latent_dim = latent_dim
+        self.omega_ = None
+
+    def _diff_log_map(self, w, x):
+        """Differentiable log map for a single (base, target) pair.
+
+        Dispatches to the appropriate differentiable log map based on
+        manifold type.
+        """
+        from prosemble.core.manifolds import SO, SPD, Grassmannian
+        from prosemble.models.riemannian_srng import (
+            _so_log_map_diff, _spd_log_map_diff, _grassmannian_log_map_diff,
+        )
+        if isinstance(self.manifold, SO):
+            return _so_log_map_diff(w, x)
+        elif isinstance(self.manifold, SPD):
+            return _spd_log_map_diff(w, x)
+        elif isinstance(self.manifold, Grassmannian):
+            return _grassmannian_log_map_diff(w, x)
+        else:
+            return self.manifold.log_map(w, x)
+
+    def _compute_tangent_vectors(self, X_manifold, W_manifold):
+        """Compute tangent vectors from prototypes to data via log map.
+
+        Uses differentiable log map implementations that support autodiff.
+
+        Parameters
+        ----------
+        X_manifold : array of shape (n_samples, *point_shape)
+        W_manifold : array of shape (n_prototypes, *point_shape)
+
+        Returns
+        -------
+        tangents_flat : array of shape (n_samples, n_prototypes, d_flat)
+        """
+        log_to_all_x = jax.vmap(self._diff_log_map, in_axes=(None, 0))
+        log_matrix = jax.vmap(log_to_all_x, in_axes=(0, None))
+        # log_matrix(W, X) → (p, n, *point_shape)
+        tangents = log_matrix(W_manifold, X_manifold)
+        # Transpose to (n, p, *point_shape)
+        tangents = jnp.moveaxis(tangents, 0, 1)
+        # Flatten to (n, p, d_flat)
+        n = X_manifold.shape[0]
+        p = W_manifold.shape[0]
+        return tangents.reshape(n, p, -1)
+
+    def _get_resume_params(self, params):
+        gamma = params.get('gamma', jnp.array(self.gamma_final))
+        omega = params.get('omega', self.omega_) if self.omega_ is not None else params.get('omega')
+        return {
+            'prototypes': params['prototypes'],
+            'omega': omega,
+            'gamma': gamma,
+        }
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        d_flat = X.shape[1]
+        latent_dim = self.latent_dim if self.latent_dim is not None else d_flat
+        omega = identity_omega_init(d_flat, latent_dim)
+
+        params = {**params, 'omega': omega}
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omega = params['omega']
+        gamma = params['gamma']
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Tangent vectors via log map, then global omega projection
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)  # (n, p, d_flat)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, omega)  # (n, p, l)
+        distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+
+        # 2. Compute ranks within same-class prototypes
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        # 3. Neighborhood function
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        # 4. Normalize
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        # 5. Closest different-class distance
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        # 6. GLVQ mu
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        # 7. Transfer function
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        # 8. Rank-weighted sum
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.omega_ = params['omega']
+
+    def predict(self, X):
+        """Predict using tangent-space omega metric.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, self.omega_)
+        distances = jnp.sum(projected ** 2, axis=2)
+
+        from prosemble.core.competitions import wtac
+        return wtac(distances, self.prototype_labels_)
+
+    def relevance_matrix(self):
+        """Return learned relevance matrix Lambda = Omega^T Omega.
+
+        Returns
+        -------
+        array of shape (d_flat, d_flat)
+        """
+        return self.omega_.T @ self.omega_
+
+    def _get_quantizable_attrs(self):
+        return {'prototypes_': self.prototypes_, 'omega_': self.omega_}
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_ is not None:
+            arrays['omega_'] = np.asarray(self.omega_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_' in arrays:
+            self.omega_ = jnp.asarray(arrays['omega_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['latent_dim'] = self.latent_dim
+        return hp

--- a/prosemble/models/riemannian_srng.py
+++ b/prosemble/models/riemannian_srng.py
@@ -1,0 +1,476 @@
+"""
+Supervised Riemannian Neural Gas (RiemannianSRNG).
+
+Extends GLVQ-style supervised classification to Riemannian manifolds
+using geodesic distances and Neural Gas neighborhood cooperation.
+Prototypes live on the manifold and are updated via projected gradient
+descent (Euclidean gradient + manifold projection).
+
+Supports SO(n), SPD(n), and Grassmannian(n,k) manifolds.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel, SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.core.protocols import Manifold
+
+
+# ---------------------------------------------------------------------------
+# Differentiable manifold operations for autodiff-based training
+# ---------------------------------------------------------------------------
+
+def _logm_spd_diff(M):
+    """Differentiable matrix log for SPD matrices via eigendecomposition.
+
+    Unlike ``jsl.funm(A, jnp.log)`` (which uses Schur decomposition with
+    no JAX differentiation rule), this uses ``jnp.linalg.eigh`` which
+    has full autodiff support.
+    """
+    eigvals, eigvecs = jnp.linalg.eigh(M)
+    eigvals = jnp.maximum(eigvals, 1e-10)
+    return eigvecs @ jnp.diag(jnp.log(eigvals)) @ eigvecs.T
+
+
+def _so_chordal_distance_squared(R, S):
+    """Chordal (Frobenius) distance squared on SO(n).
+
+    .. math::
+
+        d^2(R, S) = \\|R - S\\|_F^2
+
+    This is a standard differentiable proxy for the geodesic distance
+    on SO(n), widely used in rotation averaging (Hartley et al., 2013).
+    It is monotonically related to the geodesic distance for small angles.
+    """
+    diff = R - S
+    return jnp.sum(diff ** 2)
+
+
+def _spd_distance_squared_diff(A, B):
+    """Differentiable squared geodesic distance on SPD(n).
+
+    .. math::
+
+        d^2(A, B) = \\|\\log(A^{-1/2} B A^{-1/2})\\|_F^2
+
+    Uses eigendecomposition-based logm (differentiable) instead of
+    ``jsl.funm`` (not differentiable).
+    """
+    from prosemble.core.manifolds import inv_sqrt_spd
+    A_isqrt = inv_sqrt_spd(A)
+    M = A_isqrt @ B @ A_isqrt
+    logM = _logm_spd_diff(M)
+    return jnp.sum(logM ** 2)
+
+
+def _grassmannian_distance_squared_diff(Q1, Q2):
+    """Differentiable squared geodesic distance on Gr(n,k).
+
+    Uses SVD + arccos, both of which have JAX differentiation rules.
+    """
+    M = Q1.T @ Q2
+    svals = jnp.linalg.svd(M, compute_uv=False)
+    svals = jnp.clip(svals, -1.0 + 1e-7, 1.0 - 1e-7)
+    angles = jnp.arccos(svals)
+    return jnp.sum(angles ** 2)
+
+
+def _so_log_map_diff(R, S):
+    """Differentiable tangent vector approximation on SO(n).
+
+    Returns the skew-symmetric part of R^T S mapped to the tangent
+    space at R. This is the first-order approximation of the true
+    logarithmic map, exact when R and S are close.
+
+    .. math::
+
+        \\text{Log}_R(S) \\approx R \\cdot \\text{skew}(R^T S)
+        = R \\cdot \\frac{R^T S - S^T R}{2}
+    """
+    RtS = R.T @ S
+    skew = (RtS - RtS.T) / 2.0
+    return R @ skew
+
+
+def _spd_log_map_diff(A, B):
+    """Differentiable log map on SPD(n) via eigendecomposition.
+
+    .. math::
+
+        \\text{Log}_A(B) = A^{1/2} \\log(A^{-1/2} B A^{-1/2}) A^{1/2}
+    """
+    from prosemble.core.manifolds import sqrt_spd, inv_sqrt_spd
+    A_sqrt = sqrt_spd(A)
+    A_isqrt = inv_sqrt_spd(A)
+    M = A_isqrt @ B @ A_isqrt
+    return A_sqrt @ _logm_spd_diff(M) @ A_sqrt
+
+
+def _grassmannian_log_map_diff(Q1, Q2):
+    """Differentiable log map on Grassmannian with safe gradient.
+
+    The standard log map has a gradient singularity when Q1 and Q2 span
+    identical or nearly identical subspaces (sin(theta) -> 0). This
+    version uses the tangent space projection which is always well-conditioned:
+
+    .. math::
+
+        \\text{Log}_{Q_1}(Q_2) \\approx Q_2 - Q_1 (Q_1^T Q_2)
+
+    This is the orthogonal projection of Q2 onto the normal space of Q1's
+    column span, which equals the exact log map to first order and is
+    smooth everywhere.
+    """
+    return Q2 - Q1 @ (Q1.T @ Q2)
+
+
+class RiemannianSRNG(SupervisedPrototypeModel):
+    """Supervised Riemannian Neural Gas.
+
+    Combines three key ideas:
+
+    - GLVQ loss: :math:`(d^+ - d^-) / (d^+ + d^-)` for margin-based classification
+    - Neural Gas cooperation: all same-class prototypes participate in
+      the loss, weighted by rank via :math:`\\exp(-\\text{rank} / \\gamma)`
+    - Geodesic distance: :math:`d(x, w)` computed via the manifold's
+      intrinsic metric (matrix logarithm + Frobenius norm)
+
+    Prototypes live on the manifold and are updated via projected gradient
+    descent: optax computes Euclidean gradients, then
+    :meth:`manifold.project` maps prototypes back to the manifold after
+    each step.
+
+    The neighborhood range :math:`\\gamma` decays during training from
+    :math:`\\gamma_{\\text{init}}` to :math:`\\gamma_{\\text{final}}`.
+    When :math:`\\gamma \\to 0`, RiemannianSRNG recovers a Riemannian GLVQ.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance defining the geometry.
+    beta : float
+        Transfer function steepness parameter for sigmoid shaping.
+    gamma_init : float, optional
+        Initial neighborhood range for NG cooperation.
+        Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay factor for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    tau : float
+        Injectivity radius safety factor for manifold projection.
+        Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True, use jax.lax.scan for training (faster, JIT-compiled).
+        If False (default), use a Python for-loop with true early stopping.
+    batch_size : int, optional
+        Mini-batch size. If None (default), use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule. Default: None.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler. Default: None.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes. Default: 'stratified_random'.
+    patience : int, optional
+        Number of consecutive epochs with no improvement before stopping.
+        Default: None.
+    restore_best : bool
+        If True, restore parameters that achieved the lowest loss. Default: False.
+    class_weight : dict or 'balanced', optional
+        Weights for each class. Default: None (uniform).
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps. Default: None.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters. Default: None.
+    freeze_params : list of str, optional
+        List of parameter group names to freeze. Default: None.
+    lookahead : dict, optional
+        Enable lookahead optimizer wrapper. Default: None.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training. Default: None.
+    """
+
+    def __init__(self, manifold: Manifold, beta=10.0, gamma_init=None, gamma_final=0.01,
+                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=False, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=None,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.manifold = manifold
+        self.beta = beta
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.tau = tau
+        self.gamma_ = None
+
+        # Ensure gamma is frozen from optimizer (not trainable)
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _reshape_to_manifold(self, flat, n_points):
+        """Reshape flat array to manifold point shape.
+
+        Parameters
+        ----------
+        flat : array of shape (n_points, d_flat)
+        n_points : int
+
+        Returns
+        -------
+        array of shape (n_points, *point_shape)
+        """
+        return flat.reshape(n_points, *self.manifold.point_shape)
+
+    def _diff_distance_squared(self, x, w):
+        """Differentiable squared distance for a single pair of points.
+
+        Dispatches to the appropriate differentiable distance based on
+        manifold type. Used during training (autodiff). For inference,
+        the exact geodesic distance can also be used.
+        """
+        if isinstance(self.manifold, SO):
+            return _so_chordal_distance_squared(x, w)
+        elif isinstance(self.manifold, SPD):
+            return _spd_distance_squared_diff(x, w)
+        elif isinstance(self.manifold, Grassmannian):
+            return _grassmannian_distance_squared_diff(x, w)
+        else:
+            return self.manifold.distance_squared(x, w)
+
+    def _geodesic_distances(self, X_manifold, W_manifold):
+        """Compute pairwise squared distance matrix (differentiable).
+
+        Parameters
+        ----------
+        X_manifold : array of shape (n_samples, *point_shape)
+        W_manifold : array of shape (n_prototypes, *point_shape)
+
+        Returns
+        -------
+        distances : array of shape (n_samples, n_prototypes)
+        """
+        dist_to_all = jax.vmap(self._diff_distance_squared, in_axes=(None, 0))
+        dist_matrix = jax.vmap(dist_to_all, in_axes=(0, None))
+        return dist_matrix(X_manifold, W_manifold)
+
+    def _get_resume_params(self, params):
+        gamma = params.get('gamma', jnp.array(self.gamma_final))
+        return {
+            'prototypes': params['prototypes'],
+            'gamma': gamma,
+        }
+
+    def _init_state(self, X, y, key):
+        key1, key2 = jax.random.split(key)
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+
+        # Project initial prototypes to manifold
+        n_protos = prototypes.shape[0]
+        protos_manifold = self._reshape_to_manifold(prototypes, n_protos)
+        protos_manifold = jax.vmap(self.manifold.project)(protos_manifold)
+        prototypes = protos_manifold.reshape(n_protos, -1)
+
+        # Compute gamma_init from prototype count if not set
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        # Compute decay factor
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
+
+        params = {
+            'prototypes': prototypes,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        gamma = params['gamma']
+
+        # Reshape to manifold
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Geodesic distance matrix
+        distances = self._geodesic_distances(X_m, W_m)  # (n, p)
+
+        # 2. Compute ranks within same-class prototypes
+        same_class = (y[:, None] == proto_labels[None, :])  # (n, p)
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        # 3. Neighborhood function h = exp(-rank / gamma)
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        # 4. Normalize per sample
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        # 5. Closest different-class prototype distance
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        # 6. GLVQ mu
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        # 7. Transfer function
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        # 8. Rank-weighted sum
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        # Decay gamma
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+
+        # Project prototypes back to manifold
+        prototypes = params['prototypes']
+        n_protos = prototypes.shape[0]
+        protos_manifold = self._reshape_to_manifold(prototypes, n_protos)
+        protos_manifold = jax.vmap(self.manifold.project)(protos_manifold)
+        prototypes = protos_manifold.reshape(n_protos, -1)
+
+        return {**params, 'gamma': new_gamma, 'prototypes': prototypes}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.gamma_ = float(params['gamma'])
+
+    def predict(self, X):
+        """Predict class labels using geodesic distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+        distances = self._geodesic_distances(X_m, W_m)
+        from prosemble.core.competitions import wtac
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        return {'prototypes_': self.prototypes_}
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['beta'] = self.beta
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        hp['tau'] = self.tau
+        # Store manifold type and params for reconstruction
+        manifold = self.manifold
+        hp['manifold_type'] = type(manifold).__name__
+        if hasattr(manifold, 'n'):
+            hp['manifold_n'] = manifold.n
+        if hasattr(manifold, 'k'):
+            hp['manifold_k'] = manifold.k
+        return hp
+
+    @classmethod
+    def _reconstruct_manifold(cls, hp):
+        """Reconstruct manifold from saved hyperparameters."""
+        from prosemble.core.manifolds import SO, SPD, Grassmannian
+        mtype = hp.get('manifold_type', '')
+        if mtype == 'SO':
+            return SO(int(hp['manifold_n']))
+        elif mtype == 'SPD':
+            return SPD(int(hp['manifold_n']))
+        elif mtype == 'Grassmannian':
+            return Grassmannian(int(hp['manifold_n']), int(hp['manifold_k']))
+        else:
+            raise ValueError(f"Unknown manifold type: {mtype}")
+
+    @classmethod
+    def _pre_load_construct(cls, hyperparams, metadata):
+        manifold = cls._reconstruct_manifold(hyperparams)
+        hyperparams.pop('manifold_type', None)
+        hyperparams.pop('manifold_n', None)
+        hyperparams.pop('manifold_k', None)
+        hyperparams['manifold'] = manifold
+        return hyperparams

--- a/prosemble/models/riemannian_stng.py
+++ b/prosemble/models/riemannian_stng.py
@@ -1,0 +1,262 @@
+"""
+Supervised Riemannian Tangent Neural Gas (RiemannianSTNG).
+
+Extends RiemannianSRNG with per-prototype tangent subspace projection.
+Each prototype defines an orthonormal basis for an invariant subspace
+in its tangent space; distance is measured orthogonal to this subspace.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_smng import RiemannianSMNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.utils import orthogonalize
+
+
+class RiemannianSTNG(RiemannianSMNG):
+    """Supervised Riemannian Tangent Neural Gas.
+
+    Extends RiemannianSRNG with per-prototype tangent subspace projection.
+    Each prototype :math:`w_k` has an orthonormal basis :math:`\\Omega_k`
+    defining an invariant subspace; the distance measures how far the
+    tangent vector lies *outside* this subspace:
+
+    .. math::
+
+        d(x, w_k) = \\|(I - \\Omega_k \\Omega_k^T) \\cdot \\text{Log}_{w_k}(x)_{\\text{flat}}\\|^2
+
+    The subspace bases are re-orthogonalized after each gradient step.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    subspace_dim : int, optional
+        Dimensionality of each prototype's tangent subspace.
+        Default: n_features // 2.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor for gamma.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping.
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True, use jax.lax.scan. Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation steps.
+    ema_decay : float, optional
+        EMA decay for parameters.
+    freeze_params : list of str, optional
+        Parameter groups to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+    """
+
+    def __init__(self, manifold, subspace_dim=None, beta=10.0,
+                 gamma_init=None, gamma_final=0.01, gamma_decay=None,
+                 tau=0.95, n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=False, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        # Pass latent_dim=None since STNG uses subspace_dim instead
+        super().__init__(
+            manifold=manifold, latent_dim=None, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.subspace_dim = subspace_dim
+        self.omegas_ = None
+
+    def _get_resume_params(self, params):
+        gamma = params.get('gamma', jnp.array(self.gamma_final))
+        omegas = params.get('omegas', self.omegas_) if self.omegas_ is not None else params.get('omegas')
+        return {
+            'prototypes': params['prototypes'],
+            'omegas': omegas,
+            'gamma': gamma,
+        }
+
+    def _init_state(self, X, y, key):
+        # Call RiemannianSRNG._init_state (skip RiemannianSMNG)
+        state, params, proto_labels = RiemannianSMNG.__bases__[0]._init_state(self, X, y, key)
+
+        d_flat = X.shape[1]
+        n_protos = params['prototypes'].shape[0]
+        subspace_dim = self.subspace_dim if self.subspace_dim is not None else d_flat // 2
+
+        key_omega = jax.random.PRNGKey(self.random_seed + 1)
+        omegas = jax.random.normal(key_omega, (n_protos, d_flat, subspace_dim))
+        omegas = jax.vmap(orthogonalize)(omegas)
+
+        params = {**params, 'omegas': omegas}
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']  # (p, d_flat, s)
+        gamma = params['gamma']
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Tangent subspace distance
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)  # (n, p, d_flat)
+        proj_onto_subspace = jnp.einsum('npd,pds->nps', tangent_flat, omegas)
+        reconstruction = jnp.einsum('nps,pds->npd', proj_onto_subspace, omegas)
+        residual = tangent_flat - reconstruction
+        distances = jnp.sum(residual ** 2, axis=2)  # (n, p)
+
+        # 2-8: NG+GLVQ
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        # Project prototypes and decay gamma via parent
+        params = RiemannianSMNG.__bases__[0]._post_update(self, params)
+        # Re-orthogonalize tangent subspace bases
+        omegas = jax.vmap(orthogonalize)(params['omegas'])
+        return {**params, 'omegas': omegas}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        RiemannianSMNG.__bases__[0]._extract_results(
+            self, params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omegas_ = params['omegas']
+
+    def predict(self, X):
+        """Predict using tangent subspace distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, self.omegas_)
+        recon = jnp.einsum('nps,pds->npd', proj, self.omegas_)
+        residual = tangent_flat - recon
+        distances = jnp.sum(residual ** 2, axis=2)
+
+        from prosemble.core.competitions import wtac
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        return {'prototypes_': self.prototypes_, 'omegas_': self.omegas_}
+
+    def _get_fitted_arrays(self):
+        arrays = RiemannianSMNG.__bases__[0]._get_fitted_arrays(self)
+        if self.omegas_ is not None:
+            arrays['omegas_'] = np.asarray(self.omegas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        RiemannianSMNG.__bases__[0]._set_fitted_arrays(self, arrays)
+        if 'omegas_' in arrays:
+            self.omegas_ = jnp.asarray(arrays['omegas_'])
+
+    def _get_hyperparams(self):
+        # Call RiemannianSRNG._get_hyperparams (skip SMNG's latent_dim)
+        hp = RiemannianSMNG.__bases__[0]._get_hyperparams(self)
+        hp['subspace_dim'] = self.subspace_dim
+        return hp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,10 @@ all = [
 export = [
     "flatbuffers>=25.12.19",
 ]
+onnx = [
+    "onnx>=1.21.0",
+    "onnxruntime>=1.26.0",
+]
 
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm>=8"]

--- a/sphinx-docs/api/core.rst
+++ b/sphinx-docs/api/core.rst
@@ -118,3 +118,33 @@ Datasets
 .. automodule:: prosemble.datasets.dataset
    :members:
    :undoc-members:
+   :no-index:
+
+ONNX Export
+-----------
+
+.. automodule:: prosemble.core.onnx_export
+   :members: export_onnx
+   :undoc-members:
+
+Manifolds
+---------
+
+.. automodule:: prosemble.core.manifolds
+   :members:
+   :undoc-members:
+
+Protocols
+---------
+
+.. automodule:: prosemble.core.protocols
+   :members:
+   :undoc-members:
+
+Data Utilities
+--------------
+
+.. automodule:: prosemble.core.data
+   :members:
+   :undoc-members:
+   :no-index:

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -349,6 +349,29 @@ Topology-Preserving Models
    :members: fit, predict
    :undoc-members:
 
+Riemannian Models
+-----------------
+
+.. autoclass:: prosemble.models.RiemannianSRNG
+   :members: fit, predict
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianSMNG
+   :members: fit, predict, relevance_matrix
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianSLNG
+   :members: fit, predict
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianSTNG
+   :members: fit, predict
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianNeuralGas
+   :members: fit, predict, transform
+   :undoc-members:
+
 Utility Models
 --------------
 

--- a/sphinx-docs/guides/advanced.rst
+++ b/sphinx-docs/guides/advanced.rst
@@ -560,6 +560,27 @@ The exported function contains only the compiled XLA computation and
 the frozen prototype/metric parameters — no Python dependencies needed
 at inference time.
 
+ONNX Export
+-----------
+
+Export fitted models to ONNX for deployment without JAX or prosemble.
+68 of 71 models are supported, including encoder models (MLP/CNN
+backbones), one-class classifiers, and fuzzy clustering:
+
+.. code-block:: python
+
+   from prosemble.core.onnx_export import export_onnx
+
+   model.fit(X_train, y_train)
+   onnx_model = export_onnx(model, path='model.onnx')
+
+   # Run with ONNX Runtime
+   import onnxruntime as ort
+   session = ort.InferenceSession('model.onnx')
+   preds = session.run(None, {'X': X_test_np})[0]
+
+See the full guide: :doc:`/guides/onnx`.
+
 Prototype Analysis
 -------------------
 

--- a/sphinx-docs/guides/onnx.rst
+++ b/sphinx-docs/guides/onnx.rst
@@ -1,0 +1,222 @@
+ONNX Export
+===========
+
+Prosemble can export fitted models to `ONNX <https://onnx.ai/>`_ format for
+cross-platform deployment.  An exported ONNX model reproduces the ``predict()``
+output of the original model and runs anywhere ONNX Runtime is available —
+no JAX or prosemble dependency needed at inference time.
+
+**68 of 71 models** are supported.
+
+Installation
+------------
+
+ONNX export requires the ``onnx`` package.  For inference, install
+``onnxruntime`` as well:
+
+.. code-block:: bash
+
+   pip install onnx onnxruntime
+
+Basic Usage
+-----------
+
+.. code-block:: python
+
+   from prosemble.models import GLVQ
+   from prosemble.core.onnx_export import export_onnx
+
+   model = GLVQ(n_prototypes_per_class=2, max_iter=100, lr=0.01)
+   model.fit(X_train, y_train)
+
+   # Export to ONNX
+   onnx_model = export_onnx(model, path='glvq_model.onnx')
+
+The ``export_onnx`` function accepts:
+
+- ``model`` — a fitted prosemble model
+- ``batch_size`` — fixed batch dimension (default ``1``; use ``-1`` for
+  dynamic batch size)
+- ``opset_version`` — ONNX opset version (default ``17``)
+- ``path`` — optional file path to save the ONNX model
+
+Running with ONNX Runtime
+--------------------------
+
+.. code-block:: python
+
+   import numpy as np
+   import onnxruntime as ort
+
+   session = ort.InferenceSession('glvq_model.onnx')
+   X_test_np = np.asarray(X_test, dtype=np.float32)
+
+   onnx_preds = session.run(None, {'X': X_test_np})[0]
+
+The ONNX model takes a single input ``X`` of shape ``(batch_size, n_features)``
+and returns an integer array of predicted labels.
+
+Full Workflow Example
+---------------------
+
+.. code-block:: python
+
+   import numpy as np
+   from prosemble.models import GMLVQ
+   from prosemble.datasets import load_iris_jax
+   from prosemble.core.onnx_export import export_onnx
+   import onnxruntime as ort
+
+   # Train
+   dataset = load_iris_jax()
+   X, y = dataset.input_data, dataset.target_data
+   model = GMLVQ(
+       n_prototypes_per_class=1, max_iter=100,
+       lr=0.01, latent_dim=2,
+   )
+   model.fit(X, y)
+
+   # Export
+   onnx_model = export_onnx(model, batch_size=-1, path='gmlvq.onnx')
+
+   # Run with ONNX Runtime
+   session = ort.InferenceSession('gmlvq.onnx')
+   X_np = np.asarray(X, dtype=np.float32)
+   onnx_preds = session.run(None, {'X': X_np})[0]
+
+   # Verify
+   jax_preds = model.predict(X)
+   assert np.array_equal(jax_preds, onnx_preds)
+
+Supported Models
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Family
+     - Count
+     - Models
+   * - Supervised LVQ (squared Euclidean)
+     - 9
+     - GLVQ, GLVQ1, GLVQ21, LVQ1, LVQ21, MedianLVQ, CELVQ, SLVQ, RSLVQ
+   * - Supervised LVQ (global omega)
+     - 2
+     - GMLVQ, MRSLVQ
+   * - Supervised LVQ (local omega)
+     - 2
+     - LGMLVQ, LMRSLVQ
+   * - Supervised LVQ (tangent)
+     - 1
+     - GTLVQ
+   * - Supervised NG (squared Euclidean)
+     - 3
+     - SRNG, CELVQ_NG, RSLVQ_NG
+   * - Supervised NG (global omega)
+     - 3
+     - SMNG, MCELVQ_NG, MRSLVQ_NG
+   * - Supervised NG (local omega)
+     - 3
+     - SLNG, LCELVQ_NG, LMRSLVQ_NG
+   * - Supervised NG (tangent)
+     - 2
+     - STNG, TCELVQ_NG
+   * - Unsupervised
+     - 3
+     - NeuralGas, KohonenSOM, HeskesSOM
+   * - Fuzzy clustering
+     - 8
+     - FCM, PCM, FPCM, PFCM, AFCM, HCM, IPCM, IPCM2
+   * - One-class GLVQ
+     - 10
+     - OCGLVQ, OCGLVQ_NG, OCGRLVQ, OCGRLVQ_NG, OCGMLVQ, OCGMLVQ_NG, OCLGMLVQ, OCLGMLVQ_NG, OCGTLVQ, OCGTLVQ_NG
+   * - One-class RSLVQ
+     - 6
+     - OCRSLVQ, OCRSLVQ_NG, OCMRSLVQ, OCMRSLVQ_NG, OCLMRSLVQ, OCLMRSLVQ_NG
+   * - SVQ-OCC
+     - 5
+     - SVQOCC, SVQOCC_R, SVQOCC_M, SVQOCC_LM, SVQOCC_T
+   * - MLP encoder + WTAC
+     - 4
+     - SiameseGLVQ, SiameseGMLVQ, SiameseGTLVQ, LVQMLN
+   * - CNN encoder + WTAC
+     - 3
+     - ImageGLVQ, ImageGMLVQ, ImageGTLVQ
+   * - PLVQ (Gaussian mixture)
+     - 1
+     - PLVQ
+   * - CBC (reasoning matrices)
+     - 2
+     - CBC, ImageCBC
+
+Encoder Models
+--------------
+
+Models with MLP or CNN backbones (Siamese, Image, LVQMLN, PLVQ, ImageCBC)
+are fully supported.  The ONNX graph encodes the backbone as standard ops:
+
+- **MLP**: ``MatMul`` :math:`\rightarrow` ``Add`` :math:`\rightarrow`
+  ``Activation`` per layer
+- **CNN**: ``Conv`` (SAME padding) :math:`\rightarrow` ``Activation``
+  per layer :math:`\rightarrow` ``GlobalAveragePool`` :math:`\rightarrow`
+  ``Linear``
+
+Prototypes are pre-computed in the latent space at export time, so only the
+input needs to be encoded at runtime.  Supported activations: Sigmoid, ReLU,
+Tanh, LeakyReLU, SELU.
+
+Distance Functions in ONNX
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 40 30
+
+   * - Distance
+     - ONNX Implementation
+     - Models
+   * - Squared Euclidean
+     - Expansion trick
+     - GLVQ family, NG, NeuralGas, FCM, OC, SVQ-OCC, Encoders, CBC
+   * - Global Omega
+     - Project then squared Euclidean
+     - GMLVQ, MRSLVQ, SMNG, OCGMLVQ, SVQOCC_M
+   * - Local Omega
+     - Batched MatMul per prototype
+     - LGMLVQ, SLNG, OCLGMLVQ, SVQOCC_LM
+   * - Tangent
+     - Batched project-reconstruct
+     - GTLVQ, STNG, OCGTLVQ, SVQOCC_T
+   * - Relevance-weighted
+     - Element-wise weighted squared diff
+     - OCGRLVQ, SVQOCC_R
+
+Not Supported
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Models
+     - Count
+     - Reason
+   * - Kernel fuzzy clustering (KFCM, KPCM, KFPCM, KPFCM, KAFCM, KIPCM, KIPCM2)
+     - 7
+     - Gaussian kernel distance has no standard ONNX operator
+   * - Riemannian models (RiemannianSRNG, RiemannianSMNG, RiemannianSLNG, RiemannianSTNG, RiemannianNeuralGas)
+     - 5
+     - Matrix logarithm/exponential and eigendecomposition have no ONNX operator
+   * - GrowingNeuralGas
+     - 1
+     - Dynamic topology (variable number of prototypes)
+   * - KNN
+     - 1
+     - k-nearest-neighbor logic, not prototype-based
+   * - NPC
+     - 1
+     - Different predict pattern
+   * - Utility (KMeansPlusPlus, Kmeans, BGPC)
+     - 3
+     - Not prototype model base classes

--- a/sphinx-docs/guides/riemannian.rst
+++ b/sphinx-docs/guides/riemannian.rst
@@ -1,0 +1,224 @@
+Riemannian Models
+=================
+
+Prosemble provides prototype-based learning on Riemannian manifolds.
+Prototypes live directly on the manifold and distances are computed via
+the intrinsic geodesic metric, preserving the geometric structure of the
+data.
+
+Supported Manifolds
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Manifold
+     - Points
+     - Applications
+   * - **SO(n)**
+     - :math:`n \times n` rotation matrices
+     - Robotics (grasp/pose), 3D vision, structural biology
+   * - **SPD(n)**
+     - :math:`n \times n` symmetric positive definite matrices
+     - EEG/BCI (covariance matrices), diffusion tensor imaging
+   * - **Gr(n, k)**
+     - :math:`k`-dimensional subspaces of :math:`\mathbb{R}^n`
+     - Hyperspectral imaging, video analysis, subspace tracking
+
+All three are available from ``prosemble.core.manifolds``:
+
+.. code-block:: python
+
+   from prosemble.core.manifolds import SO, SPD, Grassmannian
+
+   so3 = SO(3)           # 3x3 rotation matrices
+   spd4 = SPD(4)         # 4x4 SPD matrices
+   gr5_2 = Grassmannian(5, 2)  # 2D subspaces of R^5
+
+RiemannianSRNG
+--------------
+
+Supervised Riemannian Neural Gas.  Combines GLVQ-style margin-based
+classification with Neural Gas neighbourhood cooperation on the manifold.
+
+The loss for each sample uses all same-class prototypes, rank-weighted by
+:math:`h(k) = \exp(-k / \gamma)`:
+
+.. math::
+
+   \mathcal{L} = \sum_i \sum_j h(k_j) \cdot \sigma\!\left(\frac{d^+(x_i) - d^-(x_i)}{d^+(x_i) + d^-(x_i)}\right)
+
+where :math:`d^+, d^-` are the nearest same-class and different-class
+geodesic distances.
+
+.. code-block:: python
+
+   from prosemble.models import RiemannianSRNG
+   from prosemble.core.manifolds import SO
+   import jax.numpy as jnp
+
+   # Generate synthetic rotation data
+   key = jax.random.PRNGKey(0)
+   manifold = SO(3)
+   X = jnp.stack([manifold.random_point(jax.random.fold_in(key, i))
+                   for i in range(40)])
+   X = X.reshape(40, -1)  # flatten to (n_samples, 9)
+   y = jnp.array([0] * 20 + [1] * 20)
+
+   model = RiemannianSRNG(
+       manifold=manifold,
+       n_prototypes_per_class=2,
+       max_iter=50,
+       lr=0.01,
+       gamma_final=0.01,
+   )
+   model.fit(X, y)
+   labels = model.predict(X)
+
+RiemannianSMNG
+--------------
+
+Supervised Matrix Neural Gas on manifolds.  Adds a global metric
+adaptation matrix :math:`\Omega` that operates in the tangent space at
+each prototype:
+
+.. math::
+
+   d(x, w_k) = \|\Omega \cdot \text{Log}_{w_k}(x)\|^2
+
+where :math:`\text{Log}_{w_k}` is the Riemannian logarithmic map
+(tangent vector from :math:`w_k` to :math:`x`).
+
+.. code-block:: python
+
+   from prosemble.models import RiemannianSMNG
+   from prosemble.core.manifolds import SPD
+
+   manifold = SPD(3)
+   model = RiemannianSMNG(
+       manifold=manifold,
+       n_prototypes_per_class=2,
+       latent_dim=4,
+       max_iter=50,
+       lr=0.01,
+   )
+   model.fit(X, y)
+
+   # Learned relevance matrix
+   print(model.relevance_matrix().shape)
+
+RiemannianSLNG
+--------------
+
+Supervised Localized Matrix Neural Gas.  Each prototype :math:`w_k` has
+its own metric matrix :math:`\Omega_k`:
+
+.. math::
+
+   d(x, w_k) = \|\Omega_k \cdot \text{Log}_{w_k}(x)\|^2
+
+This allows different prototypes to focus on different tangent directions,
+useful when the discriminative structure varies across the manifold.
+
+.. code-block:: python
+
+   from prosemble.models import RiemannianSLNG
+   from prosemble.core.manifolds import Grassmannian
+
+   manifold = Grassmannian(5, 2)
+   model = RiemannianSLNG(
+       manifold=manifold,
+       n_prototypes_per_class=2,
+       latent_dim=3,
+       max_iter=50,
+       lr=0.01,
+   )
+   model.fit(X, y)
+
+RiemannianSTNG
+--------------
+
+Supervised Tangent Neural Gas.  Each prototype has a tangent subspace
+:math:`\Omega_k`, and distance is measured in the complement of that
+subspace (the residual after projection):
+
+.. math::
+
+   d(x, w_k) = \|\text{Log}_{w_k}(x) - \Omega_k \Omega_k^T \text{Log}_{w_k}(x)\|^2
+
+This captures invariance structure — directions spanned by
+:math:`\Omega_k` are ignored.
+
+.. code-block:: python
+
+   from prosemble.models import RiemannianSTNG
+   from prosemble.core.manifolds import SO
+
+   manifold = SO(3)
+   model = RiemannianSTNG(
+       manifold=manifold,
+       n_prototypes_per_class=2,
+       subspace_dim=2,
+       max_iter=50,
+       lr=0.01,
+   )
+   model.fit(X, y)
+
+RiemannianNeuralGas
+-------------------
+
+Unsupervised Neural Gas on Riemannian manifolds.  Distributes prototypes
+to match the data density using rank-based cooperation with geodesic
+distances and exponential map updates.
+
+.. code-block:: python
+
+   from prosemble.models import RiemannianNeuralGas
+   from prosemble.core.manifolds import SO
+
+   manifold = SO(3)
+   model = RiemannianNeuralGas(
+       manifold=manifold,
+       n_prototypes=5,
+       max_iter=50,
+       lr_init=0.3,
+       lr_final=0.01,
+       lambda_final=0.01,
+   )
+   model.fit(X)
+
+   labels = model.predict(X)       # nearest prototype assignment
+   distances = model.transform(X)  # geodesic distance matrix
+
+.. note::
+
+   All Riemannian models use **Python loops** (not ``lax.scan``) because
+   manifold projection after each gradient step is not compatible with
+   JAX's functional loop primitives.
+
+Choosing a Model
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 30 45
+
+   * - Model
+     - Metric
+     - Best For
+   * - RiemannianSRNG
+     - Geodesic distance
+     - General manifold classification
+   * - RiemannianSMNG
+     - Global :math:`\Omega` in tangent space
+     - Feature selection on manifolds
+   * - RiemannianSLNG
+     - Per-prototype :math:`\Omega_k`
+     - Heterogeneous tangent structure
+   * - RiemannianSTNG
+     - Tangent subspace projection
+     - Invariance learning on manifolds
+   * - RiemannianNeuralGas
+     - Geodesic distance
+     - Unsupervised manifold clustering

--- a/sphinx-docs/guides/topology.rst
+++ b/sphinx-docs/guides/topology.rst
@@ -141,10 +141,39 @@ is highest, automatically focusing model capacity on complex data regions.
    topology (changing number of nodes and edges). It uses Python loops
    instead of ``lax.scan``.
 
+Riemannian Neural Gas
+---------------------
+
+Neural Gas extended to Riemannian manifolds.  Prototypes live on the
+manifold and are updated via exponential maps.  Supports SO(n), SPD(n),
+and Grassmannian(n,k).
+
+.. code-block:: python
+
+   from prosemble.models import RiemannianNeuralGas
+   from prosemble.core.manifolds import SO
+
+   manifold = SO(3)
+   model = RiemannianNeuralGas(
+       manifold=manifold,
+       n_prototypes=5,
+       max_iter=50,
+       lr_init=0.3,
+       lr_final=0.01,
+       lambda_final=0.01,
+   )
+   model.fit(X)  # X: (n_samples, 9) flattened 3x3 rotation matrices
+
+   labels = model.predict(X)
+   distances = model.transform(X)
+
 .. note::
 
-   **Riemannian Neural Gas** (Neural Gas on manifolds: SO(n), SPD(n),
-   Grassmannian) is available via ``prosemble.models.RiemannianNeuralGas``.
+   Riemannian Neural Gas uses **Python loops** (not ``lax.scan``) because
+   manifold projection is required after each update step.
+
+For supervised Riemannian models (RiemannianSRNG, RiemannianSMNG,
+RiemannianSLNG, RiemannianSTNG), see :doc:`/guides/riemannian`.
 
 Choosing a Model
 ----------------

--- a/sphinx-docs/index.rst
+++ b/sphinx-docs/index.rst
@@ -14,6 +14,8 @@ JIT-compiled and run on CPU, GPU, and TPU.
    guides/one_class
    guides/clustering
    guides/topology
+   guides/riemannian
+   guides/onnx
    guides/advanced
    api/models
    api/core

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,123 @@
+"""Tests for prosemble.core.data — batching and shuffling utilities."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+
+from prosemble.core.data import shuffle_arrays, padded_batches, batched_iterator
+
+
+class TestShuffleArrays:
+
+    def test_same_permutation(self):
+        key = jax.random.PRNGKey(0)
+        X = jnp.arange(12).reshape(4, 3)
+        y = jnp.array([10, 20, 30, 40])
+        X_s, y_s = shuffle_arrays(key, X, y)
+
+        # Each row of X_s should correspond to the same y_s label
+        for i in range(4):
+            # Find the original index of this row
+            orig_idx = int(X_s[i, 0]) // 3
+            assert y_s[i] == y[orig_idx]
+
+    def test_shapes_preserved(self):
+        key = jax.random.PRNGKey(1)
+        a = jnp.ones((5, 3))
+        b = jnp.ones((5,))
+        c = jnp.ones((5, 2, 2))
+        a_s, b_s, c_s = shuffle_arrays(key, a, b, c)
+        assert a_s.shape == (5, 3)
+        assert b_s.shape == (5,)
+        assert c_s.shape == (5, 2, 2)
+
+    def test_empty(self):
+        key = jax.random.PRNGKey(2)
+        result = shuffle_arrays(key)
+        assert result == ()
+
+    def test_single_array(self):
+        key = jax.random.PRNGKey(3)
+        X = jnp.arange(6).reshape(3, 2)
+        X_s, = shuffle_arrays(key, X)
+        assert X_s.shape == (3, 2)
+        # All original rows should be present
+        assert set(int(X_s[i, 0]) for i in range(3)) == {0, 2, 4}
+
+
+class TestPaddedBatches:
+
+    def test_exact_division(self):
+        X = jnp.ones((8, 3))
+        y = jnp.arange(8)
+        X_b, y_b = padded_batches(X, y, batch_size=4)
+        assert X_b.shape == (2, 4, 3)
+        assert y_b.shape == (2, 4)
+
+    def test_padding(self):
+        X = jnp.ones((10, 3))
+        y = jnp.arange(10)
+        X_b, y_b = padded_batches(X, y, batch_size=4)
+        # 10 -> 12 (3 batches of 4)
+        assert X_b.shape == (3, 4, 3)
+        assert y_b.shape == (3, 4)
+
+    def test_no_labels(self):
+        X = jnp.ones((10, 3))
+        X_b, y_b = padded_batches(X, batch_size=4)
+        assert X_b.shape == (3, 4, 3)
+        assert y_b is None
+
+    def test_with_shuffle(self):
+        key = jax.random.PRNGKey(42)
+        X = jnp.arange(20).reshape(10, 2)
+        y = jnp.arange(10)
+        X_b, y_b = padded_batches(X, y, batch_size=4, key=key)
+        assert X_b.shape == (3, 4, 2)
+        # After shuffling and padding, we should still have valid data
+        assert not jnp.all(X_b[0] == X[:4])  # very likely shuffled
+
+    def test_single_batch(self):
+        X = jnp.ones((3, 2))
+        X_b, y_b = padded_batches(X, batch_size=5)
+        assert X_b.shape == (1, 5, 2)
+
+
+class TestBatchedIterator:
+
+    def test_basic_iteration(self):
+        X = jnp.ones((10, 3))
+        y = jnp.arange(10)
+        batches = list(batched_iterator(X, y, batch_size=4, shuffle=False))
+        assert len(batches) == 3
+        assert batches[0][0].shape == (4, 3)
+        assert batches[1][0].shape == (4, 3)
+        assert batches[2][0].shape == (2, 3)  # last batch is smaller
+
+    def test_drop_last(self):
+        X = jnp.ones((10, 3))
+        batches = list(batched_iterator(X, batch_size=4, shuffle=False, drop_last=True))
+        assert len(batches) == 2
+        for X_b, _ in batches:
+            assert X_b.shape[0] == 4
+
+    def test_no_labels(self):
+        X = jnp.ones((10, 3))
+        for X_b, y_b in batched_iterator(X, batch_size=4, shuffle=False):
+            assert y_b is None
+
+    def test_shuffle(self):
+        key = jax.random.PRNGKey(0)
+        X = jnp.arange(20).reshape(10, 2)
+        y = jnp.arange(10)
+        batches = list(batched_iterator(X, y, batch_size=4, key=key))
+        # Check that data was shuffled
+        first_batch_X = batches[0][0]
+        assert not jnp.array_equal(first_batch_X, X[:4])
+
+    def test_exact_division(self):
+        X = jnp.ones((8, 3))
+        batches = list(batched_iterator(X, batch_size=4, shuffle=False))
+        assert len(batches) == 2
+        for X_b, _ in batches:
+            assert X_b.shape[0] == 4

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -1,0 +1,1072 @@
+"""Tests for prosemble.core.onnx_export — ONNX model export."""
+
+import pytest
+import numpy as np
+import numpy.testing as npt
+import jax.numpy as jnp
+
+onnx = pytest.importorskip("onnx")
+ort = pytest.importorskip("onnxruntime")
+
+from prosemble.models import GLVQ, GMLVQ, NeuralGas, FCM, KFCM
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_supervised_data(n=60, d=4, n_classes=3, seed=42):
+    np.random.seed(seed)
+    X = jnp.array(np.random.randn(n, d).astype(np.float32))
+    y = jnp.array(np.tile(np.arange(n_classes), n // n_classes))
+    return X, y
+
+
+def _make_oc_data(n=60, d=4, seed=42):
+    """One-class data: label 1 = target (normal), label 0 = outlier."""
+    np.random.seed(seed)
+    # 40 normal samples (class 1), 20 outliers (class 0)
+    X_normal = np.random.randn(40, d).astype(np.float32)
+    X_outlier = np.random.randn(20, d).astype(np.float32) + 5.0
+    X = jnp.array(np.concatenate([X_normal, X_outlier], axis=0))
+    y = jnp.array([1]*40 + [0]*20)
+    return X, y
+
+
+def _onnx_predict(model, X, batch_size=None):
+    """Run ONNX inference and return predictions."""
+    if batch_size is None:
+        batch_size = X.shape[0]
+    onnx_model = model.export_onnx(batch_size=batch_size)
+    sess = ort.InferenceSession(onnx_model.SerializeToString())
+    return sess.run(None, {'X': np.asarray(X)})[0]
+
+
+# ---------------------------------------------------------------------------
+# Existing tests: GLVQ, GMLVQ, NeuralGas, FCM
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fitted_glvq():
+    X, y = _make_supervised_data(30, 4)
+    model = GLVQ(n_prototypes_per_class=1, max_iter=5, random_seed=42)
+    model.fit(X, y)
+    return model, X, y
+
+
+@pytest.fixture
+def fitted_gmlvq():
+    X, y = _make_supervised_data(30, 4)
+    model = GMLVQ(n_prototypes_per_class=1, max_iter=5, random_seed=42)
+    model.fit(X, y)
+    return model, X, y
+
+
+@pytest.fixture
+def fitted_ng():
+    np.random.seed(42)
+    X = jnp.array(np.random.randn(30, 4).astype(np.float32))
+    model = NeuralGas(n_prototypes=3, max_iter=5, random_seed=42)
+    model.fit(X)
+    return model, X
+
+
+class TestGLVQExport:
+
+    def test_export_returns_model_proto(self, fitted_glvq):
+        model, X, y = fitted_glvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_export_saves_to_file(self, fitted_glvq, tmp_path):
+        model, X, y = fitted_glvq
+        path = str(tmp_path / "glvq.onnx")
+        model.export_onnx(path=path)
+        assert (tmp_path / "glvq.onnx").exists()
+
+    def test_numerical_match(self, fitted_glvq):
+        model, X, y = fitted_glvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+    def test_single_sample(self, fitted_glvq):
+        model, X, y = fitted_glvq
+        x_single = X[:1]
+        jax_pred = np.asarray(model.predict(x_single))
+        ort_pred = _onnx_predict(model, x_single, batch_size=1)
+        npt.assert_array_equal(jax_pred, ort_pred)
+
+
+class TestGMLVQExport:
+
+    def test_omega_distance_detected(self, fitted_gmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X, y = fitted_gmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'omega'
+
+    def test_export_returns_model_proto(self, fitted_gmlvq):
+        model, X, y = fitted_gmlvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_gmlvq):
+        model, X, y = fitted_gmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestNeuralGasExport:
+
+    def test_unsupervised_export(self, fitted_ng):
+        model, X = fitted_ng
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ng):
+        model, X = fitted_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestFCMExport:
+
+    @pytest.fixture
+    def fitted_fcm(self):
+        np.random.seed(42)
+        X = jnp.array(np.random.randn(30, 4).astype(np.float32))
+        model = FCM(n_clusters=3, max_iter=20, random_seed=42)
+        model.fit(X)
+        return model, X
+
+    def test_export_returns_model_proto(self, fitted_fcm):
+        model, X = fitted_fcm
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_fcm):
+        model, X = fitted_fcm
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+    def test_export_saves_to_file(self, fitted_fcm, tmp_path):
+        model, X = fitted_fcm
+        path = str(tmp_path / "fcm.onnx")
+        model.export_onnx(path=path)
+        assert (tmp_path / "fcm.onnx").exists()
+
+
+class TestKernelFuzzyRejection:
+
+    def test_kfcm_raises(self):
+        from prosemble.core.onnx_export import _check_model_exportable
+        model = KFCM(n_clusters=3, max_iter=1)
+        with pytest.raises(NotImplementedError, match="kernel fuzzy"):
+            _check_model_exportable(model)
+
+
+class TestUnsupportedModels:
+
+    def test_riemannian_raises(self):
+        from prosemble.core.manifolds import SO
+        from prosemble.models import RiemannianSRNG
+        model = RiemannianSRNG(manifold=SO(3), n_prototypes_per_class=1, max_iter=1)
+        from prosemble.core.onnx_export import _check_model_exportable
+        with pytest.raises(NotImplementedError, match="Riemannian"):
+            _check_model_exportable(model)
+
+    def test_riemannian_ng_raises(self):
+        from prosemble.core.manifolds import SO
+        from prosemble.models import RiemannianNeuralGas
+        model = RiemannianNeuralGas(manifold=SO(3), n_prototypes=2, max_iter=1)
+        from prosemble.core.onnx_export import _check_model_exportable
+        with pytest.raises(NotImplementedError, match="RiemannianNeuralGas"):
+            _check_model_exportable(model)
+
+
+class TestOnnxImportGuard:
+
+    def test_export_onnx_importable(self):
+        from prosemble.core import export_onnx
+        assert callable(export_onnx)
+
+
+# ---------------------------------------------------------------------------
+# NEW: Local omega / tangent supervised models
+# ---------------------------------------------------------------------------
+
+class TestLocalOmegaExport:
+    """LGMLVQ: per-prototype Omega, ||Omega_k (x - w_k)||^2, WTAC."""
+
+    @pytest.fixture
+    def fitted_lgmlvq(self):
+        from prosemble.models import LGMLVQ
+        X, y = _make_supervised_data(60, 4)
+        model = LGMLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_lgmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_lgmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'local_omega'
+
+    def test_export_returns_model_proto(self, fitted_lgmlvq):
+        model, X = fitted_lgmlvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_lgmlvq):
+        model, X = fitted_lgmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestTangentExport:
+    """GTLVQ: per-prototype tangent subspace, orthogonal complement distance."""
+
+    @pytest.fixture
+    def fitted_gtlvq(self):
+        from prosemble.models import GTLVQ
+        X, y = _make_supervised_data(60, 4)
+        model = GTLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            subspace_dim=2, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_gtlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_gtlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'tangent'
+
+    def test_export_returns_model_proto(self, fitted_gtlvq):
+        model, X = fitted_gtlvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_gtlvq):
+        model, X = fitted_gtlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestSLNGExport:
+    """SLNG: same local omega distance as LGMLVQ, NG training only."""
+
+    @pytest.fixture
+    def fitted_slng(self):
+        from prosemble.models import SLNG
+        X, y = _make_supervised_data(60, 4)
+        model = SLNG(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_numerical_match(self, fitted_slng):
+        model, X = fitted_slng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestSTNGExport:
+    """STNG: same tangent distance as GTLVQ, NG training only."""
+
+    @pytest.fixture
+    def fitted_stng(self):
+        from prosemble.models import STNG
+        X, y = _make_supervised_data(60, 4)
+        model = STNG(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            subspace_dim=2, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_numerical_match(self, fitted_stng):
+        model, X = fitted_stng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestLMRSLVQExport:
+    """LMRSLVQ: local omega + RSLVQ loss."""
+
+    @pytest.fixture
+    def fitted_lmrslvq(self):
+        from prosemble.models import LMRSLVQ
+        X, y = _make_supervised_data(60, 4)
+        model = LMRSLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_numerical_match(self, fitted_lmrslvq):
+        model, X = fitted_lmrslvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: One-class hard nearest models
+# ---------------------------------------------------------------------------
+
+class TestOCGLVQExport:
+    """OCGLVQ: squared Euclidean + hard nearest decision."""
+
+    @pytest.fixture
+    def fitted_ocglvq(self):
+        from prosemble.models import OCGLVQ
+        X, y = _make_oc_data()
+        model = OCGLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocglvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocglvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_ocglvq):
+        model, X = fitted_ocglvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ocglvq):
+        model, X = fitted_ocglvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+    def test_single_sample(self, fitted_ocglvq):
+        model, X = fitted_ocglvq
+        x_single = X[:1]
+        jax_pred = np.asarray(model.predict(x_single))
+        ort_pred = _onnx_predict(model, x_single, batch_size=1)
+        npt.assert_array_equal(jax_pred, ort_pred)
+
+
+class TestOCGMLVQExport:
+    """OCGMLVQ: global omega + hard nearest decision."""
+
+    @pytest.fixture
+    def fitted_ocgmlvq(self):
+        from prosemble.models import OCGMLVQ
+        X, y = _make_oc_data()
+        model = OCGMLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocgmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocgmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'omega'
+
+    def test_numerical_match(self, fitted_ocgmlvq):
+        model, X = fitted_ocgmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCGRLVQExport:
+    """OCGRLVQ: relevance-weighted + hard nearest decision."""
+
+    @pytest.fixture
+    def fitted_ocgrlvq(self):
+        from prosemble.models import OCGRLVQ
+        X, y = _make_oc_data()
+        model = OCGRLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocgrlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocgrlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'relevance'
+
+    def test_numerical_match(self, fitted_ocgrlvq):
+        model, X = fitted_ocgrlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCLGMLVQExport:
+    """OCLGMLVQ: local omega + hard nearest decision."""
+
+    @pytest.fixture
+    def fitted_oclgmlvq(self):
+        from prosemble.models import OCLGMLVQ
+        X, y = _make_oc_data()
+        model = OCLGMLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_oclgmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_oclgmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'local_omega'
+
+    def test_numerical_match(self, fitted_oclgmlvq):
+        model, X = fitted_oclgmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCGTLVQExport:
+    """OCGTLVQ: tangent + hard nearest decision."""
+
+    @pytest.fixture
+    def fitted_ocgtlvq(self):
+        from prosemble.models import OCGTLVQ
+        X, y = _make_oc_data()
+        model = OCGTLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            subspace_dim=2, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocgtlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocgtlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'tangent'
+
+    def test_numerical_match(self, fitted_ocgtlvq):
+        model, X = fitted_ocgtlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: One-class Gaussian soft models
+# ---------------------------------------------------------------------------
+
+class TestOCRSLVQExport:
+    """OCRSLVQ: squared Euclidean + Gaussian soft decision."""
+
+    @pytest.fixture
+    def fitted_ocrslvq(self):
+        from prosemble.models import OCRSLVQ
+        X, y = _make_oc_data()
+        model = OCRSLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            sigma=1.0, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocrslvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocrslvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_gaussian_soft'
+        assert dist_type == 'squared_euclidean'
+
+    def test_numerical_match(self, fitted_ocrslvq):
+        model, X = fitted_ocrslvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCMRSLVQExport:
+    """OCMRSLVQ: global omega + Gaussian soft decision."""
+
+    @pytest.fixture
+    def fitted_ocmrslvq(self):
+        from prosemble.models import OCMRSLVQ
+        X, y = _make_oc_data()
+        model = OCMRSLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            sigma=1.0, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocmrslvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocmrslvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_gaussian_soft'
+        assert dist_type == 'omega'
+
+    def test_numerical_match(self, fitted_ocmrslvq):
+        model, X = fitted_ocmrslvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: One-class Gaussian+NG models
+# ---------------------------------------------------------------------------
+
+class TestOCRSLVQNGExport:
+    """OCRSLVQ_NG: squared Euclidean + Gaussian+NG soft decision."""
+
+    @pytest.fixture
+    def fitted_ocrslvq_ng(self):
+        from prosemble.models import OCRSLVQ_NG
+        X, y = _make_oc_data()
+        model = OCRSLVQ_NG(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            sigma=1.0, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocrslvq_ng):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocrslvq_ng
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_gaussian_ng'
+        assert dist_type == 'squared_euclidean'
+
+    def test_numerical_match(self, fitted_ocrslvq_ng):
+        model, X = fitted_ocrslvq_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: SVQ-OCC models
+# ---------------------------------------------------------------------------
+
+class TestSVQOCCExport:
+    """SVQOCC: squared Euclidean + Gaussian response."""
+
+    @pytest.fixture
+    def fitted_svqocc(self):
+        from prosemble.models import SVQOCC
+        X, y = _make_oc_data()
+        model = SVQOCC(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            response_type='gaussian', random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_svqocc):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_svqocc
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'svqocc'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_svqocc):
+        model, X = fitted_svqocc
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_svqocc):
+        model, X = fitted_svqocc
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestSVQOCCStudentTExport:
+    """SVQOCC with Student-t response."""
+
+    @pytest.fixture
+    def fitted_svqocc_t_response(self):
+        from prosemble.models import SVQOCC
+        X, y = _make_oc_data()
+        model = SVQOCC(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            response_type='student_t', random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_numerical_match(self, fitted_svqocc_t_response):
+        model, X = fitted_svqocc_t_response
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestSVQOCCUniformExport:
+    """SVQOCC with uniform response."""
+
+    @pytest.fixture
+    def fitted_svqocc_uniform(self):
+        from prosemble.models import SVQOCC
+        X, y = _make_oc_data()
+        model = SVQOCC(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            response_type='uniform', random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_numerical_match(self, fitted_svqocc_uniform):
+        model, X = fitted_svqocc_uniform
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestSVQOCCOmegaExport:
+    """SVQOCC_M: global omega + SVQ-OCC response."""
+
+    @pytest.fixture
+    def fitted_svqocc_m(self):
+        from prosemble.models import SVQOCC_M
+        X, y = _make_oc_data()
+        model = SVQOCC_M(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            response_type='gaussian', random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_svqocc_m):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_svqocc_m
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'svqocc'
+        assert dist_type == 'omega'
+
+    def test_numerical_match(self, fitted_svqocc_m):
+        model, X = fitted_svqocc_m
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestSVQOCCTangentExport:
+    """SVQOCC_T: tangent + SVQ-OCC response."""
+
+    @pytest.fixture
+    def fitted_svqocc_t(self):
+        from prosemble.models import SVQOCC_T
+        X, y = _make_oc_data()
+        model = SVQOCC_T(
+            n_prototypes=3, max_iter=10, lr=0.01,
+            subspace_dim=2, response_type='gaussian', random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_svqocc_t):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_svqocc_t
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'svqocc'
+        assert dist_type == 'tangent'
+
+    def test_numerical_match(self, fitted_svqocc_t):
+        model, X = fitted_svqocc_t
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: Encoder models (MLP backbone)
+# ---------------------------------------------------------------------------
+
+def _make_image_data(n=40, input_shape=(8, 8, 1), n_classes=2, seed=42):
+    """Generate synthetic flat image data for CNN encoder model tests."""
+    np.random.seed(seed)
+    d = int(np.prod(input_shape))
+    X = np.random.randn(n, d).astype(np.float32)
+    y = np.tile(np.arange(n_classes), n // n_classes)[:n]
+    return jnp.array(X), jnp.array(y)
+
+
+class TestSiameseGLVQExport:
+    """SiameseGLVQ: MLP encoder + squared Euclidean + WTAC."""
+
+    @pytest.fixture
+    def fitted_siamese_glvq(self):
+        from prosemble.models import SiameseGLVQ
+        X, y = _make_supervised_data(40, 4, n_classes=2)
+        model = SiameseGLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            hidden_sizes=[8], latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_siamese_glvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_siamese_glvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_siamese_glvq):
+        model, X = fitted_siamese_glvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_siamese_glvq):
+        model, X = fitted_siamese_glvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+    def test_single_sample(self, fitted_siamese_glvq):
+        model, X = fitted_siamese_glvq
+        x_single = X[:1]
+        jax_pred = np.asarray(model.predict(x_single))
+        ort_pred = _onnx_predict(model, x_single, batch_size=1)
+        npt.assert_array_equal(jax_pred, ort_pred)
+
+
+class TestSiameseGMLVQExport:
+    """SiameseGMLVQ: MLP encoder + omega distance + WTAC."""
+
+    @pytest.fixture
+    def fitted_siamese_gmlvq(self):
+        from prosemble.models import SiameseGMLVQ
+        X, y = _make_supervised_data(40, 4, n_classes=2)
+        model = SiameseGMLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            hidden_sizes=[8], latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_siamese_gmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_siamese_gmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'omega'
+
+    def test_numerical_match(self, fitted_siamese_gmlvq):
+        model, X = fitted_siamese_gmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestSiameseGTLVQExport:
+    """SiameseGTLVQ: MLP encoder + tangent distance + WTAC."""
+
+    @pytest.fixture
+    def fitted_siamese_gtlvq(self):
+        from prosemble.models import SiameseGTLVQ
+        X, y = _make_supervised_data(40, 4, n_classes=2)
+        model = SiameseGTLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            hidden_sizes=[8], latent_dim=3, subspace_dim=2,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_siamese_gtlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_siamese_gtlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'tangent'
+
+    def test_numerical_match(self, fitted_siamese_gtlvq):
+        model, X = fitted_siamese_gtlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: Encoder models (CNN backbone)
+# ---------------------------------------------------------------------------
+
+class TestImageGLVQExport:
+    """ImageGLVQ: CNN encoder + squared Euclidean + WTAC."""
+
+    @pytest.fixture
+    def fitted_image_glvq(self):
+        from prosemble.models import ImageGLVQ
+        input_shape = (8, 8, 1)
+        X, y = _make_image_data(40, input_shape, n_classes=2)
+        model = ImageGLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            input_shape=input_shape, channels=[4], kernel_sizes=[3],
+            latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_image_glvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_image_glvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_image_glvq):
+        model, X = fitted_image_glvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_image_glvq):
+        model, X = fitted_image_glvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+    def test_single_sample(self, fitted_image_glvq):
+        model, X = fitted_image_glvq
+        x_single = X[:1]
+        jax_pred = np.asarray(model.predict(x_single))
+        ort_pred = _onnx_predict(model, x_single, batch_size=1)
+        npt.assert_array_equal(jax_pred, ort_pred)
+
+
+class TestImageGMLVQExport:
+    """ImageGMLVQ: CNN encoder + omega distance + WTAC."""
+
+    @pytest.fixture
+    def fitted_image_gmlvq(self):
+        from prosemble.models import ImageGMLVQ
+        input_shape = (8, 8, 1)
+        X, y = _make_image_data(40, input_shape, n_classes=2)
+        model = ImageGMLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            input_shape=input_shape, channels=[4], kernel_sizes=[3],
+            latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_image_gmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_image_gmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'omega'
+
+    def test_numerical_match(self, fitted_image_gmlvq):
+        model, X = fitted_image_gmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestImageGTLVQExport:
+    """ImageGTLVQ: CNN encoder + tangent distance + WTAC."""
+
+    @pytest.fixture
+    def fitted_image_gtlvq(self):
+        from prosemble.models import ImageGTLVQ
+        input_shape = (8, 8, 1)
+        X, y = _make_image_data(40, input_shape, n_classes=2)
+        model = ImageGTLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            input_shape=input_shape, channels=[4], kernel_sizes=[3],
+            latent_dim=3, subspace_dim=2, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_image_gtlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_image_gtlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'tangent'
+
+    def test_numerical_match(self, fitted_image_gtlvq):
+        model, X = fitted_image_gtlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: LVQMLN and PLVQ (MLP encoder, prototypes in latent space)
+# ---------------------------------------------------------------------------
+
+class TestLVQMLNExport:
+    """LVQMLN: MLP encoder + squared Euclidean + WTAC (latent protos)."""
+
+    @pytest.fixture
+    def fitted_lvqmln(self):
+        from prosemble.models import LVQMLN
+        X, y = _make_supervised_data(40, 4, n_classes=2)
+        model = LVQMLN(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            hidden_sizes=[8], latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_lvqmln):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_lvqmln
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_lvqmln):
+        model, X = fitted_lvqmln
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_lvqmln):
+        model, X = fitted_lvqmln
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestPLVQExport:
+    """PLVQ: MLP encoder + Gaussian mixture soft assignment."""
+
+    @pytest.fixture
+    def fitted_plvq(self):
+        from prosemble.models import PLVQ
+        X, y = _make_supervised_data(40, 4, n_classes=2)
+        model = PLVQ(
+            n_prototypes_per_class=2, max_iter=10, lr=0.01,
+            hidden_sizes=[8], latent_dim=3, sigma=1.0,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_plvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_plvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'plvq'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_plvq):
+        model, X = fitted_plvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_plvq):
+        model, X = fitted_plvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# NEW: CBC models (reasoning matrices)
+# ---------------------------------------------------------------------------
+
+class TestCBCExport:
+    """CBC: squared Euclidean + Gaussian similarity + CBCC reasoning."""
+
+    @pytest.fixture
+    def fitted_cbc(self):
+        from prosemble.models import CBC
+        X, y = _make_supervised_data(40, 4, n_classes=2)
+        model = CBC(
+            n_components=3, n_classes=2, sigma=1.0,
+            max_iter=10, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_cbc):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_cbc
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'cbc'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_cbc):
+        model, X = fitted_cbc
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_cbc):
+        model, X = fitted_cbc
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestImageCBCExport:
+    """ImageCBC: CNN encoder + Gaussian similarity + CBCC reasoning."""
+
+    @pytest.fixture
+    def fitted_image_cbc(self):
+        from prosemble.models import ImageCBC
+        input_shape = (8, 8, 1)
+        X, y = _make_image_data(40, input_shape, n_classes=2)
+        model = ImageCBC(
+            n_components=3, n_classes=2, sigma=1.0,
+            max_iter=10, lr=0.01,
+            input_shape=input_shape, channels=[4], kernel_sizes=[3],
+            latent_dim=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_image_cbc):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_image_cbc
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'cbc'
+        assert dist_type == 'squared_euclidean'
+
+    def test_export_returns_model_proto(self, fitted_image_cbc):
+        model, X = fitted_image_cbc
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_image_cbc):
+        model, X = fitted_image_cbc
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,74 @@
+"""Tests for prosemble.core.protocols."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+
+from prosemble.core.protocols import Manifold, CallbackLike
+from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.core.callbacks import Callback
+
+
+class TestManifoldProtocol:
+    """Verify concrete manifolds satisfy the Manifold protocol."""
+
+    def test_so_isinstance(self):
+        assert isinstance(SO(3), Manifold)
+
+    def test_spd_isinstance(self):
+        assert isinstance(SPD(3), Manifold)
+
+    def test_grassmannian_isinstance(self):
+        assert isinstance(Grassmannian(4, 2), Manifold)
+
+    def test_arbitrary_object_not_manifold(self):
+        assert not isinstance("hello", Manifold)
+        assert not isinstance(42, Manifold)
+        assert not isinstance({}, Manifold)
+
+    def test_partial_impl_not_manifold(self):
+        """An object with only some methods should not satisfy the protocol."""
+        class Partial:
+            def distance(self, p, q):
+                pass
+        assert not isinstance(Partial(), Manifold)
+
+
+class TestCallbackProtocol:
+    """Verify Callback satisfies the CallbackLike protocol."""
+
+    def test_callback_isinstance(self):
+        assert isinstance(Callback(), CallbackLike)
+
+    def test_custom_callback(self):
+        class MyCallback:
+            def on_fit_start(self, model, X):
+                pass
+            def on_iteration_end(self, model, info):
+                pass
+            def on_fit_end(self, model, info):
+                pass
+        assert isinstance(MyCallback(), CallbackLike)
+
+    def test_incomplete_callback_not_match(self):
+        class Incomplete:
+            def on_fit_start(self, model, X):
+                pass
+        assert not isinstance(Incomplete(), CallbackLike)
+
+
+class TestTypeAliases:
+    """Smoke-test that type aliases are importable."""
+
+    def test_imports(self):
+        from prosemble.core.protocols import (
+            DistanceMatrixFn,
+            DistancePairwiseFn,
+            SupervisedInitFn,
+            UnsupervisedInitFn,
+        )
+        # They are just Callable aliases — no runtime check needed
+        assert DistanceMatrixFn is not None
+        assert DistancePairwiseFn is not None
+        assert SupervisedInitFn is not None
+        assert UnsupervisedInitFn is not None

--- a/tests/test_riemannian_supervised_ng.py
+++ b/tests/test_riemannian_supervised_ng.py
@@ -1,0 +1,388 @@
+"""Tests for Supervised Riemannian Neural Gas variants."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tempfile
+import os
+
+from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.models import (
+    RiemannianSRNG, RiemannianSMNG, RiemannianSLNG, RiemannianSTNG,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: generate labeled manifold data
+# ---------------------------------------------------------------------------
+
+def _make_so3_data(n_per_class=10, seed=0):
+    """Two classes of SO(3) rotations, separated by a known rotation."""
+    manifold = SO(3)
+    keys = jax.random.split(jax.random.PRNGKey(seed), n_per_class * 2)
+    points = jnp.stack([manifold.random_point(k) for k in keys])
+    X_flat = points.reshape(n_per_class * 2, -1)
+    y = jnp.array([0] * n_per_class + [1] * n_per_class)
+    return manifold, X_flat, y
+
+
+def _make_spd3_data(n_per_class=10, seed=0):
+    """Two classes of SPD(3) matrices."""
+    manifold = SPD(3)
+    keys = jax.random.split(jax.random.PRNGKey(seed), n_per_class * 2)
+    points = jnp.stack([manifold.random_point(k) for k in keys])
+    X_flat = points.reshape(n_per_class * 2, -1)
+    y = jnp.array([0] * n_per_class + [1] * n_per_class)
+    return manifold, X_flat, y
+
+
+def _make_gr42_data(n_per_class=10, seed=0):
+    """Two classes of Grassmannian(4,2) points."""
+    manifold = Grassmannian(4, 2)
+    keys = jax.random.split(jax.random.PRNGKey(seed), n_per_class * 2)
+    points = jnp.stack([manifold.random_point(k) for k in keys])
+    X_flat = points.reshape(n_per_class * 2, -1)
+    y = jnp.array([0] * n_per_class + [1] * n_per_class)
+    return manifold, X_flat, y
+
+
+MANIFOLD_DATA = [
+    pytest.param(_make_so3_data, id='SO3'),
+    pytest.param(_make_spd3_data, id='SPD3'),
+    pytest.param(_make_gr42_data, id='Gr42'),
+]
+
+
+# ---------------------------------------------------------------------------
+# RiemannianSRNG
+# ---------------------------------------------------------------------------
+
+class TestRiemannianSRNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_prototypes_on_manifold(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            assert manifold.belongs(protos[i]), f"Prototype {i} not on manifold"
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        unique_preds = set(np.asarray(preds).tolist())
+        assert unique_preds.issubset({0, 1})
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_save_load_roundtrip(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = RiemannianSRNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+    def test_gamma_decays(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_scan_mode(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=True,
+        )
+        model.fit(X, y)
+        assert model.loss_ is not None
+
+
+# ---------------------------------------------------------------------------
+# RiemannianSMNG
+# ---------------------------------------------------------------------------
+
+class TestRiemannianSMNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_prototypes_on_manifold(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            assert manifold.belongs(protos[i]), f"Prototype {i} not on manifold"
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        unique_preds = set(np.asarray(preds).tolist())
+        assert unique_preds.issubset({0, 1})
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_omega_learned(self, make_data):
+        manifold, X, y = make_data()
+        d_flat = X.shape[1]
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=15, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_ is not None
+        assert model.omega_.shape[0] == d_flat
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_save_load_roundtrip(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = RiemannianSMNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+    def test_latent_dim(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianSMNG(
+            manifold=manifold, latent_dim=4,
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_.shape == (9, 4)
+
+    def test_relevance_matrix(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        lam = model.relevance_matrix()
+        assert lam.shape == (9, 9)
+        # Lambda should be symmetric positive semi-definite
+        np.testing.assert_allclose(lam, lam.T, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# RiemannianSLNG
+# ---------------------------------------------------------------------------
+
+class TestRiemannianSLNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSLNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_prototypes_on_manifold(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            assert manifold.belongs(protos[i]), f"Prototype {i} not on manifold"
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        unique_preds = set(np.asarray(preds).tolist())
+        assert unique_preds.issubset({0, 1})
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_per_prototype_omegas(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSLNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        d_flat = X.shape[1]
+        assert model.omegas_.shape[0] == n_protos
+        assert model.omegas_.shape[1] == d_flat
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_save_load_roundtrip(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = RiemannianSLNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+
+# ---------------------------------------------------------------------------
+# RiemannianSTNG
+# ---------------------------------------------------------------------------
+
+class TestRiemannianSTNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSTNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_prototypes_on_manifold(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            assert manifold.belongs(protos[i]), f"Prototype {i} not on manifold"
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        unique_preds = set(np.asarray(preds).tolist())
+        assert unique_preds.issubset({0, 1})
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_omegas_orthonormal(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        for i in range(model.omegas_.shape[0]):
+            OtO = model.omegas_[i].T @ model.omegas_[i]
+            np.testing.assert_allclose(
+                OtO, jnp.eye(OtO.shape[0]), atol=1e-4,
+                err_msg=f"Omega {i} not orthonormal"
+            )
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_save_load_roundtrip(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = RiemannianSTNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+    def test_subspace_dim(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianSTNG(
+            manifold=manifold, subspace_dim=3,
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omegas_.shape == (2, 9, 3)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,170 @@
+"""Tests for prosemble.core.serialization — unified save/load."""
+
+import os
+import tempfile
+
+import pytest
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+
+from prosemble.models import GLVQ, NeuralGas, FCM
+
+
+@pytest.fixture
+def iris_data():
+    """Small synthetic classification dataset."""
+    np.random.seed(42)
+    X = np.random.randn(30, 4).astype(np.float32)
+    y = np.array([0]*10 + [1]*10 + [2]*10)
+    return jnp.array(X), jnp.array(y)
+
+
+@pytest.fixture
+def cluster_data():
+    """Small synthetic clustering dataset."""
+    np.random.seed(42)
+    X = np.random.randn(30, 4).astype(np.float32)
+    return jnp.array(X)
+
+
+class TestSupervisedSaveLoad:
+
+    def test_glvq_roundtrip(self, iris_data, tmp_path):
+        X, y = iris_data
+        model = GLVQ(n_prototypes_per_class=1, max_iter=3, random_seed=42)
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        path = str(tmp_path / "glvq.npz")
+        model.save(path)
+
+        loaded = GLVQ.load(path)
+        preds_after = loaded.predict(X)
+
+        npt.assert_array_equal(preds_before, preds_after)
+        npt.assert_array_almost_equal(
+            np.asarray(model.prototypes_),
+            np.asarray(loaded.prototypes_),
+        )
+
+    def test_metadata_preserved(self, iris_data, tmp_path):
+        X, y = iris_data
+        model = GLVQ(n_prototypes_per_class=1, max_iter=3, random_seed=42)
+        model.fit(X, y)
+
+        path = str(tmp_path / "glvq_meta.npz")
+        model.save(path)
+        loaded = GLVQ.load(path)
+
+        assert loaded.n_iter_ is not None
+        assert loaded.loss_ is not None
+        assert loaded.n_classes_ == model.n_classes_
+
+    def test_quantized_save(self, iris_data, tmp_path):
+        X, y = iris_data
+        model = GLVQ(n_prototypes_per_class=1, max_iter=3, random_seed=42)
+        model.fit(X, y)
+
+        path = str(tmp_path / "glvq_q.npz")
+        model.save(path, quantize='float16')
+
+        # Model in memory should be unchanged
+        assert model.prototypes_.dtype == jnp.float32
+
+        loaded = GLVQ.load(path)
+        assert loaded._quantized_dtype == 'float16'
+
+
+class TestUnsupervisedSaveLoad:
+
+    def test_neural_gas_roundtrip(self, cluster_data, tmp_path):
+        X = cluster_data
+        model = NeuralGas(n_prototypes=3, max_iter=3, random_seed=42)
+        model.fit(X)
+        preds_before = model.predict(X)
+
+        path = str(tmp_path / "ng.npz")
+        model.save(path)
+
+        loaded = NeuralGas.load(path)
+        preds_after = loaded.predict(X)
+
+        npt.assert_array_equal(preds_before, preds_after)
+
+    def test_metadata_preserved(self, cluster_data, tmp_path):
+        X = cluster_data
+        model = NeuralGas(n_prototypes=3, max_iter=3, random_seed=42)
+        model.fit(X)
+
+        path = str(tmp_path / "ng_meta.npz")
+        model.save(path)
+        loaded = NeuralGas.load(path)
+
+        assert loaded.n_iter_ is not None
+        assert loaded.loss_ is not None
+
+
+class TestFuzzySaveLoad:
+
+    def test_fcm_roundtrip(self, cluster_data, tmp_path):
+        X = cluster_data
+        model = FCM(n_clusters=3, max_iter=10, random_seed=42)
+        model.fit(X)
+        preds_before = model.predict(X)
+
+        path = str(tmp_path / "fcm.npz")
+        model.save(path)
+
+        loaded = FCM.load(path)
+        preds_after = loaded.predict(X)
+
+        npt.assert_array_equal(preds_before, preds_after)
+
+    def test_metadata_preserved(self, cluster_data, tmp_path):
+        X = cluster_data
+        model = FCM(n_clusters=3, max_iter=10, random_seed=42)
+        model.fit(X)
+
+        path = str(tmp_path / "fcm_meta.npz")
+        model.save(path)
+        loaded = FCM.load(path)
+
+        assert loaded.n_iter_ is not None
+        assert loaded.objective_ is not None
+
+
+class TestSchemaVersion:
+
+    def test_schema_version_in_metadata(self, iris_data, tmp_path):
+        import json
+        X, y = iris_data
+        model = GLVQ(n_prototypes_per_class=1, max_iter=3, random_seed=42)
+        model.fit(X, y)
+
+        path = str(tmp_path / "versioned.npz")
+        model.save(path)
+
+        data = np.load(path, allow_pickle=False)
+        metadata = json.loads(str(data['__metadata__']))
+        assert metadata['schema_version'] == 1
+
+
+class TestRegistryLoad:
+
+    def test_load_unknown_class_raises(self, tmp_path):
+        """Load should raise for unknown model class."""
+        import json
+        path = str(tmp_path / "bad.npz")
+        np.savez_compressed(
+            path,
+            __metadata__=np.array(json.dumps({
+                'class_name': 'NonExistentModel',
+                'module': 'fake',
+                'hyperparams': {},
+                'fitted_array_names': [],
+                'quantized_dtype': None,
+            })),
+        )
+        with pytest.raises(ValueError, match="Unknown model class"):
+            GLVQ.load(path)

--- a/uv.lock
+++ b/uv.lock
@@ -2,18 +2,30 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -173,7 +185,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -516,7 +528,7 @@ name = "cryptography"
 version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cffi", marker = "platform_machine != 's390x' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
 wheels = [
@@ -730,7 +742,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -786,7 +798,7 @@ name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools" },
+    { name = "more-itertools", marker = "platform_machine != 's390x'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
 wheels = [
@@ -798,7 +810,7 @@ name = "jaraco-context"
 version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+    { name = "backports-tarfile", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
@@ -810,7 +822,7 @@ name = "jaraco-functools"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools" },
+    { name = "more-itertools", marker = "platform_machine != 's390x'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
 wheels = [
@@ -967,13 +979,13 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
+    { name = "jaraco-classes", marker = "platform_machine != 's390x'" },
+    { name = "jaraco-context", marker = "platform_machine != 's390x'" },
+    { name = "jaraco-functools", marker = "platform_machine != 's390x'" },
+    { name = "jeepney", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "platform_machine != 's390x' and sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
@@ -1678,6 +1690,79 @@ wheels = [
 ]
 
 [[package]]
+name = "onnx"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/93/942d2a0f6a70538eea042ce0445c8aefd46559ad153469986f29a743c01c/onnx-1.21.0.tar.gz", hash = "sha256:4d8b67d0aaec5864c87633188b91cc520877477ec0254eda122bef8be43cd764", size = 12074608, upload-time = "2026-03-27T21:33:36.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/48/32e383aa6bc40b72a9fd419937aaa647078190c9bfccdc97b316d2dee687/onnx-1.21.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:2aca19949260875c14866fc77ea0bc37e4e809b24976108762843d328c92d3ce", size = 17968053, upload-time = "2026-03-27T21:32:29.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/26/5726e8df7d36e96bb3c679912d1a86af42f393d77aa17d6b98a97d4289ce/onnx-1.21.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82aa6ab51144df07c58c4850cb78d4f1ae969d8c0bf657b28041796d49ba6974", size = 17534821, upload-time = "2026-03-27T21:32:32.351Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2b/021dcd2dd50c3c71b7959d7368526da384a295c162fb4863f36057973f78/onnx-1.21.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c3185a232089335581fabb98fba4e86d3e8246b8140f2e406082438100ebda", size = 17616664, upload-time = "2026-03-27T21:32:34.921Z" },
+    { url = "https://files.pythonhosted.org/packages/12/00/afa32a46fa122a7ed42df1cfe8796922156a3725ba8fc581c4779c96e2fc/onnx-1.21.0-cp311-cp311-win32.whl", hash = "sha256:f53b3c15a3b539c16b99655c43c365622046d68c49b680c48eba4da2a4fb6f27", size = 16289035, upload-time = "2026-03-27T21:32:37.783Z" },
+    { url = "https://files.pythonhosted.org/packages/73/8d/483cc980a24d4c0131d0af06d0ff6a37fb08ae90a7848ece8cef645194f1/onnx-1.21.0-cp311-cp311-win_amd64.whl", hash = "sha256:5f78c411743db317a76e5d009f84f7e3d5380411a1567a868e82461a1e5c775d", size = 16443748, upload-time = "2026-03-27T21:32:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/38/78/9d06fd5aaaed1ec9cb8a3b70fbbf00c1bdc18db610771e96379f0ed58112/onnx-1.21.0-cp311-cp311-win_arm64.whl", hash = "sha256:ab6a488dabbb172eebc9f3b3e7ac68763f32b0c571626d4a5004608f866cc83d", size = 16406123, upload-time = "2026-03-27T21:32:45.159Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ae/cb644ec84c25e63575d9d8790fdcc5d1a11d67d3f62f872edb35fa38d158/onnx-1.21.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:fc2635400fe39ff37ebc4e75342cc54450eadadf39c540ff132c319bf4960095", size = 17965930, upload-time = "2026-03-27T21:32:48.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/eeb5903586645ef8a49b4b7892580438741acc3df91d7a5bd0f3a59ea9cb/onnx-1.21.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9003d5206c01fa2ff4b46311566865d8e493e1a6998d4009ec6de39843f1b59b", size = 17531344, upload-time = "2026-03-27T21:32:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9261bd580fb8548c9c37b3c6750387eb8f21ea43c63880d37b2c622e1684285", size = 17613697, upload-time = "2026-03-27T21:32:54.222Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1d/391f3c567ae068c8ac4f1d1316bae97c9eb45e702f05975fe0e17ad441f0/onnx-1.21.0-cp312-abi3-win32.whl", hash = "sha256:9ea4e824964082811938a9250451d89c4ec474fe42dd36c038bfa5df31993d1e", size = 16287200, upload-time = "2026-03-27T21:32:57.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a6/5eefbe5b40ea96de95a766bd2e0e751f35bdea2d4b951991ec9afaa69531/onnx-1.21.0-cp312-abi3-win_amd64.whl", hash = "sha256:458d91948ad9a7729a347550553b49ab6939f9af2cddf334e2116e45467dc61f", size = 16441045, upload-time = "2026-03-27T21:33:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c4/0ed8dc037a39113d2a4d66e0005e07751c299c46b993f1ad5c2c35664c20/onnx-1.21.0-cp312-abi3-win_arm64.whl", hash = "sha256:ca14bc4842fccc3187eb538f07eabeb25a779b39388b006db4356c07403a7bbb", size = 16403134, upload-time = "2026-03-27T21:33:03.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/89/0e1a9beb536401e2f45ac88735e123f2735e12fc7b56ff6c11727e097526/onnx-1.21.0-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:257d1d1deb6a652913698f1e3f33ef1ca0aa69174892fe38946d4572d89dd94f", size = 17975430, upload-time = "2026-03-27T21:33:07.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e6dc71a7b3b317265591b20a5f71d0ff5c0d26c24e52283139dc90c66038/onnx-1.21.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7cd7cb8f6459311bdb557cbf6c0ccc6d8ace11c304d1bba0a30b4a4688e245f8", size = 17537435, upload-time = "2026-03-27T21:33:09.765Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/27affcac63eaf2ef183a44fd1a1354b11da64a6c72fe6f3fdcf5571bcee5/onnx-1.21.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b58a4cfec8d9311b73dc083e4c1fa362069267881144c05139b3eba5dc3a840", size = 17617687, upload-time = "2026-03-27T21:33:12.619Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5c/ac8ed15e941593a3672ce424280b764979026317811f2e8508432bfc3429/onnx-1.21.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1a9baf882562c4cebf79589bebb7cd71a20e30b51158cac3e3bbaf27da6163bd", size = 16449402, upload-time = "2026-03-27T21:33:15.555Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/aa/d2231e0dcaad838217afc64c306c8152a080134d2034e247cc973d577674/onnx-1.21.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bba12181566acf49b35875838eba49536a327b2944664b17125577d230c637ad", size = 16408273, upload-time = "2026-03-27T21:33:18.599Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0a/8905b14694def6ad23edf1011fdd581500384062f8c4c567e114be7aa272/onnx-1.21.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:7ee9d8fd6a4874a5fa8b44bbcabea104ce752b20469b88bc50c7dcf9030779ad", size = 17975331, upload-time = "2026-03-27T21:33:21.69Z" },
+    { url = "https://files.pythonhosted.org/packages/61/28/f4e401e5199d1b9c8b76c7e7ae1169e050515258e877b58fa8bb49d3bdcc/onnx-1.21.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5489f25fe461e7f32128218251a466cabbeeaf1eaa791c79daebf1a80d5a2cc9", size = 17537430, upload-time = "2026-03-27T21:33:24.547Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/5d13320eb3660d5af360ea3b43aa9c63a70c92a9b4d1ea0d34501a32fcb8/onnx-1.21.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:db17fc0fec46180b6acbd1d5d8650a04e5527c02b09381da0b5b888d02a204c8", size = 17617662, upload-time = "2026-03-27T21:33:27.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/50/3eaa1878338247be021e6423696813d61e77e534dccbd15a703a144e703d/onnx-1.21.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19d9971a3e52a12968ae6c70fd0f86c349536de0b0c33922ecdbe52d1972fe60", size = 16463688, upload-time = "2026-03-27T21:33:30.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/38d46b43bbb525e0b6a4c2c4204cc6795d67e45687a2f7403e06d8e7053d/onnx-1.21.0-cp314-cp314t-win_arm64.whl", hash = "sha256:efba467efb316baf2a9452d892c2f982b9b758c778d23e38c7f44fa211b30bb9", size = 16423387, upload-time = "2026-03-27T21:33:33.446Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/81/29a9eb470994a75eb7b3ccf32be314d7c66675a00ac7b50294816cc2db27/onnxruntime-1.26.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ee1109ef4ef27cad90e823399e61e03b3c6c7bfe0fb820b4baf3678c15be8b3c", size = 18005108, upload-time = "2026-05-08T19:08:11.728Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c7/73efa6c8a4000c38fcc14947d84f234a17e5d66f203b37b7f1ad4a7b46eb/onnxruntime-1.26.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35c7c7b0ac2e02001d28fab6c9fc24e9abc5e6faa35e6e19c63cecf1406ba89f", size = 16043752, upload-time = "2026-05-08T19:07:10.707Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/8de630f595daf6ce884d4dd95afd2a60e70ec6572e52bfee3aa2229befab/onnxruntime-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11a8df4dcfe9ad5ff0bd71a7571dbed019fabc7594676c89fe8b86ea029c246f", size = 18176043, upload-time = "2026-05-08T19:07:33.735Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/9f041de20787cd85498bd48e0ec4d098bf2a6c486e25b24b8dae1bf492b2/onnxruntime-1.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:e6456718125fd777c673f3b78d4a9ab58d6adea641e9afae85ee6444f0e0e9a9", size = 13023165, upload-time = "2026-05-08T19:08:00.633Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/82/3b9fe0ead2557cc3adf74c74c141bd1c7c4c6a9548c610af37df199f4512/onnxruntime-1.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:cd920e45b730e4a87833e2910d8ca375aaca9da6ccc09e24bce463b3356d637f", size = 12789514, upload-time = "2026-05-08T19:07:49.433Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b1/d111b1df656761f980d9e298a60039a9cb66036b1d039e777537743d0ac3/onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac", size = 18016624, upload-time = "2026-05-12T00:41:01.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a0/3f9d896a0385a36bd04345d6d0b802821a5782adde562e7e135f6bb71c73/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0", size = 16052692, upload-time = "2026-05-08T19:07:13.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6", size = 18185439, upload-time = "2026-05-08T19:07:36.299Z" },
+    { url = "https://files.pythonhosted.org/packages/44/fc/026d0a7162b9c2153dac292baea9e027c42304dc1d9dc6f8ff5b4cfbaedd/onnxruntime-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:a26374dc7fbcaae593601086b242120e13f2310558df0991da6dd8b8fac00414", size = 13026427, upload-time = "2026-05-08T19:08:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/27/1dcf88e45e4c69db5f7b106f2dacc3801ba98994e082ca03e1dfdf7bfe57/onnxruntime-1.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:54a8053410fd31fd66469bd754fcfe8a4df9f7eb44756b4b5479bf50c842d948", size = 12796647, upload-time = "2026-05-08T19:07:52.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a2/c801242685e0ce48a4ca51dfafbb588765e0446397e123be53ba5598f3f5/onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0", size = 18016563, upload-time = "2026-05-08T19:07:28.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/64/0492c0b1db04e29b2630c87cfa36f9d6872b1ca8614b90c5cad58fac7d76/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdbed8cf3b672b66acb032f33a253bc27f42bce6ece48ae3fab4fa483a5e96e0", size = 16052634, upload-time = "2026-05-08T19:07:16.885Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/26/4d09ddc755a84fc8d5e192991626b0e0680e8f6c5d58f4f1d05c42bc48cf/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c07af6fc6d5557835f2b6ee7a96d8b3235d0c57a8e230efdedaee106a8a3cbc6", size = 18185632, upload-time = "2026-05-08T19:07:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/77/89/3e52249aa08fa301e217ecba07b5246a8338fa2b401e109326e3fc5be0f9/onnxruntime-1.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:61bec80655efa460591c2bc655392d57d2650ce85533a6b9b3b7a790d7ea7916", size = 13026751, upload-time = "2026-05-08T19:08:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/c1c8782b14af6797c303de132d6eef26a9fb80dfacd3750ce57911d11c6b/onnxruntime-1.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a6677545ff451e3539a02746d2f207d8c5baa4a0a818886bb9d6a6eb9511ee89", size = 12796807, upload-time = "2026-05-08T19:07:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f5/47b0676408abec652c14b84d7173e389837832d850c24f87184277313e8d/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e016edc15d3c19f36807e1c6b10be5b27807688c32720f91b5ae480a95215d0", size = 16057265, upload-time = "2026-05-08T19:07:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/45/33ab6deeef010ca844c877dd618cebc079590bbe52d2a3678e7223b1b908/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5fc48a91a046a6a5c9b147f83fb41d65d24d24923373b222cdd248f0f4f4aac", size = 18197590, upload-time = "2026-05-08T19:07:41.422Z" },
+    { url = "https://files.pythonhosted.org/packages/40/89/17546c1c20f6bfc3ae41c22152378a26edfea918af3129e2139dcd7c99f3/onnxruntime-1.26.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:33a791f31432a3af1a96db5e54818b37aba5e5eefc2e6af5794c10a9118a9993", size = 18019724, upload-time = "2026-05-08T19:07:30.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/24/89457a35f6af29538a76647f2c18c3a28277e6c19234c847e7b4b7c19860/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e90c00732c4553618103149d93f688e8c3063017938f8983e21a71d9f3b6d22e", size = 16054821, upload-time = "2026-05-08T19:07:22.348Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f9/15b2e1815cf570d238e0135529f80d2dce64e8e8818a1489cae83823c5c6/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01498e80ba8988428d08c2d51b1338f89e3de2a93e6ffe555f79c68f26a5c06b", size = 18185815, upload-time = "2026-05-08T19:07:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/65/2e11055faf015e4b07f45b513fa49b391baf2e19d92d77d73ebee13c1004/onnxruntime-1.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:7ead61450d8405167c87dd3a31d8da1d576b490a57dab1aa8b82a7da6825f5aa", size = 13349887, upload-time = "2026-05-08T19:08:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e4/0f9d1a5718b1781c610c1e354765a3820597081754277a6a9a2b50705702/onnxruntime-1.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:31d71a53490e46910877d0902b5ad99c69a5955e5c7ea6c82863519410e1ba7c", size = 13140121, upload-time = "2026-05-08T19:07:57.804Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/42/3b8e635f067d06d9f45bede470b8d539d101a4166c272213158dfd08b6ce/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b6d258fb78fdfcf049795bcfaa74dcb90ae7baa277afd21e6fd28b83f2c496", size = 16057240, upload-time = "2026-05-08T19:07:25.163Z" },
+    { url = "https://files.pythonhosted.org/packages/93/99/f2be40a31b908d96b861ae0ce98582fa376c18a7f816b9d5eb4cd6aa0a4c/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eefd386a45202aefb7a5132b94f32df9d506c9edcc7faf2fc60d65183f4b183", size = 18197382, upload-time = "2026-05-08T19:07:46.965Z" },
+]
+
+[[package]]
 name = "opt-einsum"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1938,6 +2023,10 @@ jax-cuda12 = [
     { name = "jax", extra = ["cuda12"] },
     { name = "optax" },
 ]
+onnx = [
+    { name = "onnx" },
+    { name = "onnxruntime" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1974,6 +2063,8 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'all'" },
     { name = "numpy" },
     { name = "numpy", marker = "extra == 'all'" },
+    { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.21.0" },
+    { name = "onnxruntime", marker = "extra == 'onnx'", specifier = ">=1.26.0" },
     { name = "optax", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "optax", marker = "extra == 'jax'", specifier = ">=0.2.0" },
     { name = "optax", marker = "extra == 'jax-cuda12'", specifier = ">=0.2.0" },
@@ -1998,10 +2089,25 @@ requires-dist = [
     { name = "wheel", marker = "extra == 'all'" },
     { name = "wheel", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev", "jax", "jax-cuda12", "docs", "all", "export"]
+provides-extras = ["dev", "jax", "jax-cuda12", "docs", "all", "export", "onnx"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "python-docx", specifier = ">=1.2.0" }]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
 
 [[package]]
 name = "psutil"
@@ -2401,8 +2507,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2441,9 +2547,12 @@ name = "sphinx"
 version = "9.0.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version < '3.12'" },
@@ -2474,15 +2583,24 @@ name = "sphinx"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version >= '3.12'" },


### PR DESCRIPTION
…docs

- Supervised Riemannian Neural Gas variants: RiemannianSRNG, RiemannianSMNG, RiemannianSLNG, RiemannianSTNG with SO(n)/SPD(n)/Grassmannian manifolds
- ONNX export support for 68/71 models via prosemble.core.onnx_export
- Core utilities: protocols.py (typing.Protocol contracts), serialization.py (save/load consolidation), data.py (JAX-native data iterators)
- Sphinx documentation: ONNX export guide, Riemannian models guide, updated API reference, math rendering fixes (Unicode → RST :math:)
- Tests for all new modules