### PR TITLE
feat: Add 9 DK models (OC/NG) + ONNX export for all 15 DK models

### DIFF
--- a/prosemble/core/onnx_export.py
+++ b/prosemble/core/onnx_export.py
@@ -666,6 +666,268 @@ def _tangent_onnx(builder, X_name, proto_name, omegas_name):
 
 
 # ---------------------------------------------------------------------------
+# Differentiating Kernel distance builders
+# ---------------------------------------------------------------------------
+
+def _kernel_per_proto_onnx(builder, X_name, proto_name, sigmas_name):
+    r"""Gaussian kernel distance with per-prototype bandwidth.
+
+    .. math::
+
+        d_\kappa^2(x, w_k) = 2\left(1 - \exp\left(
+            -\frac{\|x - w_k\|^2}{2\sigma_k^2}
+        \right)\right)
+
+    Parameters
+    ----------
+    sigmas_name : str
+        Name of the (n_proto,) per-prototype bandwidth initializer.
+        Should be pre-clamped to sigma_min at export time.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+        Output shape: (batch, n_proto), values in [0, 2].
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Unsqueeze X -> (batch, 1, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [X_name, '_kpp_axis1'], ['_kpp_x_exp'],
+    ))
+    # Unsqueeze W -> (1, n_proto, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [proto_name, '_kpp_axis0'], ['_kpp_w_exp'],
+    ))
+
+    # diff = X - W -> (batch, n_proto, features)
+    nodes.append(oh.make_node('Sub', ['_kpp_x_exp', '_kpp_w_exp'], ['_kpp_diff']))
+
+    # diff^2
+    nodes.append(oh.make_node('Mul', ['_kpp_diff', '_kpp_diff'], ['_kpp_diff_sq']))
+
+    # sq_norms = sum(diff^2, axis=2) -> (batch, n_proto)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_kpp_diff_sq', '_kpp_axis2'],
+        ['_kpp_sq_norms'], keepdims=0,
+    ))
+
+    # scaled = sq_norms * neg_inv_2sigma_sq
+    # neg_inv_2sigma_sq is (n_proto,), broadcasts with (batch, n_proto)
+    nodes.append(oh.make_node(
+        'Mul', ['_kpp_sq_norms', sigmas_name], ['_kpp_scaled'],
+    ))
+
+    # K = exp(scaled)
+    nodes.append(oh.make_node('Exp', ['_kpp_scaled'], ['_kpp_K']))
+
+    # 1 - K
+    nodes.append(oh.make_node('Sub', ['_kpp_one', '_kpp_K'], ['_kpp_one_minus_K']))
+
+    # 2 * (1 - K)
+    nodes.append(oh.make_node(
+        'Mul', ['_kpp_two', '_kpp_one_minus_K'], ['distances_kpp'],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_kpp_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_kpp_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_kpp_axis2', TensorProto.INT64, [1], [2]),
+        oh.make_tensor('_kpp_one', TensorProto.FLOAT, [], [1.0]),
+        oh.make_tensor('_kpp_two', TensorProto.FLOAT, [], [2.0]),
+    ]
+    return nodes, extra_initializers, 'distances_kpp'
+
+
+def _kernel_relevance_onnx(builder, X_name, proto_name, sigmas_name,
+                           relevances_name):
+    r"""Relevance-weighted Gaussian kernel distance.
+
+    .. math::
+
+        d_\kappa^2(x, w_k) = 2\left(1 - \exp\left(
+            -\frac{\sum_j \lambda_j (x_j - w_{kj})^2}{2\sigma_k^2}
+        \right)\right)
+
+    where :math:`\lambda = \text{softmax}(\text{relevances})`.
+
+    Parameters
+    ----------
+    sigmas_name : str
+        Name of the (n_proto,) per-prototype bandwidth initializer.
+    relevances_name : str
+        Name of the (n_features,) raw relevance logits initializer.
+        Softmax is applied inside this function.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+        Output shape: (batch, n_proto), values in [0, 2].
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Softmax on raw relevances -> normalized lambdas
+    nodes.append(oh.make_node(
+        'Softmax', [relevances_name], ['_kr_lambdas'], axis=0,
+    ))
+
+    # Unsqueeze X -> (batch, 1, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [X_name, '_kr_axis1'], ['_kr_x_exp'],
+    ))
+    # Unsqueeze W -> (1, n_proto, features)
+    nodes.append(oh.make_node(
+        'Unsqueeze', [proto_name, '_kr_axis0'], ['_kr_w_exp'],
+    ))
+
+    # diff = X - W -> (batch, n_proto, features)
+    nodes.append(oh.make_node('Sub', ['_kr_x_exp', '_kr_w_exp'], ['_kr_diff']))
+
+    # diff^2
+    nodes.append(oh.make_node('Mul', ['_kr_diff', '_kr_diff'], ['_kr_diff_sq']))
+
+    # weighted = lambdas * diff^2  (lambdas broadcasts as (d,))
+    nodes.append(oh.make_node(
+        'Mul', ['_kr_lambdas', '_kr_diff_sq'], ['_kr_weighted'],
+    ))
+
+    # weighted_norms = sum(weighted, axis=2) -> (batch, n_proto)
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_kr_weighted', '_kr_axis2'],
+        ['_kr_weighted_norms'], keepdims=0,
+    ))
+
+    # scaled = weighted_norms * neg_inv_2sigma_sq
+    nodes.append(oh.make_node(
+        'Mul', ['_kr_weighted_norms', sigmas_name], ['_kr_scaled'],
+    ))
+
+    # K = exp(scaled)
+    nodes.append(oh.make_node('Exp', ['_kr_scaled'], ['_kr_K']))
+
+    # 1 - K
+    nodes.append(oh.make_node('Sub', ['_kr_one', '_kr_K'], ['_kr_one_minus_K']))
+
+    # 2 * (1 - K)
+    nodes.append(oh.make_node(
+        'Mul', ['_kr_two', '_kr_one_minus_K'], ['distances_kr'],
+    ))
+
+    extra_initializers = [
+        oh.make_tensor('_kr_axis0', TensorProto.INT64, [1], [0]),
+        oh.make_tensor('_kr_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_kr_axis2', TensorProto.INT64, [1], [2]),
+        oh.make_tensor('_kr_one', TensorProto.FLOAT, [], [1.0]),
+        oh.make_tensor('_kr_two', TensorProto.FLOAT, [], [2.0]),
+    ]
+    return nodes, extra_initializers, 'distances_kr'
+
+
+def _kernel_exponential_onnx(builder, X_name, proto_name, omega_hat_name):
+    r"""Exponential kernel distance with learnable transformation.
+
+    .. math::
+
+        \hat\Lambda = \hat\Omega \hat\Omega^T
+
+        d_\kappa^2(x, w) = \exp(x^T \hat\Lambda x)
+                          + \exp(w^T \hat\Lambda w)
+                          - 2 \exp(x^T \hat\Lambda w)
+
+    Parameters
+    ----------
+    omega_hat_name : str
+        Name of the (n_features, latent_dim) transformation matrix
+        initializer.
+
+    Returns
+    -------
+    nodes, initializers, output_name
+        Output shape: (batch, n_proto).
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+
+    # Lambda_hat = omega_hat @ omega_hat^T  -> (d, d)
+    nodes.append(oh.make_node(
+        'Transpose', [omega_hat_name], ['_ke_omega_hat_T'],
+    ))
+    nodes.append(oh.make_node(
+        'MatMul', [omega_hat_name, '_ke_omega_hat_T'], ['_ke_lambda_hat'],
+    ))
+
+    # XL = X @ Lambda_hat -> (batch, d)
+    nodes.append(oh.make_node(
+        'MatMul', [X_name, '_ke_lambda_hat'], ['_ke_XL'],
+    ))
+
+    # xLx = sum(X * XL, axis=1, keepdims=1) -> (batch, 1)
+    nodes.append(oh.make_node('Mul', [X_name, '_ke_XL'], ['_ke_X_XL']))
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_ke_X_XL', '_ke_axis1'],
+        ['_ke_xLx'], keepdims=1,
+    ))
+
+    # WL = W @ Lambda_hat -> (n_proto, d)
+    nodes.append(oh.make_node(
+        'MatMul', [proto_name, '_ke_lambda_hat'], ['_ke_WL'],
+    ))
+
+    # wLw = sum(W * WL, axis=1, keepdims=1) -> (n_proto, 1)
+    nodes.append(oh.make_node('Mul', [proto_name, '_ke_WL'], ['_ke_W_WL']))
+    nodes.append(oh.make_node(
+        'ReduceSum', ['_ke_W_WL', '_ke_axis1'],
+        ['_ke_wLw'], keepdims=1,
+    ))
+
+    # wLw_T -> (1, n_proto)
+    nodes.append(oh.make_node('Transpose', ['_ke_wLw'], ['_ke_wLw_T']))
+
+    # W^T -> (d, n_proto)
+    nodes.append(oh.make_node('Transpose', [proto_name], ['_ke_W_T']))
+
+    # xLw = XL @ W^T -> (batch, n_proto)
+    nodes.append(oh.make_node('MatMul', ['_ke_XL', '_ke_W_T'], ['_ke_xLw']))
+
+    # exp terms
+    nodes.append(oh.make_node('Exp', ['_ke_xLx'], ['_ke_exp_xLx']))
+    nodes.append(oh.make_node('Exp', ['_ke_wLw_T'], ['_ke_exp_wLw']))
+    nodes.append(oh.make_node('Exp', ['_ke_xLw'], ['_ke_exp_xLw']))
+
+    # 2 * exp(xLw)
+    nodes.append(oh.make_node(
+        'Mul', ['_ke_two', '_ke_exp_xLw'], ['_ke_2exp_xLw'],
+    ))
+
+    # exp(xLx) + exp(wLw)  (broadcasts: (batch,1) + (1,n_proto) -> (batch,n_proto))
+    nodes.append(oh.make_node(
+        'Add', ['_ke_exp_xLx', '_ke_exp_wLw'], ['_ke_sum_self'],
+    ))
+
+    # dist_raw = sum_self - 2*exp(xLw)
+    nodes.append(oh.make_node(
+        'Sub', ['_ke_sum_self', '_ke_2exp_xLw'], ['_ke_dist_raw'],
+    ))
+
+    # Clip negatives (numerical stability)
+    nodes.append(oh.make_node('Relu', ['_ke_dist_raw'], ['distances_ke']))
+
+    extra_initializers = [
+        oh.make_tensor('_ke_axis1', TensorProto.INT64, [1], [1]),
+        oh.make_tensor('_ke_two', TensorProto.FLOAT, [], [2.0]),
+    ]
+    return nodes, extra_initializers, 'distances_ke'
+
+
+# ---------------------------------------------------------------------------
 # Riemannian model builders
 # ---------------------------------------------------------------------------
 
@@ -1895,7 +2157,8 @@ def _identify_model_type(model):
         'oc_gaussian_soft', 'oc_gaussian_ng', 'svqocc', 'cbc', 'plvq'.
     dist_type : str
         One of 'squared_euclidean', 'euclidean', 'manhattan', 'omega',
-        'relevance', 'local_omega', 'tangent'.
+        'relevance', 'local_omega', 'tangent', 'kernel_per_proto',
+        'kernel_relevance', 'kernel_exponential'.
     """
     # --- Determine model type ---
 
@@ -1964,12 +2227,28 @@ def _identify_model_type(model):
 def _identify_distance_fn(model, model_type='supervised') -> str:
     """Identify which distance function a model uses.
 
-    For OC and SVQ-OCC models, distance is detected from learned
-    metric parameters (omega_, omegas_, relevances_).  For supervised
-    and unsupervised models, distance is detected from the distance_fn
-    attribute.
+    For DK models, distance is detected from kernel-specific attributes
+    (sigmas_, omega_hat_).  For OC and SVQ-OCC models, distance is
+    detected from learned metric parameters (omega_, omegas_,
+    relevances_).  For supervised and unsupervised models, distance is
+    detected from the distance_fn attribute.
     """
     # --- Attribute-based detection (OC, SVQ-OCC, and supervised metric models) ---
+
+    # Kernel distance detection (DK models) — must come before Euclidean
+    # attribute checks to prevent misidentification
+    has_sigmas = hasattr(model, 'sigmas_') and model.sigmas_ is not None
+    has_omega_hat = hasattr(model, 'omega_hat_') and model.omega_hat_ is not None
+
+    if has_omega_hat:
+        return 'kernel_exponential'
+
+    if has_sigmas:
+        has_relevances = (hasattr(model, 'relevances_')
+                          and model.relevances_ is not None)
+        if has_relevances:
+            return 'kernel_relevance'
+        return 'kernel_per_proto'
 
     # Tangent vs local omega: tangent models have subspace_dim
     has_omegas = hasattr(model, 'omegas_') and model.omegas_ is not None
@@ -2036,7 +2315,8 @@ def _identify_distance_fn(model, model_type='supervised') -> str:
     raise NotImplementedError(
         f"ONNX export is not supported for distance function "
         f"'{fn_name or fn}'. Supported: squared_euclidean, euclidean, "
-        f"manhattan, omega, relevance, local_omega, tangent."
+        f"manhattan, omega, relevance, local_omega, tangent, "
+        f"kernel_per_proto, kernel_relevance, kernel_exponential."
     )
 
 
@@ -2101,8 +2381,9 @@ def export_onnx(
     output.  Supports supervised (WTAC), unsupervised (ArgMin),
     one-class (threshold-based), SVQ-OCC (response model), CBC
     (reasoning matrices), PLVQ (Gaussian mixture), encoder models
-    (MLP/CNN backbone), and Riemannian models on SO(n)/Grassmannian
-    manifolds (73 of 87 models total).
+    (MLP/CNN backbone), Differentiating Kernel models (Gaussian,
+    relevance-weighted, and exponential kernels), and Riemannian
+    models on SO(n)/Grassmannian manifolds (85 of 87 models total).
 
     Parameters
     ----------
@@ -2311,6 +2592,55 @@ def export_onnx(
         )
         nodes, extra_inits, dist_out = _tangent_onnx(
             None, X_for_distance, 'prototypes', 'omegas',
+        )
+    elif dist_type == 'kernel_per_proto':
+        sigmas = np.asarray(model.sigmas_).astype(np.float32)
+        sigma_min = getattr(model, 'sigma_min', 1e-3)
+        sigmas = np.maximum(sigmas, sigma_min)
+        neg_inv_2sigma_sq = (-1.0 / (2.0 * sigmas ** 2)).astype(np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'neg_inv_2sigma_sq', TensorProto.FLOAT,
+                list(neg_inv_2sigma_sq.shape),
+                neg_inv_2sigma_sq.flatten().tolist(),
+            ),
+        )
+        nodes, extra_inits, dist_out = _kernel_per_proto_onnx(
+            None, X_for_distance, 'prototypes', 'neg_inv_2sigma_sq',
+        )
+    elif dist_type == 'kernel_relevance':
+        sigmas = np.asarray(model.sigmas_).astype(np.float32)
+        sigma_min = getattr(model, 'sigma_min', 1e-3)
+        sigmas = np.maximum(sigmas, sigma_min)
+        neg_inv_2sigma_sq = (-1.0 / (2.0 * sigmas ** 2)).astype(np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'neg_inv_2sigma_sq', TensorProto.FLOAT,
+                list(neg_inv_2sigma_sq.shape),
+                neg_inv_2sigma_sq.flatten().tolist(),
+            ),
+        )
+        relevances = np.asarray(model.relevances_).astype(np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'relevances', TensorProto.FLOAT,
+                list(relevances.shape), relevances.flatten().tolist(),
+            ),
+        )
+        nodes, extra_inits, dist_out = _kernel_relevance_onnx(
+            None, X_for_distance, 'prototypes', 'neg_inv_2sigma_sq',
+            'relevances',
+        )
+    elif dist_type == 'kernel_exponential':
+        omega_hat = np.asarray(model.omega_hat_).astype(np.float32)
+        initializers.append(
+            oh.make_tensor(
+                'omega_hat', TensorProto.FLOAT,
+                list(omega_hat.shape), omega_hat.flatten().tolist(),
+            ),
+        )
+        nodes, extra_inits, dist_out = _kernel_exponential_onnx(
+            None, X_for_distance, 'prototypes', 'omega_hat',
         )
     else:
         raise NotImplementedError(f"Unknown distance type: {dist_type}")

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -96,9 +96,20 @@ try:
     from .dk_glvq import DKGLVQ
     from .dk_relevance_lvq import DKGRLVQ
     from .dk_matrix_lvq import DKGMLVQ
+    from .dk_glvq_ng import DKGLVQ_NG
+    from .dk_relevance_lvq_ng import DKGRLVQ_NG
+    from .dk_matrix_lvq_ng import DKGMLVQ_NG
     from .dk_neural_gas import DKNeuralGas
     from .dk_kohonen_som import DKKohonenSOM
     from .dk_heskes_som import DKHeskesSOM
+
+    # One-Class Differentiating Kernel models
+    from .oc_dk_glvq import OCDKGLVQ
+    from .oc_dk_relevance_lvq import OCDKGRLVQ
+    from .oc_dk_matrix_lvq import OCDKGMLVQ
+    from .oc_dk_glvq_ng import OCDKGLVQ_NG
+    from .oc_dk_relevance_lvq_ng import OCDKGRLVQ_NG
+    from .oc_dk_matrix_lvq_ng import OCDKGMLVQ_NG
 
     _MODEL_REGISTRY = {
         # Unsupervised clustering
@@ -144,8 +155,15 @@ try:
         'RiemannianNeuralGas': RiemannianNeuralGas,
         # Differentiating Kernel
         'DKGLVQ': DKGLVQ, 'DKGRLVQ': DKGRLVQ, 'DKGMLVQ': DKGMLVQ,
+        'DKGLVQ_NG': DKGLVQ_NG, 'DKGRLVQ_NG': DKGRLVQ_NG,
+        'DKGMLVQ_NG': DKGMLVQ_NG,
         'DKNeuralGas': DKNeuralGas, 'DKKohonenSOM': DKKohonenSOM,
         'DKHeskesSOM': DKHeskesSOM,
+        # One-Class Differentiating Kernel
+        'OCDKGLVQ': OCDKGLVQ, 'OCDKGRLVQ': OCDKGRLVQ,
+        'OCDKGMLVQ': OCDKGMLVQ,
+        'OCDKGLVQ_NG': OCDKGLVQ_NG, 'OCDKGRLVQ_NG': OCDKGRLVQ_NG,
+        'OCDKGMLVQ_NG': OCDKGMLVQ_NG,
     }
 
     JAX_AVAILABLE = True
@@ -194,7 +212,11 @@ __all__ = [
     'RiemannianNeuralGas',
     # Differentiating Kernel
     'DKGLVQ', 'DKGRLVQ', 'DKGMLVQ',
+    'DKGLVQ_NG', 'DKGRLVQ_NG', 'DKGMLVQ_NG',
     'DKNeuralGas', 'DKKohonenSOM', 'DKHeskesSOM',
+    # One-Class Differentiating Kernel
+    'OCDKGLVQ', 'OCDKGRLVQ', 'OCDKGMLVQ',
+    'OCDKGLVQ_NG', 'OCDKGRLVQ_NG', 'OCDKGMLVQ_NG',
     # Status
     'JAX_AVAILABLE',
 ]

--- a/prosemble/models/dk_glvq_ng.py
+++ b/prosemble/models/dk_glvq_ng.py
@@ -1,0 +1,351 @@
+"""
+Differentiating Kernel GLVQ with Neural Gas cooperation (DKGLVQ-NG).
+
+Combines DKGLVQ's Gaussian kernel distance and per-prototype bandwidth
+adaptation with Neural Gas neighborhood cooperation. All same-class
+prototypes participate in the loss, weighted by their distance rank.
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\|x - w_k\\|^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+       Neural Gas with General Similarity Measure. Neural Processing
+       Letters.
+"""
+
+import jax
+import jax.numpy as jnp
+from jax import jit
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.core.competitions import wtac
+from prosemble.core.kernel import kernel_distance_squared_per_proto
+
+
+@jit
+def _predict_dkglvq_ng_jit(X, prototypes, sigmas, proto_labels, sigma_min):
+    """JIT-compiled prediction with per-prototype kernel distance."""
+    sigmas = jnp.maximum(sigmas, sigma_min)
+    distances = kernel_distance_squared_per_proto(X, prototypes, sigmas)
+    return wtac(distances, proto_labels)
+
+
+class DKGLVQ_NG(SupervisedPrototypeModel):
+    """Differentiating Kernel GLVQ with Neural Gas cooperation.
+
+    Combines Gaussian kernel distance with per-prototype bandwidth
+    adaptation and Neural Gas rank-weighted loss. All same-class
+    prototypes participate, weighted by :math:`\\exp(-\\text{rank} / \\gamma)`.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\|x - w_k\\|^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    When :math:`\\gamma \\to 0`, DKGLVQ-NG recovers standard DKGLVQ.
+
+    Parameters
+    ----------
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median distance from prototype
+        to class members.
+        'mean': per-class mean distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma to prevent bandwidth collapse. Default: 1e-3.
+    beta : float
+        Transfer function steepness. Default: 10.0.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    sigmas_ : array of shape (n_prototypes,)
+        Learned per-prototype kernel bandwidths.
+    gamma_ : float
+        Final gamma value after training.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+           Neural Gas with General Similarity Measure. Neural Processing
+           Letters.
+
+    See Also
+    --------
+    DKGLVQ : Base variant without NG cooperation.
+    SRNG : NG variant with Euclidean relevance-weighted distance.
+    """
+
+    def __init__(self, sigma_init='median', sigma_min=1e-3, beta=10.0,
+                 gamma_init=None, gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.beta = beta
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.sigmas_ = None
+        self.gamma_ = None
+
+        # Ensure gamma is frozen from optimizer (not trainable)
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _estimate_sigmas(self, X, y, prototypes, proto_labels):
+        """Estimate per-prototype bandwidths from same-class data."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(prototypes.shape[0], float(self.sigma_init))
+
+        sigmas = []
+        for k in range(prototypes.shape[0]):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            X_class = X[class_mask]
+            dists = jnp.sqrt(jnp.sum((X_class - prototypes[k]) ** 2, axis=1))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists)
+            else:  # 'mean'
+                sigma_k = jnp.mean(dists)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        params['sigmas'] = self.sigmas_
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _init_state(self, X, y, key):
+        key1, key2 = jax.random.split(key)
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+        sigmas = self._estimate_sigmas(X, y, prototypes, proto_labels)
+
+        # Gamma initialization (same pattern as SRNG)
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
+
+        params = {
+            'prototypes': prototypes,
+            'sigmas': sigmas,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        gamma = params['gamma']
+
+        # Kernel distances: (n, p)
+        distances = kernel_distance_squared_per_proto(X, prototypes, sigmas)
+
+        # Class-aware ranking (only same-class prototypes)
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        # Double argsort for ranks
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        # h = exp(-rank / gamma), zero for wrong-class
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        # Normalize over same-class prototypes
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        # Closest different-class prototype distance
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        # GLVQ mu for each (sample, prototype) pair
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        # Apply transfer function
+        from prosemble.core.activations import sigmoid_beta
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        # Rank-weighted sum over same-class prototypes
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {
+            **params,
+            'sigmas': jnp.maximum(params['sigmas'], self.sigma_min),
+            'gamma': new_gamma,
+        }
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.sigmas_ = params['sigmas']
+        self.gamma_ = float(params['gamma'])
+
+    def predict(self, X):
+        """Predict using learned kernel distance."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_dkglvq_ng_jit(
+            X, self.prototypes_, self.sigmas_,
+            self.prototype_labels_, self.sigma_min,
+        )
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.sigmas_ is not None:
+            attrs.append('sigmas_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['beta'] = self.beta
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        return hp

--- a/prosemble/models/dk_matrix_lvq_ng.py
+++ b/prosemble/models/dk_matrix_lvq_ng.py
@@ -1,0 +1,332 @@
+"""
+Differentiating Kernel GMLVQ with Neural Gas cooperation (DKGMLVQ-NG).
+
+Combines DKGMLVQ's exponential kernel distance and adaptive matrix
+:math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T` with Neural Gas
+neighborhood cooperation.
+
+.. math::
+
+    d_\\kappa^2(x, w) = \\exp(x^T \\hat\\Lambda x)
+                      + \\exp(w^T \\hat\\Lambda w)
+                      - 2 \\exp(x^T \\hat\\Lambda w)
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+       Neural Gas with General Similarity Measure. Neural Processing
+       Letters.
+"""
+
+import jax
+import jax.numpy as jnp
+from jax import jit
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.core.competitions import wtac
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.kernel import exponential_kernel_distance_squared
+
+
+@jit
+def _predict_dkgmlvq_ng_jit(X, prototypes, omega_hat, proto_labels):
+    """JIT-compiled prediction with exponential kernel distance."""
+    distances = exponential_kernel_distance_squared(X, prototypes, omega_hat)
+    return wtac(distances, proto_labels)
+
+
+class DKGMLVQ_NG(SupervisedPrototypeModel):
+    """Differentiating Kernel GMLVQ with Neural Gas cooperation.
+
+    Combines exponential kernel distance with a learnable transformation
+    matrix :math:`\\hat\\Omega` and Neural Gas rank-weighted loss.
+
+    .. math::
+
+        d_\\kappa^2(x, w) = \\exp(x^T \\hat\\Lambda x)
+                          + \\exp(w^T \\hat\\Lambda w)
+                          - 2 \\exp(x^T \\hat\\Lambda w)
+
+    where :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`.
+
+    When :math:`\\gamma \\to 0`, DKGMLVQ-NG recovers standard DKGMLVQ.
+
+    Parameters
+    ----------
+    latent_dim : int, optional
+        Dimensionality of the transformation. If None, uses input dim.
+    omega_hat_scale : float
+        Scale factor for omega_hat initialization. Default: 0.1.
+    beta : float
+        Transfer function steepness. Default: 10.0.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    omega_hat_ : array of shape (n_features, latent_dim)
+        Learned transformation matrix.
+    gamma_ : float
+        Final gamma value after training.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+           Neural Gas with General Similarity Measure. Neural Processing
+           Letters.
+
+    See Also
+    --------
+    DKGMLVQ : Base variant without NG cooperation.
+    SMNG : NG variant with Euclidean Omega-projected distance.
+    """
+
+    def __init__(self, latent_dim=None, omega_hat_scale=0.1, beta=10.0,
+                 gamma_init=None, gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.latent_dim = latent_dim
+        self.omega_hat_scale = omega_hat_scale
+        self.beta = beta
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.omega_hat_ = None
+        self.gamma_ = None
+
+        # Ensure gamma is frozen from optimizer
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _get_resume_params(self, params):
+        params['omega_hat'] = self.omega_hat_
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim or n_features
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+        omega_hat = self.omega_hat_scale * identity_omega_init(
+            n_features, latent_dim
+        )
+
+        # Gamma initialization
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
+
+        params = {
+            'prototypes': prototypes,
+            'omega_hat': omega_hat,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omega_hat = params['omega_hat']
+        gamma = params['gamma']
+
+        # Exponential kernel distances: (n, p)
+        distances = exponential_kernel_distance_squared(
+            X, prototypes, omega_hat
+        )
+
+        # Class-aware ranking
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        from prosemble.core.activations import sigmoid_beta
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {**params, 'gamma': new_gamma}
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omega_hat_ = params['omega_hat']
+        self.gamma_ = float(params['gamma'])
+
+    def predict(self, X):
+        """Predict using learned exponential kernel distance."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_dkgmlvq_ng_jit(
+            X, self.prototypes_, self.omega_hat_, self.prototype_labels_
+        )
+
+    @property
+    def omega_hat_matrix(self):
+        """Return the learned :math:`\\hat\\Omega` matrix."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_
+
+    @property
+    def lambda_hat_matrix(self):
+        """Return :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_ @ self.omega_hat_.T
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omega_hat_ is not None:
+            attrs.append('omega_hat_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_hat_ is not None:
+            arrays['omega_hat_'] = np.asarray(self.omega_hat_)
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_hat_' in arrays:
+            self.omega_hat_ = jnp.asarray(arrays['omega_hat_'])
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['beta'] = self.beta
+        hp['omega_hat_scale'] = self.omega_hat_scale
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp

--- a/prosemble/models/dk_relevance_lvq_ng.py
+++ b/prosemble/models/dk_relevance_lvq_ng.py
@@ -1,0 +1,370 @@
+"""
+Differentiating Kernel GRLVQ with Neural Gas cooperation (DKGRLVQ-NG).
+
+Combines DKGRLVQ's per-feature relevance weighting and Gaussian kernel
+distance with Neural Gas neighborhood cooperation.
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\sum_j \\lambda_j (x_j - w_{kj})^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`\\lambda = \\text{softmax}(\\text{relevances})`.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+       Neural Gas with General Similarity Measure. Neural Processing
+       Letters.
+"""
+
+import jax
+import jax.numpy as jnp
+from jax import jit
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel
+from prosemble.core.competitions import wtac
+from prosemble.core.kernel import kernel_distance_squared_relevance
+
+
+@jit
+def _predict_dkgrlvq_ng_jit(X, prototypes, sigmas, relevances,
+                             proto_labels, sigma_min):
+    """JIT-compiled prediction with relevance-weighted kernel distance."""
+    sigmas = jnp.maximum(sigmas, sigma_min)
+    lam = jax.nn.softmax(relevances)
+    distances = kernel_distance_squared_relevance(X, prototypes, sigmas, lam)
+    return wtac(distances, proto_labels)
+
+
+class DKGRLVQ_NG(SupervisedPrototypeModel):
+    """Differentiating Kernel GRLVQ with Neural Gas cooperation.
+
+    Combines relevance-weighted Gaussian kernel distance with per-prototype
+    bandwidth adaptation and Neural Gas rank-weighted loss.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\sum_j \\lambda_j (x_j - w_{kj})^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    where :math:`\\lambda = \\text{softmax}(\\text{relevances})`.
+
+    When :math:`\\gamma \\to 0`, DKGRLVQ-NG recovers standard DKGRLVQ.
+
+    Parameters
+    ----------
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median distance.
+        'mean': per-class mean distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma. Default: 1e-3.
+    beta : float
+        Transfer function steepness. Default: 10.0.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: max prototypes per class / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    sigmas_ : array of shape (n_prototypes,)
+        Learned per-prototype kernel bandwidths.
+    relevances_ : array of shape (n_features,)
+        Learned per-feature relevance weights (raw logits).
+    gamma_ : float
+        Final gamma value after training.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Hammer, B., Strickert, M., & Villmann, T. (2003). Supervised
+           Neural Gas with General Similarity Measure. Neural Processing
+           Letters.
+
+    See Also
+    --------
+    DKGRLVQ : Base variant without NG cooperation.
+    SRNG : NG variant with Euclidean relevance-weighted distance.
+    """
+
+    def __init__(self, sigma_init='median', sigma_min=1e-3, beta=10.0,
+                 gamma_init=None, gamma_final=0.01, gamma_decay=None,
+                 n_prototypes_per_class=1, max_iter=100,
+                 lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.beta = beta
+        self.gamma_init = gamma_init
+        self.gamma_final = gamma_final
+        self.gamma_decay = gamma_decay
+        self.sigmas_ = None
+        self.relevances_ = None
+        self.gamma_ = None
+
+        # Ensure gamma is frozen from optimizer
+        if self.freeze_params is None:
+            self.freeze_params = ['gamma']
+        elif 'gamma' not in self.freeze_params:
+            self.freeze_params = list(self.freeze_params) + ['gamma']
+
+    def _estimate_sigmas(self, X, y, prototypes, proto_labels):
+        """Estimate per-prototype bandwidths from same-class data."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(prototypes.shape[0], float(self.sigma_init))
+
+        sigmas = []
+        for k in range(prototypes.shape[0]):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            X_class = X[class_mask]
+            dists = jnp.sqrt(jnp.sum((X_class - prototypes[k]) ** 2, axis=1))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists)
+            else:  # 'mean'
+                sigma_k = jnp.mean(dists)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        params['sigmas'] = self.sigmas_
+        params['relevances'] = self.relevances_
+        gamma = self.gamma_ if self.gamma_ is not None else (
+            self._gamma_init_actual if hasattr(self, '_gamma_init_actual') else 1.0
+        )
+        params['gamma'] = jnp.array(gamma, dtype=jnp.float32)
+        return params
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        key1, key2 = jax.random.split(key)
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+        sigmas = self._estimate_sigmas(X, y, prototypes, proto_labels)
+
+        # Gamma initialization
+        if isinstance(self.n_prototypes_per_class, int):
+            max_per_class = self.n_prototypes_per_class
+        elif isinstance(self.n_prototypes_per_class, dict):
+            max_per_class = max(self.n_prototypes_per_class.values())
+        else:
+            max_per_class = max(self.n_prototypes_per_class)
+        gamma_init = self.gamma_init if self.gamma_init is not None else max_per_class / 2.0
+        gamma_init = max(gamma_init, self.gamma_final + 1e-6)
+        self._gamma_init_actual = gamma_init
+
+        if self.gamma_decay is not None:
+            self._gamma_decay = self.gamma_decay
+        else:
+            self._gamma_decay = (self.gamma_final / gamma_init) ** (1.0 / self.max_iter)
+
+        relevances = jnp.ones(n_features) / n_features
+        params = {
+            'prototypes': prototypes,
+            'sigmas': sigmas,
+            'relevances': relevances,
+            'gamma': jnp.array(gamma_init, dtype=jnp.float32),
+        }
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        gamma = params['gamma']
+
+        # Relevance-weighted kernel distances: (n, p)
+        lam = jax.nn.softmax(params['relevances'])
+        distances = kernel_distance_squared_relevance(
+            X, prototypes, sigmas, lam
+        )
+
+        # Class-aware ranking
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        from prosemble.core.activations import sigmoid_beta
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        new_gamma = params['gamma'] * self._gamma_decay
+        new_gamma = jnp.maximum(new_gamma, self.gamma_final)
+        return {
+            **params,
+            'sigmas': jnp.maximum(params['sigmas'], self.sigma_min),
+            'gamma': new_gamma,
+        }
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.sigmas_ = params['sigmas']
+        self.relevances_ = params['relevances']  # raw logits
+        self.gamma_ = float(params['gamma'])
+
+    def predict(self, X):
+        """Predict using learned relevance-weighted kernel distance."""
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        return _predict_dkgrlvq_ng_jit(
+            X, self.prototypes_, self.sigmas_, self.relevances_,
+            self.prototype_labels_, self.sigma_min,
+        )
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    @property
+    def relevance_profile(self):
+        """Return the learned relevance weights (normalized via softmax)."""
+        if self.relevances_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return jax.nn.softmax(self.relevances_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.sigmas_ is not None:
+            attrs.append('sigmas_')
+        if self.relevances_ is not None:
+            attrs.append('relevances_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        if self.relevances_ is not None:
+            arrays['relevances_'] = np.asarray(self.relevances_)
+        if self.gamma_ is not None:
+            arrays['gamma_'] = np.asarray(self.gamma_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+        if 'relevances_' in arrays:
+            self.relevances_ = jnp.asarray(arrays['relevances_'])
+        if 'gamma_' in arrays:
+            self.gamma_ = float(arrays['gamma_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['beta'] = self.beta
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        hp['gamma_init'] = self.gamma_init
+        hp['gamma_final'] = self.gamma_final
+        hp['gamma_decay'] = self.gamma_decay
+        return hp

--- a/prosemble/models/oc_dk_glvq.py
+++ b/prosemble/models/oc_dk_glvq.py
@@ -1,0 +1,305 @@
+"""
+One-Class Differentiating Kernel GLVQ (OC-DKGLVQ).
+
+Combines OC-GLVQ's :math:`\\theta`-based hypothesis testing with Gaussian
+kernel distance and per-prototype bandwidth adaptation:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\|x - w_k\\|^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+The :math:`\\mu` function replaces the Euclidean :math:`d^-` with learned
+per-prototype thresholds :math:`\\theta_k`:
+
+.. math::
+
+    \\mu_{k^*}(x_i) = s_i \\cdot \\frac{d_\\kappa(x_i, w_{k^*}) - \\theta_{k^*}}{d_\\kappa(x_i, w_{k^*}) + \\theta_{k^*}}
+
+where :math:`s_i = +1` for target, :math:`-1` for outlier.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IEEE WSOM+ 2022.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.oc_glvq import OCGLVQ
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.kernel import kernel_distance_squared_per_proto
+
+
+class OCDKGLVQ(OCGLVQ):
+    """One-Class Differentiating Kernel GLVQ.
+
+    Combines OC-GLVQ with Gaussian kernel distance and learnable
+    per-prototype bandwidths :math:`\\sigma_k`.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\|x - w_k\\|^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    Kernel distances are bounded in :math:`[0, 2]`, so thresholds
+    :math:`\\theta_k` are initialized in kernel distance scale.
+
+    Parameters
+    ----------
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-prototype median distance from prototype
+        to target class members.
+        'mean': per-prototype mean distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma to prevent bandwidth collapse. Default: 1e-3.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds in kernel distance scale.
+    sigmas_ : array of shape (n_prototypes,)
+        Learned per-prototype kernel bandwidths.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+           Learning Using Local Representations. IEEE WSOM+ 2022.
+
+    See Also
+    --------
+    OCGLVQ : Base class with Euclidean distance.
+    DKGLVQ : Supervised variant with kernel distance.
+    """
+
+    def __init__(self, sigma_init='median', sigma_min=1e-3,
+                 n_prototypes=3, target_label=None, beta=10.0,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+
+    def _estimate_sigmas(self, X_target, prototypes):
+        """Estimate per-prototype bandwidths from target data."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(prototypes.shape[0], float(self.sigma_init))
+
+        sigmas = []
+        for k in range(prototypes.shape[0]):
+            dists = jnp.sqrt(jnp.sum((X_target - prototypes[k]) ** 2, axis=1))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists)
+            else:  # 'mean'
+                sigma_k = jnp.mean(dists)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
+        params['sigmas'] = self.sigmas_
+        return params
+
+    def _init_state(self, X, y, key):
+        # Get base OCGLVQ state (prototypes + Euclidean thetas)
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        # Estimate sigmas from target data
+        target_mask = (y == self._target_label)
+        X_target = X[target_mask]
+        prototypes = params['prototypes']
+        sigmas = self._estimate_sigmas(X_target, prototypes)
+
+        # Re-initialize thetas using kernel distances (NOT Euclidean)
+        # Critical: Gaussian kernel distances are bounded in [0, 2]
+        kernel_dists = kernel_distance_squared_per_proto(
+            X_target, prototypes, sigmas
+        )
+        thetas = jnp.sqrt(jnp.mean(kernel_dists, axis=0) + 1e-10)
+
+        # Update params with sigmas and kernel-scale thetas
+        params['sigmas'] = sigmas
+        params['thetas'] = thetas
+
+        # Re-initialize optimizer with new params
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        thetas = params['thetas']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+
+        # Kernel distances: (n, K), bounded in [0, 2]
+        distances = kernel_distance_squared_per_proto(X, prototypes, sigmas)
+
+        # OC-GLVQ mu with kernel distance
+        n = X.shape[0]
+        nearest_idx = jnp.argmin(distances, axis=1)
+        d_nearest = distances[jnp.arange(n), nearest_idx]
+        theta_nearest = thetas[nearest_idx]
+
+        s = jnp.where(y == self._target_label, 1.0, -1.0)
+        mu = s * (d_nearest - theta_nearest) / (d_nearest + theta_nearest + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        return jnp.mean(transfer(mu + self.margin, self.beta))
+
+    def _post_update(self, params):
+        params = super()._post_update(params)  # thetas >= 1e-6
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.sigmas_ = params['sigmas']
+
+    def decision_function(self, X):
+        """Compute target-likeness scores using kernel distance.
+
+        Scores near 1.0 indicate target class, near 0.0 indicate outlier.
+        The decision boundary is at score = 0.5 (where :math:`d_\\kappa = \\theta`).
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        scores : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        distances = kernel_distance_squared_per_proto(
+            X, self.prototypes_, sigmas
+        )
+        n = X.shape[0]
+        nearest_idx = jnp.argmin(distances, axis=1)
+        d_nearest = distances[jnp.arange(n), nearest_idx]
+        theta_nearest = self.thetas_[nearest_idx]
+
+        mu = (d_nearest - theta_nearest) / (d_nearest + theta_nearest + 1e-10)
+        return 1.0 - jax.nn.sigmoid(self.beta * mu)
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.sigmas_ is not None:
+            attrs.append('sigmas_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/oc_dk_glvq_ng.py
+++ b/prosemble/models/oc_dk_glvq_ng.py
@@ -1,0 +1,137 @@
+"""
+One-Class Differentiating Kernel GLVQ with Neural Gas cooperation (OC-DKGLVQ-NG).
+
+Combines OC-DKGLVQ's Gaussian kernel distance and learnable per-prototype
+bandwidths with Neural Gas neighborhood cooperation. All prototypes
+participate in the loss, weighted by their distance rank.
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\|x - w_k\\|^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IEEE WSOM+ 2022.
+.. [3] Martinetz, T., Berkovich, S., & Schulten, K. (1993).
+       Neural-gas network for the quantization of continuous input
+       spaces. IEEE Transactions on Neural Networks.
+"""
+
+import jax.numpy as jnp
+
+from prosemble.models.oc_glvq_ng_mixin import NGCooperationMixin
+from prosemble.models.oc_dk_glvq import OCDKGLVQ
+from prosemble.core.kernel import kernel_distance_squared_per_proto
+
+
+class OCDKGLVQ_NG(NGCooperationMixin, OCDKGLVQ):
+    """One-Class Differentiating Kernel GLVQ with Neural Gas cooperation.
+
+    Combines OC-DKGLVQ (Gaussian kernel distance with learnable bandwidths)
+    with NG rank-weighted loss where all prototypes participate.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\|x - w_k\\|^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    Parameters
+    ----------
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-prototype median distance from prototype
+        to target class members.
+        'mean': per-prototype mean distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma to prevent bandwidth collapse. Default: 1e-3.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds in kernel distance scale.
+    sigmas_ : array of shape (n_prototypes,)
+        Learned per-prototype kernel bandwidths.
+    gamma_ : float
+        Final gamma value after training.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+           Learning Using Local Representations. IEEE WSOM+ 2022.
+    .. [3] Martinetz, T., Berkovich, S., & Schulten, K. (1993).
+           Neural-gas network for the quantization of continuous input
+           spaces. IEEE Transactions on Neural Networks.
+
+    See Also
+    --------
+    OCDKGLVQ : Base class without NG cooperation.
+    OCGLVQ_NG : NG variant with Euclidean distance.
+    """
+
+    def _compute_distances(self, params, X):
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        return kernel_distance_squared_per_proto(X, params['prototypes'], sigmas)

--- a/prosemble/models/oc_dk_matrix_lvq.py
+++ b/prosemble/models/oc_dk_matrix_lvq.py
@@ -1,0 +1,293 @@
+"""
+One-Class Differentiating Kernel GMLVQ (OC-DKGMLVQ).
+
+Combines OC-GLVQ's :math:`\\theta`-based hypothesis testing with the
+exponential kernel and adaptive matrix
+:math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`:
+
+.. math::
+
+    \\kappa_{\\exp}(x, w, \\hat\\Lambda) = \\exp(x^T \\hat\\Lambda w)
+
+.. math::
+
+    d_\\kappa^2(x, w) = \\exp(x^T \\hat\\Lambda x)
+                      + \\exp(w^T \\hat\\Lambda w)
+                      - 2 \\exp(x^T \\hat\\Lambda w)
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IEEE WSOM+ 2022.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.oc_glvq import OCGLVQ
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.kernel import exponential_kernel_distance_squared
+
+
+class OCDKGMLVQ(OCGLVQ):
+    """One-Class Differentiating Kernel GMLVQ.
+
+    Combines OC-GLVQ with exponential kernel distance and a learnable
+    global transformation matrix :math:`\\hat\\Omega` (d x latent_dim).
+
+    .. math::
+
+        d_\\kappa^2(x, w) = \\exp(x^T \\hat\\Lambda x)
+                          + \\exp(w^T \\hat\\Lambda w)
+                          - 2 \\exp(x^T \\hat\\Lambda w)
+
+    where :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`.
+
+    Note: :math:`\\kappa(v, v) \\neq 1` for the exponential kernel, so
+    distances are not bounded in :math:`[0, 2]`.
+
+    Parameters
+    ----------
+    latent_dim : int, optional
+        Dimensionality of the transformation. If None, uses input dim.
+    omega_hat_scale : float
+        Scale factor for omega_hat initialization. Default: 0.1.
+        Smaller values prevent exp overflow at initialization.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds in kernel distance scale.
+    omega_hat_ : array of shape (n_features, latent_dim)
+        Learned transformation matrix.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+           Learning Using Local Representations. IEEE WSOM+ 2022.
+
+    See Also
+    --------
+    OCGLVQ : Base class with Euclidean distance.
+    DKGMLVQ : Supervised variant with exponential kernel distance.
+    """
+
+    def __init__(self, latent_dim=None, omega_hat_scale=0.1,
+                 n_prototypes=3, target_label=None, beta=10.0,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.latent_dim = latent_dim
+        self.omega_hat_scale = omega_hat_scale
+        self.omega_hat_ = None
+
+    def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
+        params['omega_hat'] = self.omega_hat_
+        return params
+
+    def _init_state(self, X, y, key):
+        # Get base OCGLVQ state (prototypes + Euclidean thetas)
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim or n_features
+        target_mask = (y == self._target_label)
+        X_target = X[target_mask]
+        prototypes = params['prototypes']
+
+        # Initialize omega_hat (scaled identity)
+        omega_hat = self.omega_hat_scale * identity_omega_init(
+            n_features, latent_dim
+        )
+
+        # Re-initialize thetas using exponential kernel distances
+        kernel_dists = exponential_kernel_distance_squared(
+            X_target, prototypes, omega_hat
+        )
+        thetas = jnp.sqrt(jnp.mean(kernel_dists, axis=0) + 1e-10)
+
+        # Update params
+        params['omega_hat'] = omega_hat
+        params['thetas'] = thetas
+
+        # Re-initialize optimizer
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        thetas = params['thetas']
+        omega_hat = params['omega_hat']
+
+        # Exponential kernel distances: (n, K)
+        distances = exponential_kernel_distance_squared(
+            X, prototypes, omega_hat
+        )
+
+        # OC-GLVQ mu with kernel distance
+        n = X.shape[0]
+        nearest_idx = jnp.argmin(distances, axis=1)
+        d_nearest = distances[jnp.arange(n), nearest_idx]
+        theta_nearest = thetas[nearest_idx]
+
+        s = jnp.where(y == self._target_label, 1.0, -1.0)
+        mu = s * (d_nearest - theta_nearest) / (d_nearest + theta_nearest + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        return jnp.mean(transfer(mu + self.margin, self.beta))
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.omega_hat_ = params['omega_hat']
+
+    def decision_function(self, X):
+        """Compute target-likeness scores using exponential kernel distance.
+
+        Scores near 1.0 indicate target class, near 0.0 indicate outlier.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        scores : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+
+        distances = exponential_kernel_distance_squared(
+            X, self.prototypes_, self.omega_hat_
+        )
+        n = X.shape[0]
+        nearest_idx = jnp.argmin(distances, axis=1)
+        d_nearest = distances[jnp.arange(n), nearest_idx]
+        theta_nearest = self.thetas_[nearest_idx]
+
+        mu = (d_nearest - theta_nearest) / (d_nearest + theta_nearest + 1e-10)
+        return 1.0 - jax.nn.sigmoid(self.beta * mu)
+
+    @property
+    def omega_hat_matrix(self):
+        """Return the learned :math:`\\hat\\Omega` matrix."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_
+
+    @property
+    def lambda_hat_matrix(self):
+        """Return :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_ @ self.omega_hat_.T
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omega_hat_ is not None:
+            attrs.append('omega_hat_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_hat_ is not None:
+            arrays['omega_hat_'] = np.asarray(self.omega_hat_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_hat_' in arrays:
+            self.omega_hat_ = jnp.asarray(arrays['omega_hat_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['omega_hat_scale'] = self.omega_hat_scale
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp

--- a/prosemble/models/oc_dk_matrix_lvq_ng.py
+++ b/prosemble/models/oc_dk_matrix_lvq_ng.py
@@ -1,0 +1,134 @@
+"""
+One-Class Differentiating Kernel GMLVQ with Neural Gas cooperation (OC-DKGMLVQ-NG).
+
+Combines OC-DKGMLVQ's exponential kernel distance and adaptive matrix
+:math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T` with Neural Gas
+neighborhood cooperation.
+
+.. math::
+
+    d_\\kappa^2(x, w) = \\exp(x^T \\hat\\Lambda x)
+                      + \\exp(w^T \\hat\\Lambda w)
+                      - 2 \\exp(x^T \\hat\\Lambda w)
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IEEE WSOM+ 2022.
+.. [3] Martinetz, T., Berkovich, S., & Schulten, K. (1993).
+       Neural-gas network for the quantization of continuous input
+       spaces. IEEE Transactions on Neural Networks.
+"""
+
+from prosemble.models.oc_glvq_ng_mixin import NGCooperationMixin
+from prosemble.models.oc_dk_matrix_lvq import OCDKGMLVQ
+from prosemble.core.kernel import exponential_kernel_distance_squared
+
+
+class OCDKGMLVQ_NG(NGCooperationMixin, OCDKGMLVQ):
+    """One-Class Differentiating Kernel GMLVQ with Neural Gas cooperation.
+
+    Combines OC-DKGMLVQ (exponential kernel distance with learnable
+    :math:`\\hat\\Omega` matrix) with NG rank-weighted loss.
+
+    .. math::
+
+        d_\\kappa^2(x, w) = \\exp(x^T \\hat\\Lambda x)
+                          + \\exp(w^T \\hat\\Lambda w)
+                          - 2 \\exp(x^T \\hat\\Lambda w)
+
+    where :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`.
+
+    Parameters
+    ----------
+    latent_dim : int, optional
+        Dimensionality of the transformation. If None, uses input dim.
+    omega_hat_scale : float
+        Scale factor for omega_hat initialization. Default: 0.1.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds in kernel distance scale.
+    omega_hat_ : array of shape (n_features, latent_dim)
+        Learned transformation matrix.
+    gamma_ : float
+        Final gamma value after training.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+           Learning Using Local Representations. IEEE WSOM+ 2022.
+    .. [3] Martinetz, T., Berkovich, S., & Schulten, K. (1993).
+           Neural-gas network for the quantization of continuous input
+           spaces. IEEE Transactions on Neural Networks.
+
+    See Also
+    --------
+    OCDKGMLVQ : Base class without NG cooperation.
+    OCGMLVQ_NG : NG variant with Euclidean distance and Omega projection.
+    """
+
+    def _compute_distances(self, params, X):
+        return exponential_kernel_distance_squared(
+            X, params['prototypes'], params['omega_hat']
+        )

--- a/prosemble/models/oc_dk_relevance_lvq.py
+++ b/prosemble/models/oc_dk_relevance_lvq.py
@@ -1,0 +1,325 @@
+"""
+One-Class Differentiating Kernel GRLVQ (OC-DKGRLVQ).
+
+Combines OC-GLVQ's :math:`\\theta`-based hypothesis testing with
+per-feature relevance weighting and Gaussian kernel distance:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\sum_j \\lambda_j (x_j - w_{kj})^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`\\lambda = \\text{softmax}(\\text{relevances})`.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IEEE WSOM+ 2022.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.oc_glvq import OCGLVQ
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.kernel import kernel_distance_squared_relevance
+
+
+class OCDKGRLVQ(OCGLVQ):
+    """One-Class Differentiating Kernel GRLVQ.
+
+    Combines OC-GLVQ with per-feature relevance weighting and Gaussian
+    kernel distance with per-prototype bandwidth adaptation.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\sum_j \\lambda_j (x_j - w_{kj})^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    where :math:`\\lambda = \\text{softmax}(\\text{relevances})` are
+    learned per-feature weights.
+
+    Parameters
+    ----------
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-prototype median distance from prototype
+        to target class members.
+        'mean': per-prototype mean distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma to prevent bandwidth collapse. Default: 1e-3.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds in kernel distance scale.
+    sigmas_ : array of shape (n_prototypes,)
+        Learned per-prototype kernel bandwidths.
+    relevances_ : array of shape (n_features,)
+        Learned per-feature relevance weights (raw logits).
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+           Learning Using Local Representations. IEEE WSOM+ 2022.
+
+    See Also
+    --------
+    OCGLVQ : Base class with Euclidean distance.
+    DKGRLVQ : Supervised variant with kernel distance and relevances.
+    """
+
+    def __init__(self, sigma_init='median', sigma_min=1e-3,
+                 n_prototypes=3, target_label=None, beta=10.0,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 distance_fn=None, optimizer='adam', transfer_fn=None,
+                 margin=0.0, callbacks=None, use_scan=True,
+                 batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes=n_prototypes, target_label=target_label,
+            beta=beta, max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=distance_fn,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+        self.relevances_ = None
+
+    def _estimate_sigmas(self, X_target, prototypes):
+        """Estimate per-prototype bandwidths from target data."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(prototypes.shape[0], float(self.sigma_init))
+
+        sigmas = []
+        for k in range(prototypes.shape[0]):
+            dists = jnp.sqrt(jnp.sum((X_target - prototypes[k]) ** 2, axis=1))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists)
+            else:  # 'mean'
+                sigma_k = jnp.mean(dists)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        params = super()._get_resume_params(params)
+        params['sigmas'] = self.sigmas_
+        params['relevances'] = self.relevances_
+        return params
+
+    def _init_state(self, X, y, key):
+        # Get base OCGLVQ state (prototypes + Euclidean thetas)
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        n_features = X.shape[1]
+        target_mask = (y == self._target_label)
+        X_target = X[target_mask]
+        prototypes = params['prototypes']
+
+        # Estimate sigmas from target data
+        sigmas = self._estimate_sigmas(X_target, prototypes)
+
+        # Initialize relevances (uniform in logit space)
+        relevances = jnp.ones(n_features) / n_features
+
+        # Re-initialize thetas using relevance-weighted kernel distances
+        lam = jax.nn.softmax(relevances)
+        kernel_dists = kernel_distance_squared_relevance(
+            X_target, prototypes, sigmas, lam
+        )
+        thetas = jnp.sqrt(jnp.mean(kernel_dists, axis=0) + 1e-10)
+
+        # Update params
+        params['sigmas'] = sigmas
+        params['relevances'] = relevances
+        params['thetas'] = thetas
+
+        # Re-initialize optimizer
+        opt_state = self._optimizer.init(params)
+        from prosemble.models.prototype_base import SupervisedState
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        thetas = params['thetas']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        lam = jax.nn.softmax(params['relevances'])
+
+        # Relevance-weighted kernel distances: (n, K), bounded in [0, 2]
+        distances = kernel_distance_squared_relevance(
+            X, prototypes, sigmas, lam
+        )
+
+        # OC-GLVQ mu with kernel distance
+        n = X.shape[0]
+        nearest_idx = jnp.argmin(distances, axis=1)
+        d_nearest = distances[jnp.arange(n), nearest_idx]
+        theta_nearest = thetas[nearest_idx]
+
+        s = jnp.where(y == self._target_label, 1.0, -1.0)
+        mu = s * (d_nearest - theta_nearest) / (d_nearest + theta_nearest + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        return jnp.mean(transfer(mu + self.margin, self.beta))
+
+    def _post_update(self, params):
+        params = super()._post_update(params)  # thetas >= 1e-6
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter,
+                         **kwargs):
+        super()._extract_results(
+            params, proto_labels, loss_history, n_iter, **kwargs
+        )
+        self.sigmas_ = params['sigmas']
+        self.relevances_ = params['relevances']  # raw logits
+
+    def decision_function(self, X):
+        """Compute target-likeness scores using relevance-weighted kernel distance.
+
+        Scores near 1.0 indicate target class, near 0.0 indicate outlier.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        scores : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        lam = jax.nn.softmax(self.relevances_)
+        distances = kernel_distance_squared_relevance(
+            X, self.prototypes_, sigmas, lam
+        )
+        n = X.shape[0]
+        nearest_idx = jnp.argmin(distances, axis=1)
+        d_nearest = distances[jnp.arange(n), nearest_idx]
+        theta_nearest = self.thetas_[nearest_idx]
+
+        mu = (d_nearest - theta_nearest) / (d_nearest + theta_nearest + 1e-10)
+        return 1.0 - jax.nn.sigmoid(self.beta * mu)
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    @property
+    def relevance_profile(self):
+        """Return the learned relevance weights (normalized via softmax)."""
+        if self.relevances_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return jax.nn.softmax(self.relevances_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.sigmas_ is not None:
+            attrs.append('sigmas_')
+        if self.relevances_ is not None:
+            attrs.append('relevances_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        if self.relevances_ is not None:
+            arrays['relevances_'] = np.asarray(self.relevances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+        if 'relevances_' in arrays:
+            self.relevances_ = jnp.asarray(arrays['relevances_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/oc_dk_relevance_lvq_ng.py
+++ b/prosemble/models/oc_dk_relevance_lvq_ng.py
@@ -1,0 +1,146 @@
+"""
+One-Class Differentiating Kernel GRLVQ with Neural Gas cooperation (OC-DKGRLVQ-NG).
+
+Combines OC-DKGRLVQ's per-feature relevance weighting and Gaussian kernel
+distance with Neural Gas neighborhood cooperation.
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\sum_j \\lambda_j (x_j - w_{kj})^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`\\lambda = \\text{softmax}(\\text{relevances})`.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+.. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+       Learning Using Local Representations. IEEE WSOM+ 2022.
+.. [3] Martinetz, T., Berkovich, S., & Schulten, K. (1993).
+       Neural-gas network for the quantization of continuous input
+       spaces. IEEE Transactions on Neural Networks.
+"""
+
+import jax
+import jax.numpy as jnp
+
+from prosemble.models.oc_glvq_ng_mixin import NGCooperationMixin
+from prosemble.models.oc_dk_relevance_lvq import OCDKGRLVQ
+from prosemble.core.kernel import kernel_distance_squared_relevance
+
+
+class OCDKGRLVQ_NG(NGCooperationMixin, OCDKGRLVQ):
+    """One-Class Differentiating Kernel GRLVQ with Neural Gas cooperation.
+
+    Combines OC-DKGRLVQ (per-feature relevance weighting + Gaussian kernel
+    distance) with NG rank-weighted loss.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\sum_j \\lambda_j (x_j - w_{kj})^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    where :math:`\\lambda = \\text{softmax}(\\text{relevances})`.
+
+    Parameters
+    ----------
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-prototype median distance from prototype
+        to target class members.
+        'mean': per-prototype mean distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma to prevent bandwidth collapse. Default: 1e-3.
+    gamma_init : float, optional
+        Initial neighborhood range. Default: n_prototypes / 2.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay for gamma.
+        Default: computed from max_iter so gamma reaches gamma_final.
+    n_prototypes : int
+        Number of prototypes for the target class.
+    target_label : int, optional
+        Target (normal) class label. Default: auto-detect.
+    beta : float
+        Sigmoid steepness. Default: 10.0.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Optimizer name ('adam', 'sgd') or optax GradientTransformation.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping (default: identity).
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True (default), use jax.lax.scan for training.
+    batch_size : int, optional
+        Mini-batch size. If None, use full-batch training.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        If True, restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Weights for each class.
+    gradient_accumulation_steps : int, optional
+        Accumulate gradients over this many steps.
+    ema_decay : float, optional
+        Exponential moving average decay for parameters.
+    freeze_params : list of str, optional
+        Parameter group names to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer wrapper configuration.
+    mixed_precision : str or None, optional
+        Compute dtype for mixed precision training.
+
+    Attributes
+    ----------
+    thetas_ : array of shape (n_prototypes,)
+        Learned per-prototype visibility thresholds in kernel distance scale.
+    sigmas_ : array of shape (n_prototypes,)
+        Learned per-prototype kernel bandwidths.
+    relevances_ : array of shape (n_features,)
+        Learned per-feature relevance weights (raw logits).
+    gamma_ : float
+        Final gamma value after training.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+    .. [2] Staps et al. (2022). Prototype-based One-Class-Classification
+           Learning Using Local Representations. IEEE WSOM+ 2022.
+    .. [3] Martinetz, T., Berkovich, S., & Schulten, K. (1993).
+           Neural-gas network for the quantization of continuous input
+           spaces. IEEE Transactions on Neural Networks.
+
+    See Also
+    --------
+    OCDKGRLVQ : Base class without NG cooperation.
+    OCGRLVQ_NG : NG variant with Euclidean distance and relevances.
+    """
+
+    def _compute_distances(self, params, X):
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        lam = jax.nn.softmax(params['relevances'])
+        return kernel_distance_squared_relevance(
+            X, params['prototypes'], sigmas, lam
+        )

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -330,6 +330,36 @@ Kernel Clustering
    :members: fit, predict, predict_proba
    :undoc-members:
 
+One-Class Differentiating Kernel
+---------------------------------
+
+.. autoclass:: prosemble.models.OCDKGLVQ
+   :members: fit, predict, decision_function, predict_with_reject, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCDKGRLVQ
+   :members: fit, predict, decision_function, predict_with_reject, relevance_profile, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCDKGMLVQ
+   :members: fit, predict, decision_function, predict_with_reject, omega_hat_matrix, lambda_hat_matrix
+   :undoc-members:
+
+One-Class Differentiating Kernel (Neural Gas)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: prosemble.models.OCDKGLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCDKGRLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject, relevance_profile, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.OCDKGMLVQ_NG
+   :members: fit, predict, decision_function, predict_with_reject, omega_hat_matrix, lambda_hat_matrix
+   :undoc-members:
+
 Differentiating Kernel Models
 ------------------------------
 
@@ -345,6 +375,21 @@ Supervised
    :undoc-members:
 
 .. autoclass:: prosemble.models.DKGMLVQ
+   :members: fit, predict, predict_proba, omega_hat_matrix, lambda_hat_matrix
+   :undoc-members:
+
+Supervised (Neural Gas)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: prosemble.models.DKGLVQ_NG
+   :members: fit, predict, predict_proba, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.DKGRLVQ_NG
+   :members: fit, predict, predict_proba, relevance_profile, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.DKGMLVQ_NG
    :members: fit, predict, predict_proba, omega_hat_matrix, lambda_hat_matrix
    :undoc-members:
 

--- a/sphinx-docs/guides/differentiating_kernels.rst
+++ b/sphinx-docs/guides/differentiating_kernels.rst
@@ -160,6 +160,197 @@ semi-definite matrix :math:`\hat\Lambda = \hat\Omega \hat\Omega^T`,
 which can be analyzed for feature correlations learned by the model.
 
 
+One-Class Models
+-----------------
+
+The one-class differentiating kernel models combine OC-GLVQ's
+:math:`\theta`-based hypothesis testing with kernel distances. In standard
+OC-GLVQ, the classifier function is:
+
+.. math::
+
+   \mu_{k^*}(x_i) = s_i \cdot \frac{d(x_i, w_{k^*}) - \theta_{k^*}}{d(x_i, w_{k^*}) + \theta_{k^*}}
+
+where :math:`k^*` is the nearest prototype, :math:`\theta_{k^*}` is a learned
+per-prototype visibility threshold, and :math:`s_i = +1` for target,
+:math:`-1` for outlier. The OC-DK variants replace the Euclidean distance
+:math:`d` with kernel distances.
+
+**Critical design detail:** The :math:`\theta_k` thresholds are initialized
+in *kernel distance scale*, not Euclidean scale. Gaussian kernel distances are
+bounded in :math:`[0, 2]`, so Euclidean-initialized thetas would be far too
+large.
+
+OCDKGLVQ
+^^^^^^^^^
+
+One-class classification with Gaussian kernel distance and per-prototype
+bandwidth adaptation.
+
+.. code-block:: python
+
+   from prosemble.models import OCDKGLVQ
+   import jax
+   import jax.numpy as jnp
+
+   # Generate one-class dataset
+   key = jax.random.PRNGKey(42)
+   k1, k2 = jax.random.split(key)
+   X_target = jax.random.normal(k1, (100, 4)) * 0.5
+   X_outlier = jax.random.normal(k2, (30, 4)) * 0.5 + 3.0
+   X = jnp.concatenate([X_target, X_outlier])
+   y = jnp.concatenate([jnp.zeros(100, dtype=jnp.int32),
+                        jnp.ones(30, dtype=jnp.int32)])
+
+   model = OCDKGLVQ(
+       n_prototypes=3,
+       max_iter=100,
+       lr=0.01,
+       sigma_init='median',
+       sigma_min=1e-3,
+       target_label=0,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   scores = model.decision_function(X)
+   preds = model.predict(X)
+   print(f"Learned bandwidths: {model.kernel_bandwidths}")
+   print(f"Visibility radii: {model.visibility_radii}")
+
+OCDKGRLVQ
+^^^^^^^^^^
+
+One-class classification with relevance-weighted kernel distance,
+per-prototype bandwidth, and per-feature relevance learning.
+
+.. code-block:: python
+
+   from prosemble.models import OCDKGRLVQ
+
+   model = OCDKGRLVQ(
+       n_prototypes=3,
+       max_iter=100,
+       lr=0.01,
+       sigma_init='median',
+       sigma_min=1e-3,
+       target_label=0,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   scores = model.decision_function(X)
+   print(f"Relevance profile: {model.relevance_profile}")
+   print(f"Learned bandwidths: {model.kernel_bandwidths}")
+
+The ``relevance_profile`` property returns the softmax-normalized per-feature
+weights, identifying which features are most important for the one-class
+boundary.
+
+OCDKGMLVQ
+^^^^^^^^^^
+
+One-class classification with exponential kernel distance and a learned
+transformation matrix :math:`\hat\Omega`.
+
+.. code-block:: python
+
+   from prosemble.models import OCDKGMLVQ
+
+   model = OCDKGMLVQ(
+       n_prototypes=3,
+       max_iter=100,
+       lr=0.01,
+       latent_dim=None,
+       omega_hat_scale=0.1,
+       target_label=0,
+       random_seed=42,
+   )
+   model.fit(X, y)
+
+   scores = model.decision_function(X)
+   print(f"Omega hat shape: {model.omega_hat_matrix.shape}")
+   print(f"Lambda hat (PSD): {model.lambda_hat_matrix.shape}")
+
+Supervised Models with Neural Gas
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The supervised DK-NG variants combine differentiating kernel distances with
+Neural Gas class-aware neighborhood cooperation. All **same-class** prototypes
+participate in the loss, weighted by their distance rank:
+
+.. math::
+
+   h_k = \exp\left(-\frac{\text{rank}_k}{\gamma}\right), \quad
+   \text{only for } \text{label}(w_k) = \text{label}(x)
+
+where :math:`\gamma` decays during training from ``gamma_init`` to
+``gamma_final``, and the GLVQ margin is computed per prototype:
+
+.. math::
+
+   \mu_k = \frac{d_\kappa(x, w_k) - d^-}{d_\kappa(x, w_k) + d^-}
+
+with :math:`d^-` being the nearest different-class prototype distance.
+
+.. code-block:: python
+
+   from prosemble.models import DKGLVQ_NG
+
+   model = DKGLVQ_NG(
+       n_prototypes_per_class=3,
+       max_iter=100,
+       lr=0.01,
+       sigma_init='median',
+       gamma_init=1.5,
+       gamma_final=0.01,
+       random_seed=42,
+   )
+   model.fit(X, y)
+   preds = model.predict(X)
+   print(f"Final gamma: {model.gamma_}")
+
+The relevance-weighted variant (``DKGRLVQ_NG``) adds per-feature relevance
+weights, while the matrix variant (``DKGMLVQ_NG``) uses exponential kernel
+distance with learnable :math:`\hat\Omega` transformation.
+
+
+One-Class Models with Neural Gas
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The OC-DK-NG variants extend the one-class kernel models with Neural Gas
+neighborhood cooperation. Instead of only the nearest prototype contributing
+to the loss, **all** prototypes participate weighted by their distance rank:
+
+.. math::
+
+   h_k = \exp\left(-\frac{\text{rank}_k}{\gamma}\right)
+
+where :math:`\gamma` decays during training from ``gamma_init`` to
+``gamma_final``.
+
+.. code-block:: python
+
+   from prosemble.models import OCDKGLVQ_NG
+
+   model = OCDKGLVQ_NG(
+       n_prototypes=3,
+       max_iter=100,
+       lr=0.01,
+       sigma_init='median',
+       gamma_init=1.5,
+       gamma_final=0.01,
+       target_label=0,
+       random_seed=42,
+   )
+   model.fit(X, y)
+   print(f"Final gamma: {model.gamma_}")
+
+The relevance-weighted variant (``OCDKGRLVQ_NG``) and matrix variant
+(``OCDKGMLVQ_NG``) follow the same pattern, combining their respective
+kernel distances with NG cooperation.
+
+
 Unsupervised Models
 -------------------
 
@@ -273,6 +464,42 @@ Choosing a Model
      - Exponential
      - :math:`w_k, \hat\Omega`
      - Full metric adaptation in kernel space
+   * - DKGLVQ_NG
+     - Gaussian
+     - :math:`w_k, \sigma_k, \gamma`
+     - Supervised kernel + NG cooperation
+   * - DKGRLVQ_NG
+     - Gaussian (weighted)
+     - :math:`w_k, \sigma_k, \lambda, \gamma`
+     - Supervised kernel + relevances + NG cooperation
+   * - DKGMLVQ_NG
+     - Exponential
+     - :math:`w_k, \hat\Omega, \gamma`
+     - Supervised kernel matrix + NG cooperation
+   * - OCDKGLVQ
+     - Gaussian
+     - :math:`w_k, \sigma_k, \theta_k`
+     - One-class with kernel bandwidth adaptation
+   * - OCDKGRLVQ
+     - Gaussian (weighted)
+     - :math:`w_k, \sigma_k, \lambda, \theta_k`
+     - One-class with feature selection + kernel
+   * - OCDKGMLVQ
+     - Exponential
+     - :math:`w_k, \hat\Omega, \theta_k`
+     - One-class with full metric adaptation in kernel space
+   * - OCDKGLVQ_NG
+     - Gaussian
+     - :math:`w_k, \sigma_k, \theta_k, \gamma`
+     - One-class kernel + NG cooperation
+   * - OCDKGRLVQ_NG
+     - Gaussian (weighted)
+     - :math:`w_k, \sigma_k, \lambda, \theta_k, \gamma`
+     - One-class kernel + relevances + NG cooperation
+   * - OCDKGMLVQ_NG
+     - Exponential
+     - :math:`w_k, \hat\Omega, \theta_k, \gamma`
+     - One-class kernel matrix + NG cooperation
    * - DKNeuralGas
      - Gaussian (fixed :math:`\sigma`)
      - :math:`w_k`
@@ -285,6 +512,27 @@ Choosing a Model
      - Gaussian (fixed :math:`\sigma`)
      - :math:`w_k`
      - Principled SOM with kernel distance
+
+ONNX Export
+-----------
+
+All 15 differentiating kernel models support ONNX export.  The three kernel
+distance types are implemented as native ONNX subgraphs:
+
+.. code-block:: python
+
+   from prosemble.models import DKGLVQ
+   from prosemble.core.onnx_export import export_onnx
+
+   model = DKGLVQ(n_prototypes_per_class=2, max_iter=100, lr=0.01)
+   model.fit(X_train, y_train)
+
+   # Export to ONNX — kernel distance computed in the graph
+   onnx_model = export_onnx(model, path='dkglvq.onnx')
+
+Per-prototype bandwidths :math:`\sigma_k` are clamped at export time
+(``sigma_min``), and relevance logits are normalized via a Softmax node in
+the ONNX graph.  See the :doc:`onnx` guide for full details.
 
 References
 ----------

--- a/sphinx-docs/guides/onnx.rst
+++ b/sphinx-docs/guides/onnx.rst
@@ -6,7 +6,7 @@ cross-platform deployment.  An exported ONNX model reproduces the ``predict()``
 output of the original model and runs anywhere ONNX Runtime is available —
 no JAX or prosemble dependency needed at inference time.
 
-**73 of 87 models** are supported.
+**85 of 87 models** are supported.
 
 Installation
 ------------
@@ -125,9 +125,30 @@ Supported Models
    * - Supervised NG (tangent)
      - 2
      - STNG, TCELVQ_NG
+   * - Supervised DK (Gaussian kernel)
+     - 2
+     - DKGLVQ, DKGLVQ_NG
+   * - Supervised DK (relevance kernel)
+     - 2
+     - DKGRLVQ, DKGRLVQ_NG
+   * - Supervised DK (exponential kernel)
+     - 2
+     - DKGMLVQ, DKGMLVQ_NG
+   * - One-class DK (Gaussian kernel)
+     - 2
+     - OCDKGLVQ, OCDKGLVQ_NG
+   * - One-class DK (relevance kernel)
+     - 2
+     - OCDKGRLVQ, OCDKGRLVQ_NG
+   * - One-class DK (exponential kernel)
+     - 2
+     - OCDKGMLVQ, OCDKGMLVQ_NG
    * - Unsupervised
      - 4
      - NeuralGas, GrowingNeuralGas, KohonenSOM, HeskesSOM
+   * - Unsupervised DK
+     - 3
+     - DKNeuralGas, DKKohonenSOM, DKHeskesSOM
    * - Fuzzy clustering
      - 8
      - FCM, PCM, FPCM, PFCM, AFCM, HCM, IPCM, IPCM2
@@ -203,6 +224,15 @@ Distance Functions in ONNX
    * - Relevance-weighted
      - Element-wise weighted squared diff
      - GRLVQ, OCGRLVQ, SVQOCC_R
+   * - Gaussian Kernel (per-prototype :math:`\sigma`)
+     - :math:`2(1 - \exp(-\|x-w\|^2 / 2\sigma_k^2))`
+     - DKGLVQ, DKGLVQ_NG, OCDKGLVQ, OCDKGLVQ_NG
+   * - Relevance Kernel
+     - :math:`2(1 - \exp(-\sum_j \lambda_j(x_j - w_j)^2 / 2\sigma_k^2))`
+     - DKGRLVQ, DKGRLVQ_NG, OCDKGRLVQ, OCDKGRLVQ_NG
+   * - Exponential Kernel
+     - :math:`\exp(x^\top\hat\Lambda x) + \exp(w^\top\hat\Lambda w) - 2\exp(x^\top\hat\Lambda w)`
+     - DKGMLVQ, DKGMLVQ_NG, OCDKGMLVQ, OCDKGMLVQ_NG
    * - SO(n) Chordal
      - Broadcast subtract + Frobenius norm
      - RiemannianSRNG
@@ -225,7 +255,7 @@ Not Supported
      - Reason
    * - Kernel fuzzy clustering (KFCM, KPCM, KFPCM, KPFCM, KAFCM, KIPCM, KIPCM2)
      - 7
-     - Gaussian kernel distance has no standard ONNX operator
+     - Kernel fuzzy membership requires iterative kernel-distance update incompatible with ONNX
    * - RiemannianNeuralGas
      - 1
      - Matrix logarithm via Schur decomposition has no ONNX operator

--- a/tests/test_dk_ng_models.py
+++ b/tests/test_dk_ng_models.py
@@ -1,0 +1,377 @@
+"""Tests for supervised Differentiating Kernel models with Neural Gas cooperation."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+import numpy as np
+from sklearn.datasets import load_iris
+
+from prosemble.models import DKGLVQ_NG, DKGRLVQ_NG, DKGMLVQ_NG
+
+
+@pytest.fixture
+def separable_2d():
+    """Simple 2D separable dataset (2 classes, 4 per class)."""
+    key = jax.random.PRNGKey(42)
+    k1, k2 = jax.random.split(key)
+    X0 = jax.random.normal(k1, (8, 2)) * 0.3 - 1.5
+    X1 = jax.random.normal(k2, (8, 2)) * 0.3 + 1.5
+    X = jnp.concatenate([X0, X1])
+    y = jnp.concatenate([jnp.zeros(8, dtype=jnp.int32),
+                         jnp.ones(8, dtype=jnp.int32)])
+    return X, y
+
+
+@pytest.fixture
+def iris_data():
+    """Iris dataset (3 classes, 4 features)."""
+    iris = load_iris()
+    X = jnp.asarray(iris.data, dtype=jnp.float32)
+    y = jnp.asarray(iris.target, dtype=jnp.int32)
+    return X, y
+
+
+@pytest.fixture
+def separable_4d():
+    """4D dataset with 2 relevant + 2 noise features."""
+    key = jax.random.PRNGKey(123)
+    k1, k2, k3, k4 = jax.random.split(key, 4)
+    X0_rel = jax.random.normal(k1, (15, 2)) * 0.3 - 1.5
+    X1_rel = jax.random.normal(k2, (15, 2)) * 0.3 + 1.5
+    X0_noise = jax.random.normal(k3, (15, 2)) * 2.0
+    X1_noise = jax.random.normal(k4, (15, 2)) * 2.0
+    X0 = jnp.concatenate([X0_rel, X0_noise], axis=1)
+    X1 = jnp.concatenate([X1_rel, X1_noise], axis=1)
+    X = jnp.concatenate([X0, X1])
+    y = jnp.concatenate([jnp.zeros(15, dtype=jnp.int32),
+                         jnp.ones(15, dtype=jnp.int32)])
+    return X, y
+
+
+# ============================================================================
+# DKGLVQ_NG Tests
+# ============================================================================
+
+class TestDKGLVQ_NG:
+
+    def test_fit_predict(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                          use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (16,)
+        acc = float(jnp.mean(preds == y))
+        assert acc >= 0.75
+
+    def test_loss_decreases(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=100, lr=0.01,
+                          use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) < float(history[0])
+
+    def test_iris_accuracy(self, iris_data):
+        X, y = iris_data
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=100, lr=0.01)
+        model.fit(X, y)
+        preds = model.predict(X)
+        acc = float(jnp.mean(preds == y))
+        assert acc >= 0.80
+
+    def test_gamma_decays(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        assert model.gamma_ is not None
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_gamma_bounded(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                          gamma_init=5.0, gamma_final=0.5)
+        model.fit(X, y)
+        assert model.gamma_ >= 0.5
+        assert model.gamma_ < 5.0
+
+    def test_sigmas_learned(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                          use_scan=False)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+        assert model.sigmas_.shape == (4,)  # 2 classes x 2 prototypes
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_sigma_init_fixed(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=30, lr=0.01,
+                          sigma_init=1.0)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+
+    def test_kernel_bandwidths_property(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=20, lr=0.01)
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (4,)
+        assert jnp.all(bw >= model.sigma_min)
+
+    def test_python_loop(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=30, lr=0.01,
+                          use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (16,)
+
+    def test_scan_mode(self, separable_2d):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                          use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (16,)
+
+    def test_save_load_roundtrip(self, separable_2d, tmp_path):
+        X, y = separable_2d
+        model = DKGLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        path = str(tmp_path / "dkglvq_ng.npz")
+        model.save(path)
+        loaded = DKGLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+        assert loaded.gamma_ == pytest.approx(model.gamma_, rel=1e-4)
+        np.testing.assert_allclose(
+            np.asarray(model.sigmas_), np.asarray(loaded.sigmas_), rtol=1e-4
+        )
+
+
+# ============================================================================
+# DKGRLVQ_NG Tests
+# ============================================================================
+
+class TestDKGRLVQ_NG:
+
+    def test_fit_predict(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (30,)
+        acc = float(jnp.mean(preds == y))
+        assert acc >= 0.70
+
+    def test_loss_decreases(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=100, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) < float(history[0])
+
+    def test_iris_accuracy(self, iris_data):
+        X, y = iris_data
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=100, lr=0.01)
+        model.fit(X, y)
+        preds = model.predict(X)
+        acc = float(jnp.mean(preds == y))
+        assert acc >= 0.80
+
+    def test_gamma_decays(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        assert model.gamma_ is not None
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_gamma_bounded(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           gamma_init=5.0, gamma_final=0.5)
+        model.fit(X, y)
+        assert model.gamma_ >= 0.5
+        assert model.gamma_ < 5.0
+
+    def test_sigmas_learned(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_sigma_init_fixed(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=30, lr=0.01,
+                           sigma_init=1.0)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+
+    def test_relevances_learned(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        assert model.relevances_ is not None
+        assert model.relevances_.shape == (4,)
+
+    def test_relevance_profile_property(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        profile = model.relevance_profile
+        assert profile.shape == (4,)
+        assert abs(float(jnp.sum(profile)) - 1.0) < 1e-5
+        assert jnp.all(profile > 0)
+
+    def test_kernel_bandwidths_property(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=20, lr=0.01)
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (4,)
+        assert jnp.all(bw >= model.sigma_min)
+
+    def test_scan_mode(self, separable_4d):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (30,)
+
+    def test_save_load_roundtrip(self, separable_4d, tmp_path):
+        X, y = separable_4d
+        model = DKGRLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        path = str(tmp_path / "dkgrlvq_ng.npz")
+        model.save(path)
+        loaded = DKGRLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+        assert loaded.gamma_ == pytest.approx(model.gamma_, rel=1e-4)
+        np.testing.assert_allclose(
+            np.asarray(model.relevances_), np.asarray(loaded.relevances_),
+            rtol=1e-4
+        )
+
+
+# ============================================================================
+# DKGMLVQ_NG Tests
+# ============================================================================
+
+class TestDKGMLVQ_NG:
+
+    def test_fit_predict(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (16,)
+        acc = float(jnp.mean(preds == y))
+        assert acc >= 0.75
+
+    def test_loss_decreases(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=100, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) < float(history[0])
+
+    def test_iris_accuracy(self, iris_data):
+        X, y = iris_data
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=100, lr=0.01)
+        model.fit(X, y)
+        preds = model.predict(X)
+        acc = float(jnp.mean(preds == y))
+        assert acc >= 0.80
+
+    def test_gamma_decays(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        assert model.gamma_ is not None
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_gamma_bounded(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           gamma_init=5.0, gamma_final=0.5)
+        model.fit(X, y)
+        assert model.gamma_ >= 0.5
+        assert model.gamma_ < 5.0
+
+    def test_omega_hat_learned(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=False)
+        model.fit(X, y)
+        assert model.omega_hat_ is not None
+        assert model.omega_hat_.shape == (2, 2)
+
+    def test_omega_hat_matrix_property(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=20, lr=0.01)
+        model.fit(X, y)
+        omega = model.omega_hat_matrix
+        assert omega.shape == (2, 2)
+
+    def test_lambda_hat_matrix_psd(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=20, lr=0.01)
+        model.fit(X, y)
+        lam = model.lambda_hat_matrix
+        assert lam.shape == (2, 2)
+        eigenvalues = jnp.linalg.eigvalsh(lam)
+        assert jnp.all(eigenvalues >= -1e-6)
+
+    def test_latent_dim(self, iris_data):
+        X, y = iris_data
+        model = DKGMLVQ_NG(n_prototypes_per_class=1, max_iter=20, lr=0.01,
+                           latent_dim=2)
+        model.fit(X, y)
+        assert model.omega_hat_.shape == (4, 2)
+        assert model.lambda_hat_matrix.shape == (4, 4)
+
+    def test_numerical_stability(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=20, lr=0.01,
+                           omega_hat_scale=0.01)
+        model.fit(X, y)
+        assert jnp.all(jnp.isfinite(model.prototypes_))
+        assert jnp.all(jnp.isfinite(model.omega_hat_))
+
+    def test_scan_mode(self, separable_2d):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01,
+                           use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (16,)
+
+    def test_save_load_roundtrip(self, separable_2d, tmp_path):
+        X, y = separable_2d
+        model = DKGMLVQ_NG(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        path = str(tmp_path / "dkgmlvq_ng.npz")
+        model.save(path)
+        loaded = DKGMLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+        assert loaded.gamma_ == pytest.approx(model.gamma_, rel=1e-4)
+        np.testing.assert_allclose(
+            np.asarray(model.omega_hat_), np.asarray(loaded.omega_hat_),
+            rtol=1e-4
+        )

--- a/tests/test_oc_dk_models.py
+++ b/tests/test_oc_dk_models.py
@@ -1,0 +1,498 @@
+"""Tests for One-Class Differentiating Kernel models."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models import OCDKGLVQ, OCDKGRLVQ, OCDKGMLVQ
+
+
+@pytest.fixture
+def occ_2d():
+    """Simple 2D one-class dataset."""
+    key = jax.random.PRNGKey(42)
+    k1, k2 = jax.random.split(key)
+    X_target = jax.random.normal(k1, (40, 2)) * 0.3
+    X_outlier = jax.random.normal(k2, (20, 2)) * 0.3 + 3.0
+    X = jnp.concatenate([X_target, X_outlier])
+    y = jnp.concatenate([jnp.zeros(40, dtype=jnp.int32),
+                         jnp.ones(20, dtype=jnp.int32)])
+    return X, y
+
+
+@pytest.fixture
+def occ_4d():
+    """4D dataset with 2 relevant + 2 noise features."""
+    key = jax.random.PRNGKey(123)
+    k1, k2, k3, k4 = jax.random.split(key, 4)
+    # Relevant features: well-separated
+    X_target_rel = jax.random.normal(k1, (50, 2)) * 0.3
+    X_outlier_rel = jax.random.normal(k2, (30, 2)) * 0.3 + 3.0
+    # Noise features: overlapping
+    X_target_noise = jax.random.normal(k3, (50, 2)) * 2.0
+    X_outlier_noise = jax.random.normal(k4, (30, 2)) * 2.0
+    X_target = jnp.concatenate([X_target_rel, X_target_noise], axis=1)
+    X_outlier = jnp.concatenate([X_outlier_rel, X_outlier_noise], axis=1)
+    X = jnp.concatenate([X_target, X_outlier])
+    y = jnp.concatenate([jnp.zeros(50, dtype=jnp.int32),
+                         jnp.ones(30, dtype=jnp.int32)])
+    return X, y
+
+
+# ============================================================================
+# OCDKGLVQ Tests
+# ============================================================================
+
+class TestOCDKGLVQ:
+
+    def test_fit_predict(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                         target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        target_acc = float(jnp.mean(preds[:40] == 0))
+        assert target_acc >= 0.70
+
+    def test_loss_decreases(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=100, lr=0.01,
+                         target_label=0, use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) < float(history[0])
+
+    def test_thetas_positive(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=30, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_thetas_shape(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=4, max_iter=20, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        assert model.thetas_.shape == (4,)
+
+    def test_thetas_kernel_scale(self, occ_2d):
+        """Thetas should be in kernel distance scale [0, sqrt(2)]."""
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        # Gaussian kernel distances are bounded in [0, 2]
+        # So thetas (sqrt of mean) should be <= sqrt(2) ~ 1.414
+        assert jnp.all(model.thetas_ <= 2.0)
+
+    def test_sigmas_learned(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                         target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+        assert model.sigmas_.shape == (3,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_sigma_init_fixed(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                         target_label=0, sigma_init=2.0)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+
+    def test_sigma_init_mean(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                         target_label=0, sigma_init='mean')
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+
+    def test_decision_function_range(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (60,)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_target_higher_scores(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=100, lr=0.01,
+                         target_label=0, use_scan=False)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:40]))
+        mean_outlier = float(jnp.mean(scores[40:]))
+        assert mean_target > mean_outlier
+
+    def test_predict_with_reject(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (60,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_kernel_bandwidths_property(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (3,)
+        assert jnp.all(bw >= model.sigma_min)
+
+    def test_python_loop(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                         target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+
+    def test_scan_mode(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                         target_label=0, use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+
+    def test_visibility_radii(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        radii = model.visibility_radii
+        assert radii.shape == (3,)
+        assert jnp.all(radii > 0)
+
+    def test_predict_proba(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                         target_label=0)
+        model.fit(X, y)
+        proba = model.predict_proba(X)
+        assert proba.shape == (60,)
+        assert jnp.all(proba >= 0.0) and jnp.all(proba <= 1.0)
+
+    def test_gradient_flow(self, occ_2d):
+        """Verify gradients flow through kernel distance."""
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=5, lr=0.01,
+                         target_label=0, use_scan=False)
+        model.fit(X, y)
+        # If gradients flow, loss should change from initial
+        assert model.loss_history_ is not None
+        assert len(model.loss_history_) > 1
+
+    def test_hyperparams(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ(n_prototypes=3, max_iter=10, lr=0.01,
+                         target_label=0, sigma_init='median', sigma_min=1e-3)
+        model.fit(X, y)
+        hp = model._get_hyperparams()
+        assert hp['sigma_init'] == 'median'
+        assert hp['sigma_min'] == 1e-3
+        assert hp['n_prototypes'] == 3
+
+
+# ============================================================================
+# OCDKGRLVQ Tests
+# ============================================================================
+
+class TestOCDKGRLVQ:
+
+    def test_fit_predict(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        target_acc = float(jnp.mean(preds[:50] == 0))
+        assert target_acc >= 0.60
+
+    def test_loss_decreases(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=100, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) < float(history[0])
+
+    def test_thetas_positive(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=30, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_thetas_shape(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=4, max_iter=20, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        assert model.thetas_.shape == (4,)
+
+    def test_sigmas_learned(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+        assert model.sigmas_.shape == (3,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_relevances_learned(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.relevances_ is not None
+        assert model.relevances_.shape == (4,)
+
+    def test_relevance_profile_property(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        profile = model.relevance_profile
+        assert profile.shape == (4,)
+        # Softmax output sums to 1
+        assert abs(float(jnp.sum(profile)) - 1.0) < 1e-5
+        # All weights positive
+        assert jnp.all(profile > 0)
+
+    def test_decision_function_range(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (80,)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_target_higher_scores(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=100, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:50]))
+        mean_outlier = float(jnp.mean(scores[50:]))
+        assert mean_target > mean_outlier
+
+    def test_predict_with_reject(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (80,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_kernel_bandwidths_property(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (3,)
+        assert jnp.all(bw >= model.sigma_min)
+
+    def test_sigma_init_fixed(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                          target_label=0, sigma_init=1.5)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+
+    def test_python_loop(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (80,)
+
+    def test_scan_mode(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (80,)
+
+    def test_gradient_flow(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=5, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.loss_history_ is not None
+        assert len(model.loss_history_) > 1
+
+    def test_hyperparams(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ(n_prototypes=3, max_iter=10, lr=0.01,
+                          target_label=0, sigma_init='median', sigma_min=1e-3)
+        model.fit(X, y)
+        hp = model._get_hyperparams()
+        assert hp['sigma_init'] == 'median'
+        assert hp['sigma_min'] == 1e-3
+
+
+# ============================================================================
+# OCDKGMLVQ Tests
+# ============================================================================
+
+class TestOCDKGMLVQ:
+
+    def test_fit_predict(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        target_acc = float(jnp.mean(preds[:40] == 0))
+        assert target_acc >= 0.60
+
+    def test_loss_decreases(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=100, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) < float(history[0])
+
+    def test_thetas_positive(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=30, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_thetas_shape(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=4, max_iter=20, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        assert model.thetas_.shape == (4,)
+
+    def test_omega_hat_learned(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.omega_hat_ is not None
+        assert model.omega_hat_.shape == (2, 2)
+
+    def test_omega_hat_matrix_property(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        omega = model.omega_hat_matrix
+        assert omega.shape == (2, 2)
+
+    def test_lambda_hat_matrix(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        lam = model.lambda_hat_matrix
+        assert lam.shape == (2, 2)
+        # Lambda should be PSD (Omega^T Omega)
+        eigenvalues = jnp.linalg.eigvalsh(lam)
+        assert jnp.all(eigenvalues >= -1e-6)
+
+    def test_latent_dim(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                          target_label=0, latent_dim=2)
+        model.fit(X, y)
+        assert model.omega_hat_.shape == (4, 2)
+        assert model.lambda_hat_matrix.shape == (4, 4)
+
+    def test_decision_function_range(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (60,)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_target_higher_scores(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=100, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:40]))
+        mean_outlier = float(jnp.mean(scores[40:]))
+        assert mean_target > mean_outlier
+
+    def test_predict_with_reject(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0)
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (60,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_python_loop(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+
+    def test_scan_mode(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=50, lr=0.01,
+                          target_label=0, use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+
+    def test_numerical_stability(self, occ_2d):
+        """Small omega_hat_scale should prevent overflow."""
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=20, lr=0.01,
+                          target_label=0, omega_hat_scale=0.01)
+        model.fit(X, y)
+        assert jnp.all(jnp.isfinite(model.prototypes_))
+        assert jnp.all(jnp.isfinite(model.omega_hat_))
+        assert jnp.all(jnp.isfinite(model.thetas_))
+
+    def test_gradient_flow(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=5, lr=0.01,
+                          target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.loss_history_ is not None
+        assert len(model.loss_history_) > 1
+
+    def test_hyperparams(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ(n_prototypes=3, max_iter=10, lr=0.01,
+                          target_label=0, omega_hat_scale=0.1,
+                          latent_dim=2)
+        model.fit(X, y)
+        hp = model._get_hyperparams()
+        assert hp['omega_hat_scale'] == 0.1
+        assert hp['latent_dim'] == 2
+        assert hp['n_prototypes'] == 3

--- a/tests/test_oc_dk_ng_models.py
+++ b/tests/test_oc_dk_ng_models.py
@@ -1,0 +1,409 @@
+"""Tests for One-Class Differentiating Kernel models with Neural Gas cooperation."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models import OCDKGLVQ_NG, OCDKGRLVQ_NG, OCDKGMLVQ_NG
+
+
+@pytest.fixture
+def occ_2d():
+    """Simple 2D one-class dataset."""
+    key = jax.random.PRNGKey(42)
+    k1, k2 = jax.random.split(key)
+    X_target = jax.random.normal(k1, (40, 2)) * 0.3
+    X_outlier = jax.random.normal(k2, (20, 2)) * 0.3 + 3.0
+    X = jnp.concatenate([X_target, X_outlier])
+    y = jnp.concatenate([jnp.zeros(40, dtype=jnp.int32),
+                         jnp.ones(20, dtype=jnp.int32)])
+    return X, y
+
+
+@pytest.fixture
+def occ_4d():
+    """4D dataset with 2 relevant + 2 noise features."""
+    key = jax.random.PRNGKey(123)
+    k1, k2, k3, k4 = jax.random.split(key, 4)
+    X_target_rel = jax.random.normal(k1, (50, 2)) * 0.3
+    X_outlier_rel = jax.random.normal(k2, (30, 2)) * 0.3 + 3.0
+    X_target_noise = jax.random.normal(k3, (50, 2)) * 2.0
+    X_outlier_noise = jax.random.normal(k4, (30, 2)) * 2.0
+    X_target = jnp.concatenate([X_target_rel, X_target_noise], axis=1)
+    X_outlier = jnp.concatenate([X_outlier_rel, X_outlier_noise], axis=1)
+    X = jnp.concatenate([X_target, X_outlier])
+    y = jnp.concatenate([jnp.zeros(50, dtype=jnp.int32),
+                         jnp.ones(30, dtype=jnp.int32)])
+    return X, y
+
+
+# ============================================================================
+# OCDKGLVQ_NG Tests
+# ============================================================================
+
+class TestOCDKGLVQ_NG:
+
+    def test_fit_predict(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+        target_acc = float(jnp.mean(preds[:40] == 0))
+        assert target_acc >= 0.60
+
+    def test_loss_decreases(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=100, lr=0.01,
+                            target_label=0, use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) != float(history[0])
+
+    def test_gamma_decay(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0)
+        model.fit(X, y)
+        assert model.gamma_ is not None
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_gamma_bounded(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0, gamma_init=5.0, gamma_final=0.5)
+        model.fit(X, y)
+        assert model.gamma_ >= 0.5
+        assert model.gamma_ < 5.0
+
+    def test_thetas_positive(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=30, lr=0.01,
+                            target_label=0)
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_sigmas_learned(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+        assert model.sigmas_.shape == (3,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_decision_function_range(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (60,)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_target_higher_scores(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=100, lr=0.01,
+                            target_label=0, use_scan=False)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:40]))
+        mean_outlier = float(jnp.mean(scores[40:]))
+        assert mean_target > mean_outlier
+
+    def test_predict_with_reject(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0)
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (60,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_kernel_bandwidths_property(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=20, lr=0.01,
+                            target_label=0)
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (3,)
+        assert jnp.all(bw >= model.sigma_min)
+
+    def test_scan_mode(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0, use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+
+    def test_save_load_roundtrip(self, occ_2d, tmp_path):
+        X, y = occ_2d
+        model = OCDKGLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                            target_label=0)
+        model.fit(X, y)
+        path = str(tmp_path / "ocdkglvq_ng.npz")
+        model.save(path)
+        loaded = OCDKGLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+        assert loaded.gamma_ == pytest.approx(model.gamma_, rel=1e-4)
+
+
+# ============================================================================
+# OCDKGRLVQ_NG Tests
+# ============================================================================
+
+class TestOCDKGRLVQ_NG:
+
+    def test_fit_predict(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (80,)
+        target_acc = float(jnp.mean(preds[:50] == 0))
+        assert target_acc >= 0.50
+
+    def test_loss_decreases(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=100, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) != float(history[0])
+
+    def test_gamma_decay(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        assert model.gamma_ is not None
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_sigmas_learned(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+        assert model.sigmas_.shape == (3,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_relevances_learned(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.relevances_ is not None
+        assert model.relevances_.shape == (4,)
+
+    def test_relevance_profile_property(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        profile = model.relevance_profile
+        assert profile.shape == (4,)
+        assert abs(float(jnp.sum(profile)) - 1.0) < 1e-5
+        assert jnp.all(profile > 0)
+
+    def test_decision_function_range(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (80,)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_target_higher_scores(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=100, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:50]))
+        mean_outlier = float(jnp.mean(scores[50:]))
+        assert mean_target > mean_outlier
+
+    def test_predict_with_reject(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (80,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_kernel_bandwidths_property(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=20, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (3,)
+        assert jnp.all(bw >= model.sigma_min)
+
+    def test_scan_mode(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (80,)
+
+    def test_save_load_roundtrip(self, occ_4d, tmp_path):
+        X, y = occ_4d
+        model = OCDKGRLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        path = str(tmp_path / "ocdkgrlvq_ng.npz")
+        model.save(path)
+        loaded = OCDKGRLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+        assert loaded.gamma_ == pytest.approx(model.gamma_, rel=1e-4)
+
+
+# ============================================================================
+# OCDKGMLVQ_NG Tests
+# ============================================================================
+
+class TestOCDKGMLVQ_NG:
+
+    def test_fit_predict(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+        target_acc = float(jnp.mean(preds[:40] == 0))
+        assert target_acc >= 0.50
+
+    def test_loss_decreases(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=100, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        history = model.loss_history_
+        assert float(history[-1]) != float(history[0])
+
+    def test_gamma_decay(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        assert model.gamma_ is not None
+        assert model.gamma_ < model._gamma_init_actual
+
+    def test_thetas_positive(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=30, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        assert jnp.all(model.thetas_ > 0)
+
+    def test_omega_hat_learned(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        assert model.omega_hat_ is not None
+        assert model.omega_hat_.shape == (2, 2)
+
+    def test_omega_hat_matrix_property(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=20, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        omega = model.omega_hat_matrix
+        assert omega.shape == (2, 2)
+
+    def test_lambda_hat_matrix(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=20, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        lam = model.lambda_hat_matrix
+        assert lam.shape == (2, 2)
+        eigenvalues = jnp.linalg.eigvalsh(lam)
+        assert jnp.all(eigenvalues >= -1e-6)
+
+    def test_latent_dim(self, occ_4d):
+        X, y = occ_4d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=20, lr=0.01,
+                             target_label=0, latent_dim=2)
+        model.fit(X, y)
+        assert model.omega_hat_.shape == (4, 2)
+        assert model.lambda_hat_matrix.shape == (4, 4)
+
+    def test_decision_function_range(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        assert scores.shape == (60,)
+        assert jnp.all(scores >= 0.0) and jnp.all(scores <= 1.0)
+
+    def test_target_higher_scores(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=100, lr=0.01,
+                             target_label=0, use_scan=False)
+        model.fit(X, y)
+        scores = model.decision_function(X)
+        mean_target = float(jnp.mean(scores[:40]))
+        mean_outlier = float(jnp.mean(scores[40:]))
+        assert mean_target > mean_outlier
+
+    def test_predict_with_reject(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        preds = model.predict_with_reject(X, upper=0.7, lower=0.3)
+        assert preds.shape == (60,)
+        possible = {0, 1, -1}
+        actual = set(int(p) for p in preds)
+        assert actual.issubset(possible)
+
+    def test_scan_mode(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0, use_scan=True)
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == (60,)
+
+    def test_numerical_stability(self, occ_2d):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=20, lr=0.01,
+                             target_label=0, omega_hat_scale=0.01)
+        model.fit(X, y)
+        assert jnp.all(jnp.isfinite(model.prototypes_))
+        assert jnp.all(jnp.isfinite(model.omega_hat_))
+        assert jnp.all(jnp.isfinite(model.thetas_))
+
+    def test_save_load_roundtrip(self, occ_2d, tmp_path):
+        X, y = occ_2d
+        model = OCDKGMLVQ_NG(n_prototypes=3, max_iter=50, lr=0.01,
+                             target_label=0)
+        model.fit(X, y)
+        path = str(tmp_path / "ocdkgmlvq_ng.npz")
+        model.save(path)
+        loaded = OCDKGMLVQ_NG.load(path)
+        np.testing.assert_allclose(
+            model.predict(X), loaded.predict(X)
+        )
+        assert loaded.gamma_ == pytest.approx(model.gamma_, rel=1e-4)

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -1328,3 +1328,403 @@ class TestRiemannianONNXRejections:
         model.fit(X)
         with pytest.raises(NotImplementedError, match="RiemannianNeuralGas"):
             model.export_onnx()
+
+
+# ---------------------------------------------------------------------------
+# Differentiating Kernel models — supervised
+# ---------------------------------------------------------------------------
+
+class TestDKGLVQExport:
+    """DKGLVQ: kernel_per_proto + supervised WTAC."""
+
+    @pytest.fixture
+    def fitted_dkglvq(self):
+        from prosemble.models import DKGLVQ
+        X, y = _make_supervised_data(30, 4)
+        model = DKGLVQ(
+            n_prototypes_per_class=1, max_iter=5, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_dkglvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_dkglvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'kernel_per_proto'
+
+    def test_export_returns_model_proto(self, fitted_dkglvq):
+        model, X = fitted_dkglvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_dkglvq):
+        model, X = fitted_dkglvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestDKGRLVQExport:
+    """DKGRLVQ: kernel_relevance + supervised WTAC."""
+
+    @pytest.fixture
+    def fitted_dkgrlvq(self):
+        from prosemble.models import DKGRLVQ
+        X, y = _make_supervised_data(30, 4)
+        model = DKGRLVQ(
+            n_prototypes_per_class=1, max_iter=5, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_dkgrlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_dkgrlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'kernel_relevance'
+
+    def test_export_returns_model_proto(self, fitted_dkgrlvq):
+        model, X = fitted_dkgrlvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_dkgrlvq):
+        model, X = fitted_dkgrlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestDKGMLVQExport:
+    """DKGMLVQ: kernel_exponential + supervised WTAC."""
+
+    @pytest.fixture
+    def fitted_dkgmlvq(self):
+        from prosemble.models import DKGMLVQ
+        X, y = _make_supervised_data(30, 4)
+        model = DKGMLVQ(
+            n_prototypes_per_class=1, max_iter=5, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_dkgmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_dkgmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'kernel_exponential'
+
+    def test_export_returns_model_proto(self, fitted_dkgmlvq):
+        model, X = fitted_dkgmlvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_dkgmlvq):
+        model, X = fitted_dkgmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# Differentiating Kernel models — supervised NG variants
+# ---------------------------------------------------------------------------
+
+class TestDKGLVQNGExport:
+    """DKGLVQ_NG: kernel_per_proto + supervised WTAC (NG at train only)."""
+
+    @pytest.fixture
+    def fitted_dkglvq_ng(self):
+        from prosemble.models import DKGLVQ_NG
+        X, y = _make_supervised_data(30, 4)
+        model = DKGLVQ_NG(
+            n_prototypes_per_class=1, max_iter=5, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_dkglvq_ng):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_dkglvq_ng
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'kernel_per_proto'
+
+    def test_export_returns_model_proto(self, fitted_dkglvq_ng):
+        model, X = fitted_dkglvq_ng
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_dkglvq_ng):
+        model, X = fitted_dkglvq_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestDKGRLVQNGExport:
+    """DKGRLVQ_NG: kernel_relevance + supervised WTAC (NG at train only)."""
+
+    @pytest.fixture
+    def fitted_dkgrlvq_ng(self):
+        from prosemble.models import DKGRLVQ_NG
+        X, y = _make_supervised_data(30, 4)
+        model = DKGRLVQ_NG(
+            n_prototypes_per_class=1, max_iter=5, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_dkgrlvq_ng):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_dkgrlvq_ng
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'kernel_relevance'
+
+    def test_export_returns_model_proto(self, fitted_dkgrlvq_ng):
+        model, X = fitted_dkgrlvq_ng
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_dkgrlvq_ng):
+        model, X = fitted_dkgrlvq_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestDKGMLVQNGExport:
+    """DKGMLVQ_NG: kernel_exponential + supervised WTAC (NG at train only)."""
+
+    @pytest.fixture
+    def fitted_dkgmlvq_ng(self):
+        from prosemble.models import DKGMLVQ_NG
+        X, y = _make_supervised_data(30, 4)
+        model = DKGMLVQ_NG(
+            n_prototypes_per_class=1, max_iter=5, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_dkgmlvq_ng):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_dkgmlvq_ng
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'supervised'
+        assert dist_type == 'kernel_exponential'
+
+    def test_export_returns_model_proto(self, fitted_dkgmlvq_ng):
+        model, X = fitted_dkgmlvq_ng
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_dkgmlvq_ng):
+        model, X = fitted_dkgmlvq_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X, batch_size=30)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# One-Class Differentiating Kernel models
+# ---------------------------------------------------------------------------
+
+class TestOCDKGLVQExport:
+    """OCDKGLVQ: kernel_per_proto + OC hard nearest."""
+
+    @pytest.fixture
+    def fitted_ocdkglvq(self):
+        from prosemble.models import OCDKGLVQ
+        X, y = _make_oc_data()
+        model = OCDKGLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocdkglvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocdkglvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'kernel_per_proto'
+
+    def test_export_returns_model_proto(self, fitted_ocdkglvq):
+        model, X = fitted_ocdkglvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ocdkglvq):
+        model, X = fitted_ocdkglvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCDKGRLVQExport:
+    """OCDKGRLVQ: kernel_relevance + OC hard nearest."""
+
+    @pytest.fixture
+    def fitted_ocdkgrlvq(self):
+        from prosemble.models import OCDKGRLVQ
+        X, y = _make_oc_data()
+        model = OCDKGRLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocdkgrlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocdkgrlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'kernel_relevance'
+
+    def test_export_returns_model_proto(self, fitted_ocdkgrlvq):
+        model, X = fitted_ocdkgrlvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ocdkgrlvq):
+        model, X = fitted_ocdkgrlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCDKGMLVQExport:
+    """OCDKGMLVQ: kernel_exponential + OC hard nearest."""
+
+    @pytest.fixture
+    def fitted_ocdkgmlvq(self):
+        from prosemble.models import OCDKGMLVQ
+        X, y = _make_oc_data()
+        model = OCDKGMLVQ(
+            n_prototypes=3, max_iter=10, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocdkgmlvq):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocdkgmlvq
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'kernel_exponential'
+
+    def test_export_returns_model_proto(self, fitted_ocdkgmlvq):
+        model, X = fitted_ocdkgmlvq
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ocdkgmlvq):
+        model, X = fitted_ocdkgmlvq
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# One-Class Differentiating Kernel NG models
+# ---------------------------------------------------------------------------
+
+class TestOCDKGLVQNGExport:
+    """OCDKGLVQ_NG: kernel_per_proto + OC hard nearest (NG at train only)."""
+
+    @pytest.fixture
+    def fitted_ocdkglvq_ng(self):
+        from prosemble.models import OCDKGLVQ_NG
+        X, y = _make_oc_data()
+        model = OCDKGLVQ_NG(
+            n_prototypes=3, max_iter=10, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocdkglvq_ng):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocdkglvq_ng
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'kernel_per_proto'
+
+    def test_export_returns_model_proto(self, fitted_ocdkglvq_ng):
+        model, X = fitted_ocdkglvq_ng
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ocdkglvq_ng):
+        model, X = fitted_ocdkglvq_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCDKGRLVQNGExport:
+    """OCDKGRLVQ_NG: kernel_relevance + OC hard nearest (NG at train only)."""
+
+    @pytest.fixture
+    def fitted_ocdkgrlvq_ng(self):
+        from prosemble.models import OCDKGRLVQ_NG
+        X, y = _make_oc_data()
+        model = OCDKGRLVQ_NG(
+            n_prototypes=3, max_iter=10, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocdkgrlvq_ng):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocdkgrlvq_ng
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'kernel_relevance'
+
+    def test_export_returns_model_proto(self, fitted_ocdkgrlvq_ng):
+        model, X = fitted_ocdkgrlvq_ng
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ocdkgrlvq_ng):
+        model, X = fitted_ocdkgrlvq_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)
+
+
+class TestOCDKGMLVQNGExport:
+    """OCDKGMLVQ_NG: kernel_exponential + OC hard nearest (NG at train only)."""
+
+    @pytest.fixture
+    def fitted_ocdkgmlvq_ng(self):
+        from prosemble.models import OCDKGMLVQ_NG
+        X, y = _make_oc_data()
+        model = OCDKGMLVQ_NG(
+            n_prototypes=3, max_iter=10, lr=0.01, random_seed=42,
+        )
+        model.fit(X, y)
+        return model, X
+
+    def test_model_type_detected(self, fitted_ocdkgmlvq_ng):
+        from prosemble.core.onnx_export import _identify_model_type
+        model, X = fitted_ocdkgmlvq_ng
+        model_type, dist_type = _identify_model_type(model)
+        assert model_type == 'oc_hard_nearest'
+        assert dist_type == 'kernel_exponential'
+
+    def test_export_returns_model_proto(self, fitted_ocdkgmlvq_ng):
+        model, X = fitted_ocdkgmlvq_ng
+        onnx_model = model.export_onnx()
+        assert isinstance(onnx_model, onnx.ModelProto)
+
+    def test_numerical_match(self, fitted_ocdkgmlvq_ng):
+        model, X = fitted_ocdkgmlvq_ng
+        jax_preds = np.asarray(model.predict(X))
+        ort_preds = _onnx_predict(model, X)
+        npt.assert_array_equal(jax_preds, ort_preds)


### PR DESCRIPTION
## Summary

Completes the Differentiating Kernel model family (Villmann, Haase & Kaden, 2015) with 9 new models and adds ONNX export support for all 15 DK models.

### New Models (9)

**Supervised DK with Neural Gas cooperation (3):**
- `DKGLVQ_NG` — Gaussian kernel with per-prototype σ + NG ranking
- `DKGRLVQ_NG` — Relevance-weighted Gaussian kernel + NG ranking
- `DKGMLVQ_NG` — Exponential kernel (Ω̂ matrix) + NG ranking

**One-Class DK (3):**
- `OCDKGLVQ` — One-class with Gaussian kernel distance + learned θ thresholds
- `OCDKGRLVQ` — One-class with relevance-weighted kernel distance
- `OCDKGMLVQ` — One-class with exponential kernel distance

**One-Class DK with Neural Gas cooperation (3):**
- `OCDKGLVQ_NG` — One-class Gaussian kernel + NG cooperation
- `OCDKGRLVQ_NG` — One-class relevance kernel + NG cooperation
- `OCDKGMLVQ_NG` — One-class exponential kernel + NG cooperation

### ONNX Export (12 models)

Three new kernel distance ONNX builders:

| Builder | Formula | Models |
|---------|---------|--------|
| `kernel_per_proto` | $d_\kappa^2 = 2(1 - \exp(-\|\|x-w\|\|^2 / 2\sigma_k^2))$ | DKGLVQ, DKGLVQ_NG, OCDKGLVQ, OCDKGLVQ_NG |
| `kernel_relevance` | $d_\kappa^2 = 2(1 - \exp(-\sum_j \lambda_j(x_j - w_j)^2 / 2\sigma_k^2))$ | DKGRLVQ, DKGRLVQ_NG, OCDKGRLVQ, OCDKGRLVQ_NG |
| `kernel_exponential` | $d_\kappa^2 = \exp(x^\top\hat\Lambda x) + \exp(w^\top\hat\Lambda w) - 2\exp(x^\top\hat\Lambda w)$ | DKGMLVQ, DKGMLVQ_NG, OCDKGMLVQ, OCDKGMLVQ_NG |

- Per-prototype σ clamped at export time (no runtime Clip node needed)
- Relevance logits normalized via Softmax node in the ONNX graph
- Λ̂ = Ω̂·Ω̂ᵀ computed in-graph for exponential kernel
- 3 unsupervised DK models (DKNeuralGas, DKKohonenSOM, DKHeskesSOM) already work via inherited Euclidean predict
- **ONNX coverage: 85 of 87 models**

### Test Coverage
- 36 new ONNX tests (12 models × 3: type detection, export, numerical match)
- 35 new model tests for DK-NG variants
- 36 new model tests for OC-DK variants
- 36 new model tests for OC-DK-NG variants
- **All 1522 tests pass, 0 regressions**

### Documentation
- Sphinx API docs updated for all 9 new models
- Differentiating kernels guide: added NG and OC sections with math formatting
- ONNX guide: updated model count, added DK entries to supported models and distance tables