### PR TITLE
feat: Add ONNX export for Riemannian models on SO(n) and Grassmannian

### DIFF
--- a/ONNX_COVERAGE.md
+++ b/ONNX_COVERAGE.md
@@ -1,8 +1,8 @@
 # ONNX Export Coverage
 
-Status of ONNX export support across all 71 prosemble models.
+Status of ONNX export support across all 87 prosemble models.
 
-## Currently Supported (~68 models)
+## Currently Supported (75 models)
 
 ### Supervised LVQ — squared euclidean (9)
 
@@ -94,13 +94,31 @@ CBC, ImageCBC
 
 Squared Euclidean distance → Gaussian similarity `exp(-d²/(2σ²))` → CBCC reasoning: `probs = (detections @ (pk - nk) + sum(nk)) / (sum(pk + nk) + eps)` → ArgMax. ImageCBC adds a CNN encoder before distance computation, with components pre-computed in latent space.
 
+### Riemannian — SO(n) chordal distance (1)
+
+RiemannianSRNG (with SO(n) manifold)
+
+Chordal distance: `d²(R,S) = ||R - S||²_F`. Pure Frobenius norm on flattened rotation matrices.
+
+### Riemannian — SO(n) tangent-space metric (3)
+
+RiemannianSMNG, RiemannianSLNG, RiemannianSTNG (with SO(n) manifold)
+
+Log map: `Log_R(S) = R @ skew(R^T S)` where `skew(A) = (A - A^T)/2`. Then metric adaptation (global omega, local omega, or tangent subspace) applied to flattened tangent vectors. All ops are MatMul/Sub/Transpose.
+
+### Riemannian — Grassmannian tangent-space metric (3)
+
+RiemannianSMNG, RiemannianSLNG, RiemannianSTNG (with Grassmannian(n,k) manifold)
+
+Log map: `Log_{Q1}(Q2) = Q2 - Q1(Q1^T Q2)`. Then metric adaptation applied to flattened tangent vectors. All ops are MatMul/Sub.
+
 ### Needs verification (1)
 
 GRLVQ — uses per-feature relevance weights; needs verification on whether predict is handled correctly by the current export.
 
 ---
 
-## Not Supported (~3 unique blockers, ~21 models)
+## Not Supported (12 models)
 
 ### Kernel fuzzy clustering (7) — kernel distance not exportable
 
@@ -108,11 +126,12 @@ KFCM, KPCM, KFPCM, KPFCM, KAFCM, KIPCM, KIPCM2
 
 **Blocker:** Predict uses Gaussian kernel distance (1 - K) computed via `batch_gaussian_kernel()`. Kernel evaluation requires the `sigma` parameter and a different distance computation that has no standard ONNX equivalent.
 
-### Riemannian models (5) — manifold operations
+### Riemannian models — non-exportable combinations (2)
 
-RiemannianSRNG, RiemannianSMNG, RiemannianSLNG, RiemannianSTNG, RiemannianNeuralGas
+- **RiemannianSRNG + Grassmannian** — geodesic distance requires SVD at runtime (no ONNX op)
+- **RiemannianNeuralGas (all manifolds)** — uses `jsl.funm` (matrix logarithm via Schur decomposition, no ONNX op)
 
-**Blocker:** Predict uses matrix logarithm/exponential (`logm`, `expm`) which have no ONNX operator equivalent.
+Note: All 4 supervised Riemannian models with SPD(n) manifold are also not exportable (eigendecomposition required), but SPD(n) is a runtime manifold choice, not a separate model.
 
 ### Other (3)
 
@@ -137,6 +156,9 @@ KMeansPlusPlus, Kmeans, BGPC — don't inherit from prototype model base classes
 | Relevance-weighted | element-wise weighted sq. diff | OCGRLVQ, SVQOCC_R |
 | Local Omega | batched MatMul | LGMLVQ, SLNG, LCELVQ_NG, LMRSLVQ, OCLGMLVQ, SVQOCC_LM |
 | Tangent | batched MatMul project-reconstruct | GTLVQ, STNG, TCELVQ_NG, OCGTLVQ, SVQOCC_T, SiameseGTLVQ, ImageGTLVQ |
+| SO(n) Chordal | broadcast subtract + Frobenius | RiemannianSRNG |
+| SO(n) Tangent | skew-symmetric log map + metric | RiemannianSMNG/SLNG/STNG (SO) |
+| Grassmannian Tangent | projection log map + metric | RiemannianSMNG/SLNG/STNG (Gr) |
 
 ## Encoder Support
 

--- a/prosemble/core/onnx_export.py
+++ b/prosemble/core/onnx_export.py
@@ -666,6 +666,511 @@ def _tangent_onnx(builder, X_name, proto_name, omegas_name):
 
 
 # ---------------------------------------------------------------------------
+# Riemannian model builders
+# ---------------------------------------------------------------------------
+
+
+def _riemannian_so_chordal_onnx(X_name, proto_name, n):
+    r"""Chordal distance on SO(n): d^2(R,S) = ||R - S||^2_F.
+
+    Input X and prototypes are flattened (batch, n*n) and (p, n*n).
+    Reshapes to 3D, broadcasts, computes Frobenius distance matrix.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+        Output shape: (batch, n_proto)
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Unsqueeze X -> (batch, 1, n*n)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [X_name, '_rsc_axis1'], ['_rsc_x_exp'],
+    ))
+    # Unsqueeze W -> (1, p, n*n)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [proto_name, '_rsc_axis0'], ['_rsc_w_exp'],
+    ))
+
+    # diff = X - W -> (batch, p, n*n)
+    nodes.append(oh.make_node(
+        'Sub', ['_rsc_x_exp', '_rsc_w_exp'], ['_rsc_diff'],
+    ))
+
+    # diff^2
+    nodes.append(oh.make_node(
+        'Mul', ['_rsc_diff', '_rsc_diff'], ['_rsc_diff_sq'],
+    ))
+
+    # ReduceSum over last axis -> (batch, p)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_rsc_diff_sq', '_rsc_axis2'],
+        ['distances_rsc'], keepdims=0,
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_rsc_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_rsc_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_rsc_axis2', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_rsc'
+
+
+def _riemannian_so_tangent_onnx(X_name, proto_name, n):
+    r"""Compute SO(n) tangent vectors: Log_W(X) = W @ skew(W^T @ X).
+
+    skew(A) = (A - A^T) / 2
+
+    Input X: (batch, n*n), prototypes W: (p, n*n).
+    Output tangent: (p, batch, n*n) — ready for downstream metric.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Reshape X -> (batch, n, n)
+    nodes.append(oh.make_node(
+        'Reshape', [X_name, '_rst_x_shape'], ['_rst_X3'],
+    ))
+    # Reshape W -> (p, n, n)
+    nodes.append(oh.make_node(
+        'Reshape', [proto_name, '_rst_w_shape'], ['_rst_W3'],
+    ))
+
+    # Unsqueeze X -> (batch, 1, n, n)
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_rst_X3', '_rst_axis1'], ['_rst_X4'],
+    ))
+    # Unsqueeze W -> (1, p, n, n)
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_rst_W3', '_rst_axis0'], ['_rst_W4'],
+    ))
+
+    # W^T: transpose last two dims of W -> (1, p, n, n)
+    nodes.append(oh.make_node(
+        'Transpose', ['_rst_W4'], ['_rst_Wt'],
+        perm=[0, 1, 3, 2],
+    ))
+
+    # RtS = W^T @ X -> (batch, p, n, n) via broadcasting
+    nodes.append(oh.make_node(
+        'MatMul', ['_rst_Wt', '_rst_X4'], ['_rst_RtS'],
+    ))
+
+    # RtS^T: transpose last two dims
+    nodes.append(oh.make_node(
+        'Transpose', ['_rst_RtS'], ['_rst_RtS_T'],
+        perm=[0, 1, 3, 2],
+    ))
+
+    # skew = (RtS - RtS^T) / 2
+    nodes.append(oh.make_node(
+        'Sub', ['_rst_RtS', '_rst_RtS_T'], ['_rst_skew_raw'],
+    ))
+    nodes.append(oh.make_node(
+        'Div', ['_rst_skew_raw', '_rst_two'], ['_rst_skew'],
+    ))
+
+    # tangent = W @ skew -> (batch, p, n, n)
+    nodes.append(oh.make_node(
+        'MatMul', ['_rst_W4', '_rst_skew'], ['_rst_tangent4d'],
+    ))
+
+    # Reshape tangent -> (batch, p, n*n)
+    nodes.append(oh.make_node(
+        'Reshape', ['_rst_tangent4d', '_rst_tang_shape'], ['_rst_tangent3d'],
+    ))
+
+    # Transpose -> (p, batch, n*n) for downstream metric ops
+    nodes.append(oh.make_node(
+        'Transpose', ['_rst_tangent3d'], ['tangent_so'],
+        perm=[1, 0, 2],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_rst_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_rst_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_rst_x_shape', TensorProto.INT64, [3], [-1, n, n]),
+        oh.make_tensor('_rst_w_shape', TensorProto.INT64, [3], [-1, n, n]),
+        oh.make_tensor('_rst_tang_shape', TensorProto.INT64, [3],
+                       [0, 0, n * n]),
+        oh.make_tensor('_rst_two', TensorProto.FLOAT, [], [2.0]),
+    ]
+    return nodes, extra_initializers, 'tangent_so'
+
+
+def _riemannian_gr_tangent_onnx(X_name, proto_name, n, k):
+    r"""Compute Grassmannian tangent vectors: Log_{Q1}(Q2) = Q2 - Q1(Q1^T Q2).
+
+    Input X: (batch, n*k), prototypes W: (p, n*k).
+    Output tangent: (p, batch, n*k) — ready for downstream metric.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Reshape X -> (batch, n, k)
+    nodes.append(oh.make_node(
+        'Reshape', [X_name, '_rgt_x_shape'], ['_rgt_X3'],
+    ))
+    # Reshape W -> (p, n, k)
+    nodes.append(oh.make_node(
+        'Reshape', [proto_name, '_rgt_w_shape'], ['_rgt_W3'],
+    ))
+
+    # Unsqueeze X -> (batch, 1, n, k)
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_rgt_X3', '_rgt_axis1'], ['_rgt_X4'],
+    ))
+    # Unsqueeze W -> (1, p, n, k)
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_rgt_W3', '_rgt_axis0'], ['_rgt_W4'],
+    ))
+
+    # W^T: transpose last two dims -> (1, p, k, n)
+    nodes.append(oh.make_node(
+        'Transpose', ['_rgt_W4'], ['_rgt_Wt'],
+        perm=[0, 1, 3, 2],
+    ))
+
+    # Q1tQ2 = W^T @ X -> (batch, p, k, k)
+    nodes.append(oh.make_node(
+        'MatMul', ['_rgt_Wt', '_rgt_X4'], ['_rgt_Q1tQ2'],
+    ))
+
+    # proj = W @ Q1tQ2 -> (batch, p, n, k)
+    nodes.append(oh.make_node(
+        'MatMul', ['_rgt_W4', '_rgt_Q1tQ2'], ['_rgt_proj'],
+    ))
+
+    # tangent = X - proj -> (batch, p, n, k)
+    nodes.append(oh.make_node(
+        'Sub', ['_rgt_X4', '_rgt_proj'], ['_rgt_tangent4d'],
+    ))
+
+    # Reshape -> (batch, p, n*k)
+    nodes.append(oh.make_node(
+        'Reshape', ['_rgt_tangent4d', '_rgt_tang_shape'], ['_rgt_tangent3d'],
+    ))
+
+    # Transpose -> (p, batch, n*k)
+    nodes.append(oh.make_node(
+        'Transpose', ['_rgt_tangent3d'], ['tangent_gr'],
+        perm=[1, 0, 2],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_rgt_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_rgt_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_rgt_x_shape', TensorProto.INT64, [3], [-1, n, k]),
+        oh.make_tensor('_rgt_w_shape', TensorProto.INT64, [3], [-1, n, k]),
+        oh.make_tensor('_rgt_tang_shape', TensorProto.INT64, [3],
+                       [0, 0, n * k]),
+    ]
+    return nodes, extra_initializers, 'tangent_gr'
+
+
+def _riemannian_global_omega_onnx(tangent_name, omega_name):
+    r"""Global omega metric on pre-computed tangents: d^2 = ||tangent @ Omega||^2.
+
+    Input tangent: (p, batch, d_flat), omega: (d_flat, latent_dim).
+    Output: (batch, p) distances.
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # MatMul: (p, batch, d) @ (d, l) -> (p, batch, l)
+    nodes.append(oh.make_node(
+        'MatMul', [tangent_name, omega_name], ['_rgo_projected'],
+    ))
+
+    # projected^2
+    nodes.append(oh.make_node(
+        'Mul', ['_rgo_projected', '_rgo_projected'], ['_rgo_proj_sq'],
+    ))
+
+    # ReduceSum over latent axis=2 -> (p, batch)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_rgo_proj_sq', '_rgo_axis2'],
+        ['_rgo_dist_t'], keepdims=0,
+    ))
+
+    # Transpose -> (batch, p)
+    nodes.append(oh.make_node(
+        'Transpose', ['_rgo_dist_t'], ['distances_rgo'],
+        perm=[1, 0],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_rgo_axis2', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_rgo'
+
+
+def _riemannian_local_omega_onnx(tangent_name, omegas_name):
+    r"""Per-prototype omega metric: d^2_k = ||tangent_k @ Omega_k||^2.
+
+    Input tangent: (p, batch, d_flat), omegas: (p, d_flat, latent_dim).
+    Output: (batch, p) distances.
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Batched MatMul: (p, batch, d) @ (p, d, l) -> (p, batch, l)
+    nodes.append(oh.make_node(
+        'MatMul', [tangent_name, omegas_name], ['_rlo_projected'],
+    ))
+
+    # projected^2
+    nodes.append(oh.make_node(
+        'Mul', ['_rlo_projected', '_rlo_projected'], ['_rlo_proj_sq'],
+    ))
+
+    # ReduceSum over latent axis=2 -> (p, batch)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_rlo_proj_sq', '_rlo_axis2'],
+        ['_rlo_dist_t'], keepdims=0,
+    ))
+
+    # Transpose -> (batch, p)
+    nodes.append(oh.make_node(
+        'Transpose', ['_rlo_dist_t'], ['distances_rlo'],
+        perm=[1, 0],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_rlo_axis2', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_rlo'
+
+
+def _riemannian_tangent_subspace_onnx(tangent_name, omegas_name):
+    r"""Tangent subspace distance: d^2 = ||(I - Omega_k Omega_k^T) tangent_k||^2.
+
+    Input tangent: (p, batch, d_flat), omegas: (p, d_flat, s).
+    Output: (batch, p) distances.
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Step 1: Project onto subspace
+    # proj = (p, batch, d) @ (p, d, s) -> (p, batch, s)
+    nodes.append(oh.make_node(
+        'MatMul', [tangent_name, omegas_name], ['_rts_proj'],
+    ))
+
+    # Step 2: Transpose omegas -> (p, s, d)
+    nodes.append(oh.make_node(
+        'Transpose', [omegas_name], ['_rts_omegas_T'],
+        perm=[0, 2, 1],
+    ))
+
+    # recon = (p, batch, s) @ (p, s, d) -> (p, batch, d)
+    nodes.append(oh.make_node(
+        'MatMul', ['_rts_proj', '_rts_omegas_T'], ['_rts_recon'],
+    ))
+
+    # Step 3: residual = tangent - recon
+    nodes.append(oh.make_node(
+        'Sub', [tangent_name, '_rts_recon'], ['_rts_residual'],
+    ))
+
+    # residual^2
+    nodes.append(oh.make_node(
+        'Mul', ['_rts_residual', '_rts_residual'], ['_rts_res_sq'],
+    ))
+
+    # ReduceSum over features axis=2 -> (p, batch)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_rts_res_sq', '_rts_axis2'],
+        ['_rts_dist_t'], keepdims=0,
+    ))
+
+    # Transpose -> (batch, p)
+    nodes.append(oh.make_node(
+        'Transpose', ['_rts_dist_t'], ['distances_rts'],
+        perm=[1, 0],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_rts_axis2', TensorProto.INT64, [1], [2]),
+    ]
+    return nodes, extra_initializers, 'distances_rts'
+
+
+def _export_riemannian_onnx(model, batch_size, opset_version, path):
+    """Export a Riemannian supervised model to ONNX.
+
+    Handles RiemannianSRNG (chordal distance on SO(n)) and
+    RiemannianSMNG/SLNG/STNG (tangent-space metric on SO(n) or Grassmannian).
+    """
+    import onnx
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    from prosemble.core.manifolds import SO, Grassmannian
+
+    # Determine manifold and model variant
+    manifold = model.manifold
+    is_so = isinstance(manifold, SO)
+    is_gr = isinstance(manifold, Grassmannian)
+    model_name = type(model).__name__
+
+    # Determine point shape
+    if is_so:
+        n = manifold.n
+        n_features = n * n
+        point_shape = (n, n)
+    else:  # Grassmannian
+        n, k = manifold.n, manifold.k
+        n_features = n * k
+        point_shape = (n, k)
+
+    batch_dim = batch_size if batch_size > 0 else 'batch'
+    input_shape = [batch_dim, n_features]
+
+    all_nodes = []
+    initializers = []
+
+    # Prototypes (flattened manifold points)
+    prototypes = np.asarray(model.prototypes_, dtype=np.float32)
+    n_proto = prototypes.shape[0]
+    initializers.append(
+        oh.make_tensor(
+            'prototypes', TensorProto.FLOAT,
+            list(prototypes.shape), prototypes.flatten().tolist(),
+        ),
+    )
+
+    # Prototype labels
+    proto_labels = np.asarray(model.prototype_labels_).astype(np.int64)
+    initializers.append(
+        oh.make_tensor(
+            'proto_labels', TensorProto.INT64,
+            list(proto_labels.shape), proto_labels.flatten().tolist(),
+        ),
+    )
+
+    # --- Distance computation ---
+    if model_name == 'RiemannianSRNG':
+        # Chordal distance: ||X - W||^2_F (works on flattened vectors directly)
+        nodes, extra_inits, dist_out = _riemannian_so_chordal_onnx(
+            'X', 'prototypes', n,
+        )
+        all_nodes.extend(nodes)
+        initializers.extend(extra_inits)
+
+    else:
+        # SMNG, SLNG, STNG: compute tangent vectors first, then apply metric
+        if is_so:
+            tang_nodes, tang_inits, tangent_out = _riemannian_so_tangent_onnx(
+                'X', 'prototypes', n,
+            )
+        else:  # Grassmannian
+            tang_nodes, tang_inits, tangent_out = _riemannian_gr_tangent_onnx(
+                'X', 'prototypes', n, k,
+            )
+        all_nodes.extend(tang_nodes)
+        initializers.extend(tang_inits)
+
+        # Apply metric based on model variant
+        if model_name == 'RiemannianSMNG':
+            # Global omega
+            omega = np.asarray(model.omega_, dtype=np.float32)
+            initializers.append(
+                oh.make_tensor(
+                    'omega', TensorProto.FLOAT,
+                    list(omega.shape), omega.flatten().tolist(),
+                ),
+            )
+            met_nodes, met_inits, dist_out = _riemannian_global_omega_onnx(
+                tangent_out, 'omega',
+            )
+
+        elif model_name == 'RiemannianSLNG':
+            # Per-prototype local omega
+            omegas = np.asarray(model.omegas_, dtype=np.float32)
+            initializers.append(
+                oh.make_tensor(
+                    'omegas', TensorProto.FLOAT,
+                    list(omegas.shape), omegas.flatten().tolist(),
+                ),
+            )
+            met_nodes, met_inits, dist_out = _riemannian_local_omega_onnx(
+                tangent_out, 'omegas',
+            )
+
+        elif model_name == 'RiemannianSTNG':
+            # Tangent subspace
+            omegas = np.asarray(model.omegas_, dtype=np.float32)
+            initializers.append(
+                oh.make_tensor(
+                    'omegas', TensorProto.FLOAT,
+                    list(omegas.shape), omegas.flatten().tolist(),
+                ),
+            )
+            met_nodes, met_inits, dist_out = _riemannian_tangent_subspace_onnx(
+                tangent_out, 'omegas',
+            )
+        else:
+            raise NotImplementedError(
+                f"Unknown Riemannian model variant: {model_name}"
+            )
+
+        all_nodes.extend(met_nodes)
+        initializers.extend(met_inits)
+
+    # --- WTAC decision ---
+    comp_nodes, comp_inits = _wtac_onnx_nodes(dist_out, 'proto_labels')
+    all_nodes.extend(comp_nodes)
+    initializers.extend(comp_inits)
+
+    # --- Build graph ---
+    X_input = oh.make_tensor_value_info('X', TensorProto.FLOAT, input_shape)
+    Y_output = oh.make_tensor_value_info(
+        'predictions', TensorProto.INT64, [batch_dim],
+    )
+
+    graph = oh.make_graph(
+        all_nodes,
+        'prosemble_riemannian_predict',
+        [X_input],
+        [Y_output],
+        initializer=initializers,
+    )
+
+    onnx_model = oh.make_model(graph, opset_imports=[
+        oh.make_opsetid('', opset_version),
+    ])
+    onnx_model.ir_version = 8
+    onnx.checker.check_model(onnx_model)
+
+    if path is not None:
+        onnx.save(onnx_model, path)
+
+    return onnx_model
+
+
+# ---------------------------------------------------------------------------
 # Competition / decision builders
 # ---------------------------------------------------------------------------
 
@@ -1540,13 +2045,26 @@ def _check_model_exportable(model):
 
     Raises NotImplementedError for models that cannot be converted.
     """
-    # Riemannian models: manifold ops have no ONNX equivalent
+    # Riemannian models: check manifold-specific exportability
     from prosemble.models.riemannian_srng import RiemannianSRNG
     if isinstance(model, RiemannianSRNG):
-        raise NotImplementedError(
-            "ONNX export is not supported for Riemannian models. "
-            "Manifold operations (logm, expm) have no ONNX equivalent."
-        )
+        from prosemble.core.manifolds import SO, Grassmannian, SPD
+        if isinstance(model.manifold, SPD):
+            raise NotImplementedError(
+                "ONNX export is not supported for Riemannian models with "
+                "SPD(n) manifold. Eigendecomposition (eigh) has no ONNX "
+                "equivalent."
+            )
+        model_name = type(model).__name__
+        if (isinstance(model.manifold, Grassmannian)
+                and model_name == 'RiemannianSRNG'):
+            raise NotImplementedError(
+                "ONNX export is not supported for RiemannianSRNG with "
+                "Grassmannian manifold. SVD-based geodesic distance has "
+                "no ONNX equivalent."
+            )
+        # SO(n) for all 4 models, and Grassmannian for SMNG/SLNG/STNG are OK
+        return
 
     try:
         from prosemble.models.riemannian_neural_gas import RiemannianNeuralGas
@@ -1582,8 +2100,9 @@ def export_onnx(
     Builds an ONNX graph that reproduces the model's ``predict()``
     output.  Supports supervised (WTAC), unsupervised (ArgMin),
     one-class (threshold-based), SVQ-OCC (response model), CBC
-    (reasoning matrices), PLVQ (Gaussian mixture), and encoder
-    models (MLP/CNN backbone).
+    (reasoning matrices), PLVQ (Gaussian mixture), encoder models
+    (MLP/CNN backbone), and Riemannian models on SO(n)/Grassmannian
+    manifolds (75 of 87 models total).
 
     Parameters
     ----------
@@ -1617,6 +2136,11 @@ def export_onnx(
 
     model._check_fitted()
     _check_model_exportable(model)
+
+    # Riemannian models: use dedicated export path
+    from prosemble.models.riemannian_srng import RiemannianSRNG
+    if isinstance(model, RiemannianSRNG):
+        return _export_riemannian_onnx(model, batch_size, opset_version, path)
 
     # Identify model type and distance
     model_type, dist_type = _identify_model_type(model)

--- a/sphinx-docs/guides/onnx.rst
+++ b/sphinx-docs/guides/onnx.rst
@@ -6,7 +6,7 @@ cross-platform deployment.  An exported ONNX model reproduces the ``predict()``
 output of the original model and runs anywhere ONNX Runtime is available —
 no JAX or prosemble dependency needed at inference time.
 
-**68 of 71 models** are supported.
+**75 of 87 models** are supported.
 
 Installation
 ------------
@@ -149,6 +149,15 @@ Supported Models
    * - CBC (reasoning matrices)
      - 2
      - CBC, ImageCBC
+   * - Riemannian SO(n) (chordal)
+     - 1
+     - RiemannianSRNG
+   * - Riemannian SO(n) (tangent-space metric)
+     - 3
+     - RiemannianSMNG, RiemannianSLNG, RiemannianSTNG
+   * - Riemannian Grassmannian (tangent-space metric)
+     - 3
+     - RiemannianSMNG, RiemannianSLNG, RiemannianSTNG
 
 Encoder Models
 --------------
@@ -191,6 +200,15 @@ Distance Functions in ONNX
    * - Relevance-weighted
      - Element-wise weighted squared diff
      - OCGRLVQ, SVQOCC_R
+   * - SO(n) Chordal
+     - Broadcast subtract + Frobenius norm
+     - RiemannianSRNG
+   * - SO(n) Tangent
+     - Skew-symmetric log map + metric adaptation
+     - RiemannianSMNG/SLNG/STNG (SO)
+   * - Grassmannian Tangent
+     - Projection log map + metric adaptation
+     - RiemannianSMNG/SLNG/STNG (Gr)
 
 Not Supported
 -------------
@@ -205,9 +223,15 @@ Not Supported
    * - Kernel fuzzy clustering (KFCM, KPCM, KFPCM, KPFCM, KAFCM, KIPCM, KIPCM2)
      - 7
      - Gaussian kernel distance has no standard ONNX operator
-   * - Riemannian models (RiemannianSRNG, RiemannianSMNG, RiemannianSLNG, RiemannianSTNG, RiemannianNeuralGas)
-     - 5
-     - Matrix logarithm/exponential and eigendecomposition have no ONNX operator
+   * - RiemannianSRNG + Grassmannian
+     - 1
+     - SVD-based geodesic distance has no ONNX operator
+   * - RiemannianNeuralGas (all manifolds)
+     - 1
+     - Matrix logarithm via Schur decomposition has no ONNX operator
+   * - All Riemannian models + SPD(n)
+     - (manifold choice)
+     - Eigendecomposition (eigh) has no ONNX operator
    * - GrowingNeuralGas
      - 1
      - Dynamic topology (variable number of prototypes)

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -172,12 +172,12 @@ class TestKernelFuzzyRejection:
 
 class TestUnsupportedModels:
 
-    def test_riemannian_raises(self):
-        from prosemble.core.manifolds import SO
+    def test_riemannian_spd_raises(self):
+        from prosemble.core.manifolds import SPD
         from prosemble.models import RiemannianSRNG
-        model = RiemannianSRNG(manifold=SO(3), n_prototypes_per_class=1, max_iter=1)
+        model = RiemannianSRNG(manifold=SPD(3), n_prototypes_per_class=1, max_iter=1)
         from prosemble.core.onnx_export import _check_model_exportable
-        with pytest.raises(NotImplementedError, match="Riemannian"):
+        with pytest.raises(NotImplementedError, match="SPD"):
             _check_model_exportable(model)
 
     def test_riemannian_ng_raises(self):
@@ -1070,3 +1070,261 @@ class TestImageCBCExport:
         jax_preds = np.asarray(model.predict(X))
         ort_preds = _onnx_predict(model, X)
         npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# Riemannian model ONNX export tests
+# ---------------------------------------------------------------------------
+
+def _make_so3_data(n=30, n_classes=3, seed=42):
+    """Generate random rotation matrices on SO(3) with labels."""
+    from scipy.spatial.transform import Rotation
+    np.random.seed(seed)
+    rotations = Rotation.random(n, random_state=seed).as_matrix()
+    X = jnp.array(rotations.reshape(n, 9).astype(np.float32))
+    y = jnp.array(np.tile(np.arange(n_classes), n // n_classes))
+    return X, y
+
+
+def _make_grassmannian_data(n=30, dim_n=4, dim_k=2, n_classes=3, seed=42):
+    """Generate random points on Gr(n,k) with labels."""
+    np.random.seed(seed)
+    points = []
+    for _ in range(n):
+        A = np.random.randn(dim_n, dim_k).astype(np.float32)
+        Q, _ = np.linalg.qr(A)
+        points.append(Q[:, :dim_k].flatten())
+    X = jnp.array(np.array(points))
+    y = jnp.array(np.tile(np.arange(n_classes), n // n_classes))
+    return X, y
+
+
+class TestRiemannianSRNGSO:
+    """RiemannianSRNG + SO(n): chordal distance."""
+
+    @pytest.fixture
+    def fitted_model(self):
+        from prosemble.models import RiemannianSRNG
+        from prosemble.core.manifolds import SO
+        X, y = _make_so3_data()
+        model = RiemannianSRNG(
+            manifold=SO(3), n_prototypes_per_class=1, max_iter=3,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_export_succeeds(self, fitted_model):
+        model, X = fitted_model
+        onnx_model = model.export_onnx(batch_size=X.shape[0])
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_model):
+        model, X = fitted_model
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestRiemannianSMNGSO:
+    """RiemannianSMNG + SO(n): tangent-space global omega."""
+
+    @pytest.fixture
+    def fitted_model(self):
+        from prosemble.models import RiemannianSMNG
+        from prosemble.core.manifolds import SO
+        X, y = _make_so3_data()
+        model = RiemannianSMNG(
+            manifold=SO(3), latent_dim=5, n_prototypes_per_class=1,
+            max_iter=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_export_succeeds(self, fitted_model):
+        model, X = fitted_model
+        onnx_model = model.export_onnx(batch_size=X.shape[0])
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_model):
+        model, X = fitted_model
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestRiemannianSMNGGrassmannian:
+    """RiemannianSMNG + Grassmannian: tangent-space global omega."""
+
+    @pytest.fixture
+    def fitted_model(self):
+        from prosemble.models import RiemannianSMNG
+        from prosemble.core.manifolds import Grassmannian
+        X, y = _make_grassmannian_data()
+        model = RiemannianSMNG(
+            manifold=Grassmannian(4, 2), latent_dim=4,
+            n_prototypes_per_class=1, max_iter=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_export_succeeds(self, fitted_model):
+        model, X = fitted_model
+        onnx_model = model.export_onnx(batch_size=X.shape[0])
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_model):
+        model, X = fitted_model
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestRiemannianSLNGSO:
+    """RiemannianSLNG + SO(n): per-prototype local omega."""
+
+    @pytest.fixture
+    def fitted_model(self):
+        from prosemble.models import RiemannianSLNG
+        from prosemble.core.manifolds import SO
+        X, y = _make_so3_data()
+        model = RiemannianSLNG(
+            manifold=SO(3), latent_dim=5, n_prototypes_per_class=1,
+            max_iter=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_export_succeeds(self, fitted_model):
+        model, X = fitted_model
+        onnx_model = model.export_onnx(batch_size=X.shape[0])
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_model):
+        model, X = fitted_model
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestRiemannianSLNGGrassmannian:
+    """RiemannianSLNG + Grassmannian: per-prototype local omega."""
+
+    @pytest.fixture
+    def fitted_model(self):
+        from prosemble.models import RiemannianSLNG
+        from prosemble.core.manifolds import Grassmannian
+        X, y = _make_grassmannian_data()
+        model = RiemannianSLNG(
+            manifold=Grassmannian(4, 2), latent_dim=4,
+            n_prototypes_per_class=1, max_iter=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_export_succeeds(self, fitted_model):
+        model, X = fitted_model
+        onnx_model = model.export_onnx(batch_size=X.shape[0])
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_model):
+        model, X = fitted_model
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestRiemannianSTNGSO:
+    """RiemannianSTNG + SO(n): tangent subspace."""
+
+    @pytest.fixture
+    def fitted_model(self):
+        from prosemble.models import RiemannianSTNG
+        from prosemble.core.manifolds import SO
+        X, y = _make_so3_data()
+        model = RiemannianSTNG(
+            manifold=SO(3), subspace_dim=4, n_prototypes_per_class=1,
+            max_iter=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_export_succeeds(self, fitted_model):
+        model, X = fitted_model
+        onnx_model = model.export_onnx(batch_size=X.shape[0])
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_model):
+        model, X = fitted_model
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestRiemannianSTNGGrassmannian:
+    """RiemannianSTNG + Grassmannian: tangent subspace."""
+
+    @pytest.fixture
+    def fitted_model(self):
+        from prosemble.models import RiemannianSTNG
+        from prosemble.core.manifolds import Grassmannian
+        X, y = _make_grassmannian_data()
+        model = RiemannianSTNG(
+            manifold=Grassmannian(4, 2), subspace_dim=4,
+            n_prototypes_per_class=1, max_iter=3, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_export_succeeds(self, fitted_model):
+        model, X = fitted_model
+        onnx_model = model.export_onnx(batch_size=X.shape[0])
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_model):
+        model, X = fitted_model
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestRiemannianONNXRejections:
+    """Models/manifolds that should raise NotImplementedError."""
+
+    def test_srng_spd_raises(self):
+        from prosemble.models import RiemannianSRNG
+        from prosemble.core.manifolds import SPD
+        X, y = _make_supervised_data(30, 9)
+        model = RiemannianSRNG(
+            manifold=SPD(3), n_prototypes_per_class=1, max_iter=3,
+            random_seed=42,
+        )
+        model.fit(X, y)
+        with pytest.raises(NotImplementedError, match="SPD"):
+            model.export_onnx()
+
+    def test_srng_grassmannian_raises(self):
+        from prosemble.models import RiemannianSRNG
+        from prosemble.core.manifolds import Grassmannian
+        X, y = _make_grassmannian_data()
+        model = RiemannianSRNG(
+            manifold=Grassmannian(4, 2), n_prototypes_per_class=1,
+            max_iter=3, random_seed=42,
+        )
+        model.fit(X, y)
+        with pytest.raises(NotImplementedError, match="Grassmannian"):
+            model.export_onnx()
+
+    def test_riemannian_neural_gas_raises(self):
+        from prosemble.models import RiemannianNeuralGas
+        from prosemble.core.manifolds import SO
+        from scipy.spatial.transform import Rotation
+        np.random.seed(42)
+        X = Rotation.random(20, random_state=42).as_matrix().astype(np.float32)
+        # RiemannianNeuralGas expects (n_samples, n, n) shape
+        model = RiemannianNeuralGas(
+            manifold=SO(3), n_prototypes=3, max_iter=2, random_seed=42,
+        )
+        model.fit(X)
+        with pytest.raises(NotImplementedError, match="RiemannianNeuralGas"):
+            model.export_onnx()


### PR DESCRIPTION
Implement ONNX export for 7 model-manifold combinations:
- RiemannianSRNG with SO(n) via chordal distance
- RiemannianSMNG/SLNG/STNG with SO(n) via skew-symmetric log map
- RiemannianSMNG/SLNG/STNG with Grassmannian via projection log map

All use standard ONNX ops (MatMul, Sub, Transpose, ReduceSum). Takes ONNX coverage from 68/87 to 75/87 models.