### PR TITLE
feat: Add multi-device data parallelism, gradient checkpointing, and …

### DIFF
--- a/prosemble/core/__init__.py
+++ b/prosemble/core/__init__.py
@@ -40,6 +40,7 @@ from .protocols import (
 )
 from .serialization import SerializationMixin
 from .data import shuffle_arrays, padded_batches, batched_iterator
+from .distributed import create_mesh, shard_data, replicate_params
 
 try:
     import jax
@@ -90,6 +91,8 @@ __all__ = _distance_all + [
     'SerializationMixin',
     # Data loading utilities
     'shuffle_arrays', 'padded_batches', 'batched_iterator',
+    # Distributed training
+    'create_mesh', 'shard_data', 'replicate_params',
     # ONNX export (optional)
     'export_onnx',
 ]

--- a/prosemble/core/distributed.py
+++ b/prosemble/core/distributed.py
@@ -1,0 +1,104 @@
+"""Distributed training utilities for multi-device data parallelism.
+
+Provides functions for sharding data across devices and replicating
+model parameters, enabling data-parallel training on multi-GPU/TPU setups.
+"""
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+
+
+def create_mesh(devices=None):
+    """Create a 1D device mesh for data parallelism.
+
+    Parameters
+    ----------
+    devices : list of jax.Device or None
+        Devices to use. If None, returns None (single-device mode).
+
+    Returns
+    -------
+    Mesh or None
+    """
+    if devices is None:
+        return None
+    return Mesh(devices, axis_names=('data',))
+
+
+def shard_data(X, y, mesh):
+    """Shard data arrays along the batch dimension across devices.
+
+    Parameters
+    ----------
+    X : jnp.ndarray of shape (n_samples, ...)
+        Input data.
+    y : jnp.ndarray of shape (n_samples,)
+        Labels.
+    mesh : Mesh
+        Device mesh from create_mesh().
+
+    Returns
+    -------
+    X_sharded, y_sharded : tuple of sharded arrays
+    """
+    data_sharding = NamedSharding(mesh, P('data'))
+    X_sharded = jax.device_put(X, data_sharding)
+    y_sharded = jax.device_put(y, data_sharding)
+    return X_sharded, y_sharded
+
+
+def replicate_params(params, mesh):
+    """Replicate params across all devices (no partitioning).
+
+    Parameters
+    ----------
+    params : dict (pytree)
+        Model parameters.
+    mesh : Mesh
+        Device mesh from create_mesh().
+
+    Returns
+    -------
+    params replicated across mesh
+    """
+    replicated = NamedSharding(mesh, P())
+    return jax.device_put(params, replicated)
+
+
+def replicate_opt_state(opt_state, mesh):
+    """Replicate optimizer state across all devices.
+
+    Parameters
+    ----------
+    opt_state : pytree
+        Optax optimizer state.
+    mesh : Mesh
+        Device mesh from create_mesh().
+
+    Returns
+    -------
+    opt_state replicated across mesh
+    """
+    replicated = NamedSharding(mesh, P())
+    return jax.device_put(opt_state, replicated)
+
+
+def unshard_params(params):
+    """Bring params back to a single device.
+
+    Used after training to store results as plain arrays for
+    predict/export operations.
+
+    Parameters
+    ----------
+    params : pytree
+        Potentially sharded parameters.
+
+    Returns
+    -------
+    params on default device
+    """
+    return jax.tree.map(
+        lambda x: jax.device_put(x, jax.devices()[0]), params
+    )

--- a/prosemble/models/glvq.py
+++ b/prosemble/models/glvq.py
@@ -117,7 +117,8 @@ class GLVQ(SupervisedPrototypeModel):
                  prototypes_initializer=None, patience=None,
                  restore_best=False, class_weight=None,
                  gradient_accumulation_steps=None, ema_decay=None,
-                 freeze_params=None, lookahead=None, mixed_precision=None):
+                 freeze_params=None, lookahead=None, mixed_precision=None,
+                 **kwargs):
         super().__init__(
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
@@ -132,6 +133,7 @@ class GLVQ(SupervisedPrototypeModel):
             gradient_accumulation_steps=gradient_accumulation_steps,
             ema_decay=ema_decay, freeze_params=freeze_params,
             lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
         )
         self.beta = beta
 

--- a/prosemble/models/lvq1.py
+++ b/prosemble/models/lvq1.py
@@ -117,7 +117,8 @@ class LVQ1(SupervisedPrototypeModel):
                  prototypes_initializer=None, patience=None,
                  restore_best=False, class_weight=None,
                  gradient_accumulation_steps=None, ema_decay=None,
-                 freeze_params=None, lookahead=None, mixed_precision=None):
+                 freeze_params=None, lookahead=None, mixed_precision=None,
+                 **kwargs):
         super().__init__(
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
@@ -132,6 +133,7 @@ class LVQ1(SupervisedPrototypeModel):
             gradient_accumulation_steps=gradient_accumulation_steps,
             ema_decay=ema_decay, freeze_params=freeze_params,
             lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
         )
 
     def fit(self, X, y, initial_prototypes=None):

--- a/prosemble/models/lvq21.py
+++ b/prosemble/models/lvq21.py
@@ -116,7 +116,8 @@ class LVQ21(SupervisedPrototypeModel):
                  prototypes_initializer=None, patience=None,
                  restore_best=False, class_weight=None,
                  gradient_accumulation_steps=None, ema_decay=None,
-                 freeze_params=None, lookahead=None, mixed_precision=None):
+                 freeze_params=None, lookahead=None, mixed_precision=None,
+                 **kwargs):
         super().__init__(
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
@@ -131,6 +132,7 @@ class LVQ21(SupervisedPrototypeModel):
             gradient_accumulation_steps=gradient_accumulation_steps,
             ema_decay=ema_decay, freeze_params=freeze_params,
             lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
         )
 
     def fit(self, X, y, initial_prototypes=None):

--- a/prosemble/models/median_lvq.py
+++ b/prosemble/models/median_lvq.py
@@ -117,7 +117,8 @@ class MedianLVQ(SupervisedPrototypeModel):
                  prototypes_initializer=None, patience=None,
                  restore_best=False, class_weight=None,
                  gradient_accumulation_steps=None, ema_decay=None,
-                 freeze_params=None, lookahead=None, mixed_precision=None):
+                 freeze_params=None, lookahead=None, mixed_precision=None,
+                 **kwargs):
         super().__init__(
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
@@ -132,6 +133,7 @@ class MedianLVQ(SupervisedPrototypeModel):
             gradient_accumulation_steps=gradient_accumulation_steps,
             ema_decay=ema_decay, freeze_params=freeze_params,
             lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
         )
 
     def fit(self, X, y, initial_prototypes=None):

--- a/prosemble/models/probabilistic_lvq.py
+++ b/prosemble/models/probabilistic_lvq.py
@@ -130,7 +130,8 @@ class SLVQ(SupervisedPrototypeModel):
                  prototypes_initializer=None, patience=None,
                  restore_best=False, class_weight=None,
                  gradient_accumulation_steps=None, ema_decay=None,
-                 freeze_params=None, lookahead=None, mixed_precision=None):
+                 freeze_params=None, lookahead=None, mixed_precision=None,
+                 **kwargs):
         super().__init__(
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
@@ -145,6 +146,7 @@ class SLVQ(SupervisedPrototypeModel):
             gradient_accumulation_steps=gradient_accumulation_steps,
             ema_decay=ema_decay, freeze_params=freeze_params,
             lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
         )
         self.sigma = sigma
         self.rejection_confidence = rejection_confidence
@@ -291,7 +293,8 @@ class RSLVQ(SupervisedPrototypeModel):
                  prototypes_initializer=None, patience=None,
                  restore_best=False, class_weight=None,
                  gradient_accumulation_steps=None, ema_decay=None,
-                 freeze_params=None, lookahead=None, mixed_precision=None):
+                 freeze_params=None, lookahead=None, mixed_precision=None,
+                 **kwargs):
         super().__init__(
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
@@ -306,6 +309,7 @@ class RSLVQ(SupervisedPrototypeModel):
             gradient_accumulation_steps=gradient_accumulation_steps,
             ema_decay=ema_decay, freeze_params=freeze_params,
             lookahead=lookahead, mixed_precision=mixed_precision,
+            **kwargs,
         )
         self.sigma = sigma
         self.rejection_confidence = rejection_confidence

--- a/prosemble/models/prototype_base.py
+++ b/prosemble/models/prototype_base.py
@@ -246,6 +246,16 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
         Master weights stay in float32; forward/backward pass runs in lower
         precision for ~2x speed and ~half memory on GPU. Float16 uses static
         loss scaling to prevent gradient underflow. Default: None (disabled).
+    gradient_checkpointing : bool, optional
+        If True, applies ``jax.checkpoint`` (remat) to the loss function.
+        Trades compute for memory by re-computing forward activations during
+        the backward pass. Beneficial for deep backbone models (Image,
+        Siamese). Default: False.
+    devices : list of jax.Device or None, optional
+        Devices for data-parallel training. Data is sharded across devices
+        along the batch dimension; params and optimizer state are replicated.
+        When using mini-batch training, ``batch_size`` must be divisible by
+        the number of devices. Default: None (single-device).
     """
 
     def __init__(
@@ -273,6 +283,8 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
         freeze_params: list | None = None,
         lookahead: dict | None = None,
         mixed_precision: str | None = None,
+        gradient_checkpointing: bool = False,
+        devices: list | None = None,
     ):
         if isinstance(n_prototypes_per_class, dict):
             for cls, cnt in n_prototypes_per_class.items():
@@ -355,6 +367,13 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
         self.mixed_precision = mixed_precision
         self._mp_dtype = jnp.dtype(mixed_precision) if mixed_precision else None
         self._loss_scale = 2**15 if mixed_precision == 'float16' else 1.0
+
+        # Gradient checkpointing (remat)
+        self.gradient_checkpointing = gradient_checkpointing
+
+        # Multi-device data parallelism
+        self.devices = devices
+        self._mesh = None
 
         # Default active optimizer (may be wrapped with masking in fit())
         self._active_optimizer = self._optimizer
@@ -653,17 +672,31 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
         return self._compute_loss(params_mp, X, y, proto_labels) * self._loss_scale
 
     def _value_and_grad_fn(self, params, X, y, proto_labels):
-        """Compute loss and gradients, with optional mixed precision."""
-        if self._mp_dtype is not None:
-            scaled_loss, grads = jax.value_and_grad(self._compute_loss_mp)(
-                params, X, y, proto_labels
-            )
-            loss = scaled_loss / self._loss_scale
+        """Compute loss and gradients.
+
+        Supports optional mixed precision, gradient checkpointing (remat),
+        and custom VJP rules.
+        """
+        # Select loss function
+        if getattr(self, '_use_custom_vjp', False):
+            loss_fn = self._custom_vjp_loss
+        elif self._mp_dtype is not None:
+            loss_fn = self._compute_loss_mp
+        else:
+            loss_fn = self._compute_loss
+
+        # Apply gradient checkpointing (recompute forward during backward)
+        if self.gradient_checkpointing and not getattr(self, '_use_custom_vjp', False):
+            loss_fn = jax.checkpoint(loss_fn)
+
+        loss, grads = jax.value_and_grad(loss_fn)(params, X, y, proto_labels)
+
+        # Unscale for mixed precision
+        if self._mp_dtype is not None and not getattr(self, '_use_custom_vjp', False):
+            loss = loss / self._loss_scale
             grads = jax.tree.map(lambda g: g / self._loss_scale, grads)
-            return loss, grads
-        return jax.value_and_grad(self._compute_loss)(
-            params, X, y, proto_labels
-        )
+
+        return loss, grads
 
     def _post_update(self, params):
         """Apply constraints after gradient update (e.g., normalize relevances).
@@ -671,6 +704,16 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
         Default: no-op. Subclasses override as needed.
         """
         return params
+
+    def _custom_vjp_loss(self, params, X, y, proto_labels):
+        """Compute loss with custom VJP rule.
+
+        Override this method and set ``self._use_custom_vjp = True`` in
+        ``__init__`` to use a custom backward pass via ``@jax.custom_vjp``.
+
+        Default: None (uses standard autodiff on ``_compute_loss``).
+        """
+        return None
 
     def _get_weighted_data(self, X, y, sample_weight, key):
         """Apply sample weighting via weighted resampling.
@@ -749,6 +792,13 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
 
         if self.restore_best and best_params is not None:
             params = best_params
+
+        # Unshard params back to single device after multi-device training
+        if self._mesh is not None:
+            from prosemble.core.distributed import unshard_params
+            params = unshard_params(params)
+            proto_labels = jax.device_put(proto_labels, jax.devices()[0])
+
         self.prototypes_ = params['prototypes']
         self.prototype_labels_ = proto_labels
         self.loss_ = float(loss_history[-1]) if len(loss_history) > 0 else None
@@ -798,6 +848,18 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
 
         if X.ndim != 2:
             raise ValueError(f"X must be 2D, got shape {X.shape}")
+
+        # Multi-device sharding setup
+        if self.devices is not None:
+            from prosemble.core.distributed import create_mesh, shard_data
+            self._mesh = create_mesh(self.devices)
+            n_devices = len(self.devices)
+            if self.batch_size is not None and self.batch_size % n_devices != 0:
+                raise ValueError(
+                    f"batch_size ({self.batch_size}) must be divisible by "
+                    f"number of devices ({n_devices}) for data parallelism."
+                )
+            X, y = shard_data(X, y, self._mesh)
 
         self.classes_ = jnp.unique(y)
         self.n_classes_ = int(len(self.classes_))
@@ -855,6 +917,12 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
         else:
             opt_state = self._active_optimizer.init(params)
 
+        # Replicate params and optimizer state across devices
+        if self._mesh is not None:
+            from prosemble.core.distributed import replicate_params, replicate_opt_state
+            params = replicate_params(params, self._mesh)
+            opt_state = replicate_opt_state(opt_state, self._mesh)
+
         if self._callbacks:
             return self._fit_with_callbacks(X, y, params, opt_state, proto_labels)
         else:
@@ -881,6 +949,11 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
         X = jnp.asarray(X, dtype=jnp.float32)
         y = jnp.asarray(y, dtype=jnp.int32)
 
+        # Shard data if multi-device
+        if self._mesh is not None:
+            from prosemble.core.distributed import shard_data, replicate_params, replicate_opt_state
+            X, y = shard_data(X, y, self._mesh)
+
         # Build params from fitted state
         params = self._get_resume_params({'prototypes': self.prototypes_})
         proto_labels = self.prototype_labels_
@@ -890,6 +963,12 @@ class SupervisedPrototypeModel(SerializationMixin, MetadataCollectorMixin, Quant
             self._active_optimizer = self._optimizer
         if not hasattr(self, '_opt_state') or self._opt_state is None:
             self._opt_state = self._active_optimizer.init(params)
+
+        # Replicate params, optimizer state, and proto_labels for multi-device
+        if self._mesh is not None:
+            params = replicate_params(params, self._mesh)
+            self._opt_state = replicate_opt_state(self._opt_state, self._mesh)
+            proto_labels = replicate_params({'_': proto_labels}, self._mesh)['_']
 
         # Single gradient step
         loss, grads = self._value_and_grad_fn(params, X, y, proto_labels)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prosemble"
-version = "2.1.0"
+version = "2.3.0"
 description = "A python project for prototype-based machine learning models"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sphinx-docs/api/core.rst
+++ b/sphinx-docs/api/core.rst
@@ -141,6 +141,13 @@ Protocols
    :members:
    :undoc-members:
 
+Distributed Training
+--------------------
+
+.. automodule:: prosemble.core.distributed
+   :members:
+   :undoc-members:
+
 Data Utilities
 --------------
 

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'Prosemble'
 copyright = '2024-2026, Nana Abeka Otoo'
 author = 'Nana Abeka Otoo'
-release = '2.0.0'
+release = '2.3.0'
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/sphinx-docs/guides/advanced.rst
+++ b/sphinx-docs/guides/advanced.rst
@@ -621,6 +621,128 @@ JAX automatically uses available GPUs. Check your device:
 All prosemble operations (training, inference, distance computation) run
 on whatever device JAX is configured to use. No code changes needed.
 
+Multi-Device Data Parallelism
+------------------------------
+
+For large datasets or image models with trainable backbones, prosemble
+supports data-parallel training across multiple GPUs or TPUs using JAX's
+modern sharding API.
+
+.. code-block:: python
+
+   import jax
+   from prosemble.models import GLVQ
+
+   # Use all available devices
+   devices = jax.devices()  # e.g., [GpuDevice(id=0), GpuDevice(id=1), ...]
+
+   model = GLVQ(
+       n_prototypes_per_class=2,
+       max_iter=100,
+       lr=0.01,
+       devices=devices,
+       use_scan=False,
+   )
+   model.fit(X_train, y_train)
+
+When ``devices`` is specified:
+
+- Training data is **sharded** along the batch dimension across devices
+- Model parameters and optimizer state are **replicated** on all devices
+- Gradients are automatically aggregated (all-reduced) across devices
+- After training, parameters are moved back to a single device for inference
+
+**Requirements:**
+
+- ``batch_size`` (if set) must be divisible by the number of devices
+- The number of training samples should be divisible by the number of devices
+- ``use_scan=False`` is recommended for multi-device training
+
+**Primary use case:** Image variants (``ImageGLVQ``, ``ImageGMLVQ``,
+``ImageGTLVQ``, ``ImageCBC``) with trainable CNN backbones on large datasets
+across multiple GPUs/TPUs.
+
+.. code-block:: python
+
+   from prosemble.models import ImageGLVQ
+
+   model = ImageGLVQ(
+       n_prototypes_per_class=1,
+       max_iter=50,
+       lr=0.001,
+       devices=jax.devices(),
+       gradient_checkpointing=True,  # save memory for deep backbones
+       use_scan=False,
+   )
+   model.fit(X_images, y_labels)
+
+``partial_fit()`` also works with multi-device models:
+
+.. code-block:: python
+
+   model.fit(X_batch1, y_batch1)
+   model.partial_fit(X_batch2, y_batch2)  # data is automatically sharded
+
+Gradient Checkpointing
+-----------------------
+
+Gradient checkpointing (``jax.remat``) trades compute for memory by
+recomputing forward activations during the backward pass instead of
+storing them. This is beneficial when training models with deep backbones
+(Image, Siamese variants) that would otherwise exhaust GPU memory.
+
+.. code-block:: python
+
+   from prosemble.models import GLVQ
+
+   model = GLVQ(
+       n_prototypes_per_class=2,
+       max_iter=100,
+       lr=0.01,
+       gradient_checkpointing=True,
+   )
+   model.fit(X_train, y_train)
+
+When ``gradient_checkpointing=True``:
+
+- Forward activations are **not** stored during the forward pass
+- During backpropagation, the forward pass is **recomputed** to obtain
+  activations needed for gradient computation
+- Memory usage is reduced at the cost of ~33% more compute
+- Results are numerically identical to standard training
+
+This option has no effect on models with shallow loss functions (e.g.,
+standard GLVQ with Euclidean distance). It provides significant memory
+savings when unfreezing deep CNN backbones in Image or Siamese variants.
+
+Custom Gradient Rules
+----------------------
+
+Prosemble provides infrastructure for subclasses to define custom
+backward passes using ``jax.custom_vjp``. This is useful for:
+
+- Optimal transport distances with non-differentiable sorting operations
+- Hard thresholding operations that need surrogate gradients
+- Distances with numerically unstable standard autodiff
+
+Subclasses opt in by setting ``self._use_custom_vjp = True`` in their
+``__init__`` and overriding the ``_custom_vjp_loss`` method:
+
+.. code-block:: python
+
+   class MyModel(GLVQ):
+       def __init__(self, **kwargs):
+           super().__init__(**kwargs)
+           self._use_custom_vjp = True
+
+       def _custom_vjp_loss(self, params, X, y, proto_labels):
+           # Implement custom forward + backward pass
+           ...
+
+When ``_use_custom_vjp`` is active, gradient checkpointing is
+automatically disabled (custom VJP already controls what gets
+saved/recomputed).
+
 Training Callbacks
 ------------------
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1,0 +1,249 @@
+"""Tests for multi-device, gradient checkpointing, and custom VJP features."""
+
+import os
+
+# Simulate 4 CPU devices for testing multi-device code paths
+os.environ.setdefault(
+    'XLA_FLAGS', '--xla_force_host_platform_device_count=4'
+)
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from prosemble.models import GLVQ
+from prosemble.core.distributed import (
+    create_mesh, shard_data, replicate_params, replicate_opt_state,
+    unshard_params,
+)
+
+
+class TestGradientCheckpointing:
+    """Gradient checkpointing produces identical results to standard training."""
+
+    def test_checkpointing_same_loss(self):
+        """Loss history with checkpointing matches without."""
+        X = jnp.array(np.random.RandomState(0).randn(30, 4).astype(np.float32))
+        y = jnp.array([0] * 10 + [1] * 10 + [2] * 10, dtype=jnp.int32)
+
+        m1 = GLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            gradient_checkpointing=False, random_seed=42,
+        )
+        m1.fit(X, y)
+
+        m2 = GLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            gradient_checkpointing=True, random_seed=42,
+        )
+        m2.fit(X, y)
+
+        np.testing.assert_allclose(
+            np.asarray(m1.loss_history_),
+            np.asarray(m2.loss_history_),
+            atol=1e-5,
+        )
+
+    def test_checkpointing_same_predictions(self):
+        """Predictions match with and without checkpointing."""
+        X = jnp.array(np.random.RandomState(1).randn(20, 4).astype(np.float32))
+        y = jnp.array([0] * 10 + [1] * 10, dtype=jnp.int32)
+
+        m1 = GLVQ(
+            n_prototypes_per_class=1, max_iter=20, lr=0.01,
+            gradient_checkpointing=False, random_seed=7,
+        )
+        m1.fit(X, y)
+
+        m2 = GLVQ(
+            n_prototypes_per_class=1, max_iter=20, lr=0.01,
+            gradient_checkpointing=True, random_seed=7,
+        )
+        m2.fit(X, y)
+
+        np.testing.assert_array_equal(
+            np.asarray(m1.predict(X)),
+            np.asarray(m2.predict(X)),
+        )
+
+    def test_checkpointing_default_off(self):
+        """Default is gradient_checkpointing=False."""
+        model = GLVQ()
+        assert model.gradient_checkpointing is False
+
+
+class TestDistributedUtilities:
+    """Test sharding utility functions."""
+
+    def test_create_mesh_none(self):
+        """create_mesh(None) returns None."""
+        assert create_mesh(None) is None
+
+    def test_create_mesh_devices(self):
+        """create_mesh with devices creates a Mesh."""
+        devices = jax.devices()
+        mesh = create_mesh(devices)
+        assert mesh is not None
+        assert mesh.shape['data'] == len(devices)
+
+    def test_shard_data_shape_preserved(self):
+        """Sharded data preserves logical shape."""
+        devices = jax.devices()
+        mesh = create_mesh(devices)
+        X = jnp.ones((8, 4))
+        y = jnp.zeros(8, dtype=jnp.int32)
+        X_s, y_s = shard_data(X, y, mesh)
+        assert X_s.shape == (8, 4)
+        assert y_s.shape == (8,)
+
+    def test_replicate_params(self):
+        """Replicated params preserve values."""
+        devices = jax.devices()
+        mesh = create_mesh(devices)
+        params = {'prototypes': jnp.ones((3, 4))}
+        replicated = replicate_params(params, mesh)
+        np.testing.assert_array_equal(
+            np.asarray(replicated['prototypes']),
+            np.ones((3, 4)),
+        )
+
+    def test_unshard_params(self):
+        """unshard_params brings arrays to single device."""
+        params = {'prototypes': jnp.ones((3, 4))}
+        result = unshard_params(params)
+        assert result['prototypes'].shape == (3, 4)
+        np.testing.assert_array_equal(
+            np.asarray(result['prototypes']),
+            np.ones((3, 4)),
+        )
+
+
+class TestMultiDeviceTraining:
+    """Test multi-device training integration."""
+
+    def test_devices_none_unaffected(self):
+        """devices=None has no effect on training."""
+        X = jnp.array(np.random.RandomState(0).randn(20, 4).astype(np.float32))
+        y = jnp.array([0] * 10 + [1] * 10, dtype=jnp.int32)
+        model = GLVQ(
+            n_prototypes_per_class=1, max_iter=5, lr=0.01,
+            devices=None, random_seed=42,
+        )
+        model.fit(X, y)
+        assert model.prototypes_ is not None
+        assert model.prototypes_.shape == (2, 4)
+
+    def test_multi_device_training(self):
+        """Multi-device training produces valid results."""
+        devices = jax.devices()
+        n_devices = len(devices)
+        # n_samples must be divisible by n_devices for even sharding
+        n_per_class = 4 * n_devices
+        X = jnp.array(
+            np.random.RandomState(0).randn(2 * n_per_class, 4).astype(np.float32)
+        )
+        y = jnp.array(
+            [0] * n_per_class + [1] * n_per_class, dtype=jnp.int32
+        )
+
+        model = GLVQ(
+            n_prototypes_per_class=1, max_iter=10, lr=0.01,
+            devices=devices, random_seed=42, use_scan=False,
+        )
+        model.fit(X, y)
+
+        assert model.prototypes_ is not None
+        assert model.prototypes_.shape == (2, 4)
+        preds = model.predict(X)
+        assert preds.shape == (2 * n_per_class,)
+
+    def test_multi_device_same_as_single(self):
+        """Multi-device and single-device produce same results (deterministic)."""
+        devices = jax.devices()
+        n_devices = len(devices)
+        n_samples = 4 * n_devices
+        X = jnp.array(
+            np.random.RandomState(5).randn(n_samples, 4).astype(np.float32)
+        )
+        y = jnp.array(
+            [0] * (n_samples // 2) + [1] * (n_samples // 2), dtype=jnp.int32
+        )
+
+        m_single = GLVQ(
+            n_prototypes_per_class=1, max_iter=5, lr=0.01,
+            devices=None, random_seed=42, use_scan=False,
+        )
+        m_single.fit(X, y)
+
+        m_multi = GLVQ(
+            n_prototypes_per_class=1, max_iter=5, lr=0.01,
+            devices=devices, random_seed=42, use_scan=False,
+        )
+        m_multi.fit(X, y)
+
+        # Predictions should match (same data, same seed)
+        np.testing.assert_array_equal(
+            np.asarray(m_single.predict(X)),
+            np.asarray(m_multi.predict(X)),
+        )
+
+    def test_batch_size_validation(self):
+        """batch_size must be divisible by n_devices."""
+        devices = jax.devices()
+        n_devices = len(devices)
+        if n_devices < 2:
+            pytest.skip("Need 2+ devices for this test")
+
+        X = jnp.ones((20, 4))
+        y = jnp.array([0] * 10 + [1] * 10, dtype=jnp.int32)
+
+        # batch_size=3 not divisible by 4 devices
+        model = GLVQ(
+            n_prototypes_per_class=1, max_iter=5, lr=0.01,
+            devices=devices, batch_size=3,
+        )
+        with pytest.raises(ValueError, match="divisible"):
+            model.fit(X, y)
+
+    def test_partial_fit_with_devices(self):
+        """partial_fit works after multi-device fit."""
+        devices = jax.devices()
+        n_devices = len(devices)
+        n_samples = 4 * n_devices
+        X = jnp.array(
+            np.random.RandomState(0).randn(n_samples, 4).astype(np.float32)
+        )
+        y = jnp.array(
+            [0] * (n_samples // 2) + [1] * (n_samples // 2), dtype=jnp.int32
+        )
+
+        model = GLVQ(
+            n_prototypes_per_class=1, max_iter=5, lr=0.01,
+            devices=devices, random_seed=42, use_scan=False,
+        )
+        model.fit(X, y)
+
+        # partial_fit should work
+        model.partial_fit(X, y)
+        assert model.prototypes_ is not None
+
+
+class TestCustomVJP:
+    """Test custom_vjp infrastructure."""
+
+    def test_custom_vjp_hook_exists(self):
+        """_custom_vjp_loss method exists on base class."""
+        model = GLVQ()
+        assert hasattr(model, '_custom_vjp_loss')
+
+    def test_custom_vjp_not_used_by_default(self):
+        """Default models don't use custom VJP."""
+        model = GLVQ()
+        assert not getattr(model, '_use_custom_vjp', False)
+
+    def test_custom_vjp_returns_none_by_default(self):
+        """Default _custom_vjp_loss returns None."""
+        model = GLVQ()
+        result = model._custom_vjp_loss(None, None, None, None)
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -1953,7 +1953,7 @@ wheels = [
 
 [[package]]
 name = "prosemble"
-version = "2.1.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
…custom VJP

- Add `devices` parameter for data-parallel training across multiple GPUs/TPUs using JAX's modern sharding API (NamedSharding + PartitionSpec)
- Add `gradient_checkpointing` parameter to recompute forward activations during backward pass for memory-efficient training of deep backbones
- Add `_custom_vjp_loss` infrastructure hook for subclasses needing custom gradient rules (optimal transport, hard thresholding, etc.)
- Create prosemble.core.distributed module with sharding utilities
- Add **kwargs forwarding to GLVQ, LVQ1, LVQ21, MedianLVQ, RSLVQ subclasses
- Add comprehensive tests (16 tests, simulated 4-device parallelism)
- Update Sphinx documentation with Multi-Device, Checkpointing, Custom VJP sections
- Bump version to 2.2.0