### PR TITLE
feat: Add 12 Riemannian Differentiating Kernel models

### DIFF
--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -64,6 +64,20 @@ try:
     from .riemannian_slng import RiemannianSLNG
     from .riemannian_stng import RiemannianSTNG
 
+    # Riemannian Differentiating Kernel
+    from .riemannian_dk_glvq import RiemannianDKGLVQ
+    from .riemannian_dk_relevance_lvq import RiemannianDKGRLVQ
+    from .riemannian_dk_matrix_lvq import RiemannianDKGMLVQ
+    from .riemannian_dk_smng import RiemannianDKSMNG
+    from .riemannian_dk_slng import RiemannianDKSLNG
+    from .riemannian_dk_stng import RiemannianDKSTNG
+    from .riemannian_dk_r_smng import RiemannianDKRSMNG
+    from .riemannian_dk_m_smng import RiemannianDKMSMNG
+    from .riemannian_dk_r_slng import RiemannianDKRSLNG
+    from .riemannian_dk_m_slng import RiemannianDKMSLNG
+    from .riemannian_dk_r_stng import RiemannianDKRSTNG
+    from .riemannian_dk_m_stng import RiemannianDKMSTNG
+
     # One-class models
     from .oc_glvq import OCGLVQ
     from .oc_grlvq import OCGRLVQ
@@ -136,6 +150,19 @@ try:
         # Supervised Riemannian NG
         'RiemannianSRNG': RiemannianSRNG, 'RiemannianSMNG': RiemannianSMNG,
         'RiemannianSLNG': RiemannianSLNG, 'RiemannianSTNG': RiemannianSTNG,
+        # Riemannian Differentiating Kernel
+        'RiemannianDKGLVQ': RiemannianDKGLVQ,
+        'RiemannianDKGRLVQ': RiemannianDKGRLVQ,
+        'RiemannianDKGMLVQ': RiemannianDKGMLVQ,
+        'RiemannianDKSMNG': RiemannianDKSMNG,
+        'RiemannianDKSLNG': RiemannianDKSLNG,
+        'RiemannianDKSTNG': RiemannianDKSTNG,
+        'RiemannianDKRSMNG': RiemannianDKRSMNG,
+        'RiemannianDKMSMNG': RiemannianDKMSMNG,
+        'RiemannianDKRSLNG': RiemannianDKRSLNG,
+        'RiemannianDKMSLNG': RiemannianDKMSLNG,
+        'RiemannianDKRSTNG': RiemannianDKRSTNG,
+        'RiemannianDKMSTNG': RiemannianDKMSTNG,
         # One-class GLVQ
         'OCGLVQ': OCGLVQ, 'OCGRLVQ': OCGRLVQ, 'OCGMLVQ': OCGMLVQ,
         'OCLGMLVQ': OCLGMLVQ, 'OCGTLVQ': OCGTLVQ,
@@ -199,6 +226,12 @@ __all__ = [
     'ImageGLVQ', 'ImageGMLVQ', 'ImageGTLVQ', 'ImageCBC',
     # Supervised Riemannian NG
     'RiemannianSRNG', 'RiemannianSMNG', 'RiemannianSLNG', 'RiemannianSTNG',
+    # Riemannian Differentiating Kernel
+    'RiemannianDKGLVQ', 'RiemannianDKGRLVQ', 'RiemannianDKGMLVQ',
+    'RiemannianDKSMNG', 'RiemannianDKSLNG', 'RiemannianDKSTNG',
+    'RiemannianDKRSMNG', 'RiemannianDKMSMNG',
+    'RiemannianDKRSLNG', 'RiemannianDKMSLNG',
+    'RiemannianDKRSTNG', 'RiemannianDKMSTNG',
     # One-class GLVQ
     'OCGLVQ', 'OCGRLVQ', 'OCGMLVQ', 'OCLGMLVQ', 'OCGTLVQ',
     'OCGLVQ_NG', 'OCGRLVQ_NG', 'OCGMLVQ_NG', 'OCLGMLVQ_NG', 'OCGTLVQ_NG',

--- a/prosemble/models/riemannian_dk_glvq.py
+++ b/prosemble/models/riemannian_dk_glvq.py
@@ -1,0 +1,311 @@
+"""
+Riemannian Differentiating Kernel GLVQ (RiemannianDKGLVQ).
+
+Combines Riemannian manifold geometry with Gaussian kernel distance
+and per-prototype bandwidth adaptation:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{d_{\\text{geo}}^2(x, w_k)}{2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`d_{\\text{geo}}(x, w_k)` is the geodesic distance on the
+Riemannian manifold (SO(n), SPD(n), or Grassmannian(n,k)).
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_srng import RiemannianSRNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKGLVQ(RiemannianSRNG):
+    """Riemannian Differentiating Kernel GLVQ.
+
+    Extends RiemannianSRNG with Gaussian kernel distance. Each prototype
+    :math:`w_k` has a learnable bandwidth :math:`\\sigma_k` that controls
+    the sensitivity range of the kernel on the manifold.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{d_{\\text{geo}}^2(x, w_k)}{2\\sigma_k^2}
+        \\right)\\right)
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance defining the geometry.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median geodesic distance.
+        'mean': per-class mean geodesic distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma to prevent bandwidth collapse. Default: 1e-3.
+    beta : float
+        Transfer function steepness parameter.
+    gamma_init : float, optional
+        Initial neighborhood range for NG cooperation.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay factor for gamma.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping.
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True, use jax.lax.scan. Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation steps.
+    ema_decay : float, optional
+        EMA decay for parameters.
+    freeze_params : list of str, optional
+        Parameter groups to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSRNG : Base Riemannian supervised Neural Gas.
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 beta=10.0, gamma_init=None, gamma_final=0.01,
+                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=False, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+
+    def _estimate_sigmas(self, X_flat, y, prototypes_flat, proto_labels):
+        """Estimate per-prototype bandwidths from manifold distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(prototypes_flat.shape[0], float(self.sigma_init))
+
+        n_protos = prototypes_flat.shape[0]
+        n = X_flat.shape[0]
+        X_m = self._reshape_to_manifold(X_flat, n)
+        W_m = self._reshape_to_manifold(prototypes_flat, n_protos)
+
+        # Compute full distance matrix once
+        dist_matrix = self._geodesic_distances(X_m, W_m)  # (n, p)
+
+        sigmas = []
+        for k in range(n_protos):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(dist_matrix[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:  # 'mean'
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        sigmas = self._estimate_sigmas(X, y, params['prototypes'], proto_labels)
+        params = {**params, 'sigmas': sigmas}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Geodesic distance matrix
+        raw_distances = self._geodesic_distances(X_m, W_m)  # (n, p)
+
+        # 2. Apply Gaussian kernel
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 3. Compute ranks within same-class prototypes
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        # 4. Neighborhood function h = exp(-rank / gamma)
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        # 5. Normalize per sample
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        # 6. Closest different-class prototype distance
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        # 7. GLVQ mu
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        # 8. Transfer function
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        # 9. Rank-weighted sum
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    def predict(self, X):
+        """Predict class labels using kernel-wrapped geodesic distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        raw_distances = self._geodesic_distances(X_m, W_m)
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = {'prototypes_': self.prototypes_}
+        if self.sigmas_ is not None:
+            attrs['sigmas_'] = self.sigmas_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/riemannian_dk_m_slng.py
+++ b/prosemble/models/riemannian_dk_m_slng.py
@@ -1,0 +1,303 @@
+"""
+Riemannian Differentiating Kernel Matrix SLNG (RiemannianDKMSLNG).
+
+Combines RiemannianSLNG (per-prototype local omega metric) with an
+exponential kernel using a learned transformation matrix in the projected space:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = \\exp\\left(
+        (\\Omega_k \\cdot v)^T \\hat\\Lambda (\\Omega_k \\cdot v)
+    \\right) - 1
+
+where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`,
+:math:`\\Omega_k` is the per-prototype metric matrix, and
+:math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T` is a shared learned PSD
+matrix operating in the projected (latent) space.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_slng import RiemannianSLNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKMSLNG(RiemannianSLNG):
+    """Riemannian Differentiating Kernel Matrix SLNG.
+
+    Extends RiemannianSLNG with an exponential kernel in the per-prototype
+    omega-projected tangent space. Each prototype has its own metric matrix
+    :math:`\\Omega_k`, and a shared :math:`\\hat\\Lambda = \\hat\\Omega
+    \\hat\\Omega^T` provides further metric adaptation in the projected space:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = \\exp\\left(
+            (\\Omega_k \\cdot v)^T \\hat\\Lambda (\\Omega_k \\cdot v)
+        \\right) - 1
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    latent_dim : int, optional
+        Projection dimensionality for local omegas. Default: d_flat.
+    kernel_latent_dim : int, optional
+        Dimensionality for the kernel's omega_hat. Default: same as
+        omega's output dimension (latent_dim).
+    omega_hat_scale : float
+        Scale for omega_hat initialization. Default: 0.1.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSLNG : Base Riemannian localized matrix Neural Gas.
+    RiemannianDKSLNG : Gaussian kernel variant (no matrix kernel).
+    RiemannianDKRSLNG : Relevance kernel variant.
+    """
+
+    def __init__(self, manifold, latent_dim=None, kernel_latent_dim=None,
+                 omega_hat_scale=0.1, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, latent_dim=latent_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.kernel_latent_dim = kernel_latent_dim
+        self.omega_hat_scale = omega_hat_scale
+        self.omega_hat_ = None
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['omega_hat'] = self.omega_hat_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        # omega_hat operates in the projected space (latent_dim)
+        # omegas shape: (p, d_flat, latent_dim)
+        proj_dim = params['omegas'].shape[2]
+        kld = self.kernel_latent_dim if self.kernel_latent_dim is not None else proj_dim
+        omega_hat = self.omega_hat_scale * identity_omega_init(proj_dim, kld)
+
+        params = {**params, 'omega_hat': omega_hat}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        gamma = params['gamma']
+        omega_hat = params['omega_hat']
+        lambda_hat = jnp.dot(omega_hat, omega_hat.T)  # (proj_dim, proj_dim)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Per-prototype omega-projected tangent vectors
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, omegas)  # (n, p, L)
+
+        # 2. Exponential kernel: exp(proj^T Lambda_hat proj) - 1
+        Lp = jnp.einsum('npl,lm->npm', projected, lambda_hat)  # (n, p, L)
+        pLp = jnp.sum(projected * Lp, axis=2)  # (n, p)
+        pLp = jnp.clip(pLp, None, 20.0)  # prevent exp overflow
+        distances = jnp.maximum(jnp.exp(pLp) - 1.0, 0.0)
+
+        # 3. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.omega_hat_ = params['omega_hat']
+
+    @property
+    def omega_hat_matrix(self):
+        """Return the learned kernel :math:`\\hat\\Omega` matrix."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_
+
+    @property
+    def lambda_hat_matrix(self):
+        """Return :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_ @ self.omega_hat_.T
+
+    def predict(self, X):
+        """Predict using exponential kernel in local-omega-projected space.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, self.omegas_)
+        lambda_hat = jnp.dot(self.omega_hat_, self.omega_hat_.T)
+        Lp = jnp.einsum('npl,lm->npm', projected, lambda_hat)
+        pLp = jnp.sum(projected * Lp, axis=2)
+        pLp = jnp.clip(pLp, None, 20.0)
+        distances = jnp.maximum(jnp.exp(pLp) - 1.0, 0.0)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.omega_hat_ is not None:
+                attrs['omega_hat_'] = self.omega_hat_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_hat_ is not None:
+            arrays['omega_hat_'] = np.asarray(self.omega_hat_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_hat_' in arrays:
+            self.omega_hat_ = jnp.asarray(arrays['omega_hat_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['omega_hat_scale'] = self.omega_hat_scale
+        if self.kernel_latent_dim is not None:
+            hp['kernel_latent_dim'] = self.kernel_latent_dim
+        return hp

--- a/prosemble/models/riemannian_dk_m_smng.py
+++ b/prosemble/models/riemannian_dk_m_smng.py
@@ -1,0 +1,303 @@
+"""
+Riemannian Differentiating Kernel Matrix SMNG (RiemannianDKMSMNG).
+
+Combines RiemannianSMNG (global omega metric in tangent space) with an
+exponential kernel using a learned transformation matrix in the projected space:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = \\exp\\left(
+        (\\Omega \\cdot v)^T \\hat\\Lambda (\\Omega \\cdot v)
+    \\right) - 1
+
+where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`,
+:math:`\\Omega` is the global metric matrix projecting from d_flat to latent_dim,
+and :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T` is a learned PSD matrix
+operating in the projected (latent) space.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_smng import RiemannianSMNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKMSMNG(RiemannianSMNG):
+    """Riemannian Differentiating Kernel Matrix SMNG.
+
+    Extends RiemannianSMNG with an exponential kernel in the omega-projected
+    tangent space. The global omega :math:`\\Omega` projects tangent vectors
+    from d_flat to latent_dim, then a learned matrix
+    :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T` provides further
+    metric adaptation in the projected space:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = \\exp\\left(
+            (\\Omega \\cdot v)^T \\hat\\Lambda (\\Omega \\cdot v)
+        \\right) - 1
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    latent_dim : int, optional
+        Projection dimensionality for global omega. Default: d_flat.
+    kernel_latent_dim : int, optional
+        Dimensionality for the kernel's omega_hat. Default: same as
+        omega's output dimension (latent_dim).
+    omega_hat_scale : float
+        Scale for omega_hat initialization. Default: 0.1.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSMNG : Base Riemannian matrix Neural Gas.
+    RiemannianDKSMNG : Gaussian kernel variant (no matrix kernel).
+    RiemannianDKRSMNG : Relevance kernel variant.
+    """
+
+    def __init__(self, manifold, latent_dim=None, kernel_latent_dim=None,
+                 omega_hat_scale=0.1, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, latent_dim=latent_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.kernel_latent_dim = kernel_latent_dim
+        self.omega_hat_scale = omega_hat_scale
+        self.omega_hat_ = None
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['omega_hat'] = self.omega_hat_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        # omega_hat operates in the projected space (latent_dim)
+        proj_dim = params['omega'].shape[1]
+        kld = self.kernel_latent_dim if self.kernel_latent_dim is not None else proj_dim
+        omega_hat = self.omega_hat_scale * identity_omega_init(proj_dim, kld)
+
+        params = {**params, 'omega_hat': omega_hat}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omega = params['omega']
+        gamma = params['gamma']
+        omega_hat = params['omega_hat']
+        lambda_hat = jnp.dot(omega_hat, omega_hat.T)  # (proj_dim, proj_dim)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Omega-projected tangent vectors
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, omega)  # (n, p, L)
+
+        # 2. Exponential kernel: exp(proj^T Lambda_hat proj) - 1
+        Lp = jnp.einsum('npl,lm->npm', projected, lambda_hat)  # (n, p, L)
+        pLp = jnp.sum(projected * Lp, axis=2)  # (n, p)
+        pLp = jnp.clip(pLp, None, 20.0)  # prevent exp overflow
+        distances = jnp.maximum(jnp.exp(pLp) - 1.0, 0.0)
+
+        # 3. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.omega_hat_ = params['omega_hat']
+
+    @property
+    def omega_hat_matrix(self):
+        """Return the learned kernel :math:`\\hat\\Omega` matrix."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_
+
+    @property
+    def lambda_hat_matrix(self):
+        """Return :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_ @ self.omega_hat_.T
+
+    def predict(self, X):
+        """Predict using exponential kernel in omega-projected space.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, self.omega_)
+        lambda_hat = jnp.dot(self.omega_hat_, self.omega_hat_.T)
+        Lp = jnp.einsum('npl,lm->npm', projected, lambda_hat)
+        pLp = jnp.sum(projected * Lp, axis=2)
+        pLp = jnp.clip(pLp, None, 20.0)
+        distances = jnp.maximum(jnp.exp(pLp) - 1.0, 0.0)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.omega_hat_ is not None:
+                attrs['omega_hat_'] = self.omega_hat_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_hat_ is not None:
+            arrays['omega_hat_'] = np.asarray(self.omega_hat_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_hat_' in arrays:
+            self.omega_hat_ = jnp.asarray(arrays['omega_hat_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['omega_hat_scale'] = self.omega_hat_scale
+        if self.kernel_latent_dim is not None:
+            hp['kernel_latent_dim'] = self.kernel_latent_dim
+        return hp

--- a/prosemble/models/riemannian_dk_m_stng.py
+++ b/prosemble/models/riemannian_dk_m_stng.py
@@ -1,0 +1,307 @@
+"""
+Riemannian Differentiating Kernel Matrix STNG (RiemannianDKMSTNG).
+
+Combines RiemannianSTNG (tangent subspace projection) with an exponential
+kernel using a learned transformation matrix on the subspace residual:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = \\exp\\left(
+        r^T \\hat\\Lambda r
+    \\right) - 1
+
+where :math:`r = (I - \\Omega_k \\Omega_k^T) \\cdot v` is the subspace
+residual, :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`, and
+:math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T` is a learned PSD matrix.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_stng import RiemannianSTNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKMSTNG(RiemannianSTNG):
+    """Riemannian Differentiating Kernel Matrix STNG.
+
+    Extends RiemannianSTNG with an exponential kernel on the tangent
+    subspace residual. Each prototype has an orthonormal subspace basis
+    :math:`\\Omega_k`, and a shared :math:`\\hat\\Lambda = \\hat\\Omega
+    \\hat\\Omega^T` provides metric adaptation on the residual:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = \\exp\\left(
+            r^T \\hat\\Lambda r
+        \\right) - 1
+
+    where :math:`r = (I - \\Omega_k \\Omega_k^T) \\cdot v`.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    kernel_latent_dim : int, optional
+        Dimensionality for the kernel's omega_hat. Default: d_flat.
+    omega_hat_scale : float
+        Scale for omega_hat initialization. Default: 0.1.
+    subspace_dim : int, optional
+        Tangent subspace dimensionality. Default: d_flat - 1.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSTNG : Base Riemannian tangent Neural Gas.
+    RiemannianDKSTNG : Gaussian kernel variant (no matrix kernel).
+    RiemannianDKRSTNG : Relevance kernel variant.
+    """
+
+    def __init__(self, manifold, kernel_latent_dim=None, omega_hat_scale=0.1,
+                 subspace_dim=None, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, subspace_dim=subspace_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.kernel_latent_dim = kernel_latent_dim
+        self.omega_hat_scale = omega_hat_scale
+        self.omega_hat_ = None
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['omega_hat'] = self.omega_hat_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        # omega_hat operates on the residual (d_flat dimensional)
+        d_flat = X.shape[1]
+        kld = self.kernel_latent_dim if self.kernel_latent_dim is not None else d_flat
+        omega_hat = self.omega_hat_scale * identity_omega_init(d_flat, kld)
+
+        params = {**params, 'omega_hat': omega_hat}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        gamma = params['gamma']
+        omega_hat = params['omega_hat']
+        lambda_hat = jnp.dot(omega_hat, omega_hat.T)  # (d_flat, d_flat)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Tangent subspace residual
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, omegas)
+        recon = jnp.einsum('nps,pds->npd', proj, omegas)
+        residual = tangent_flat - recon  # (n, p, d_flat)
+
+        # 2. Exponential kernel: exp(r^T Lambda_hat r) - 1
+        Lr = jnp.einsum('npd,de->npe', residual, lambda_hat)  # (n, p, d_flat)
+        rLr = jnp.sum(residual * Lr, axis=2)  # (n, p)
+        rLr = jnp.clip(rLr, None, 20.0)  # prevent exp overflow
+        distances = jnp.maximum(jnp.exp(rLr) - 1.0, 0.0)
+
+        # 3. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.omega_hat_ = params['omega_hat']
+
+    @property
+    def omega_hat_matrix(self):
+        """Return the learned kernel :math:`\\hat\\Omega` matrix."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_
+
+    @property
+    def lambda_hat_matrix(self):
+        """Return :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_ @ self.omega_hat_.T
+
+    def predict(self, X):
+        """Predict using exponential kernel on subspace residual.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, self.omegas_)
+        recon = jnp.einsum('nps,pds->npd', proj, self.omegas_)
+        residual = tangent_flat - recon
+
+        lambda_hat = jnp.dot(self.omega_hat_, self.omega_hat_.T)
+        Lr = jnp.einsum('npd,de->npe', residual, lambda_hat)
+        rLr = jnp.sum(residual * Lr, axis=2)
+        rLr = jnp.clip(rLr, None, 20.0)
+        distances = jnp.maximum(jnp.exp(rLr) - 1.0, 0.0)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.omega_hat_ is not None:
+                attrs['omega_hat_'] = self.omega_hat_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_hat_ is not None:
+            arrays['omega_hat_'] = np.asarray(self.omega_hat_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_hat_' in arrays:
+            self.omega_hat_ = jnp.asarray(arrays['omega_hat_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['omega_hat_scale'] = self.omega_hat_scale
+        if self.kernel_latent_dim is not None:
+            hp['kernel_latent_dim'] = self.kernel_latent_dim
+        return hp

--- a/prosemble/models/riemannian_dk_matrix_lvq.py
+++ b/prosemble/models/riemannian_dk_matrix_lvq.py
@@ -1,0 +1,343 @@
+"""
+Riemannian Differentiating Kernel GMLVQ (RiemannianDKGMLVQ).
+
+Combines Riemannian manifold geometry with the exponential kernel distance
+applied in tangent space via a learned transformation matrix
+:math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = \\exp(v^T \\hat\\Lambda v) - 1
+
+where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}` is the tangent vector.
+In tangent space at :math:`w_k`, the prototype maps to the zero vector,
+simplifying the full exponential kernel formula.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_srng import RiemannianSRNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.competitions import wtac
+from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.models.riemannian_srng import (
+    _so_log_map_diff, _spd_log_map_diff, _grassmannian_log_map_diff,
+)
+
+
+class RiemannianDKGMLVQ(RiemannianSRNG):
+    """Riemannian Differentiating Kernel GMLVQ.
+
+    Extends RiemannianSRNG with exponential kernel distance applied in
+    tangent space. A global transformation matrix :math:`\\hat\\Omega`
+    (d_flat x latent_dim) is learned such that:
+
+    .. math::
+
+        \\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = \\exp(v^T \\hat\\Lambda v) - 1
+
+    where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`. Since the
+    prototype maps to the zero vector in its own tangent space, the
+    exponential kernel simplifies from the full three-term formula to
+    :math:`\\exp(v^T \\hat\\Lambda v) - 1`.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance defining the geometry.
+    latent_dim : int, optional
+        Dimensionality of the transformation. If None, uses d_flat.
+    omega_hat_scale : float
+        Scale factor for omega_hat initialization. Default: 0.1.
+        Smaller values prevent exp overflow at initialization.
+    beta : float
+        Transfer function steepness parameter.
+    gamma_init : float, optional
+        Initial neighborhood range for NG cooperation.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay factor for gamma.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping.
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True, use jax.lax.scan. Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation steps.
+    ema_decay : float, optional
+        EMA decay for parameters.
+    freeze_params : list of str, optional
+        Parameter groups to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSRNG : Base Riemannian supervised Neural Gas.
+    RiemannianDKGLVQ : Gaussian kernel variant.
+    RiemannianDKGRLVQ : Relevance-weighted kernel variant.
+    """
+
+    def __init__(self, manifold, latent_dim=None, omega_hat_scale=0.1,
+                 beta=10.0, gamma_init=None, gamma_final=0.01,
+                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=False, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.latent_dim = latent_dim
+        self.omega_hat_scale = omega_hat_scale
+        self.omega_hat_ = None
+
+    def _diff_log_map(self, w, x):
+        """Differentiable log map for a single (base, target) pair."""
+        if isinstance(self.manifold, SO):
+            return _so_log_map_diff(w, x)
+        elif isinstance(self.manifold, SPD):
+            return _spd_log_map_diff(w, x)
+        elif isinstance(self.manifold, Grassmannian):
+            return _grassmannian_log_map_diff(w, x)
+        else:
+            return self.manifold.log_map(w, x)
+
+    def _compute_tangent_vectors(self, X_manifold, W_manifold):
+        """Compute tangent vectors from prototypes to data via log map.
+
+        Parameters
+        ----------
+        X_manifold : array of shape (n_samples, *point_shape)
+        W_manifold : array of shape (n_prototypes, *point_shape)
+
+        Returns
+        -------
+        tangents_flat : array of shape (n_samples, n_prototypes, d_flat)
+        """
+        log_to_all_x = jax.vmap(self._diff_log_map, in_axes=(None, 0))
+        log_matrix = jax.vmap(log_to_all_x, in_axes=(0, None))
+        tangents = log_matrix(W_manifold, X_manifold)
+        tangents = jnp.moveaxis(tangents, 0, 1)
+        n = X_manifold.shape[0]
+        p = W_manifold.shape[0]
+        return tangents.reshape(n, p, -1)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['omega_hat'] = self.omega_hat_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        d_flat = X.shape[1]
+        latent_dim = self.latent_dim if self.latent_dim is not None else d_flat
+        omega_hat = self.omega_hat_scale * identity_omega_init(
+            d_flat, latent_dim
+        )
+
+        params = {**params, 'omega_hat': omega_hat}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        gamma = params['gamma']
+        omega_hat = params['omega_hat']
+        lambda_hat = jnp.dot(omega_hat, omega_hat.T)  # (d_flat, d_flat)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Tangent vectors via log map
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)  # (n, p, d_flat)
+
+        # 2. Exponential kernel in tangent space
+        # v^T Lambda_hat v for each (sample, proto) pair
+        Lv = jnp.einsum('npd,de->npe', tangent_flat, lambda_hat)  # (n, p, d_flat)
+        vLv = jnp.sum(tangent_flat * Lv, axis=2)  # (n, p)
+        vLv = jnp.clip(vLv, None, 20.0)  # prevent exp overflow
+        distances = jnp.maximum(jnp.exp(vLv) - 1.0, 0.0)
+
+        # 3. Compute ranks within same-class prototypes
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        # 4. Neighborhood function h = exp(-rank / gamma)
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        # 5. Normalize per sample
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        # 6. Closest different-class prototype distance
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        # 7. GLVQ mu
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        # 8. Transfer function
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        # 9. Rank-weighted sum
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.omega_hat_ = params['omega_hat']
+
+    @property
+    def omega_hat_matrix(self):
+        """Return the learned :math:`\\hat\\Omega` matrix."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_
+
+    @property
+    def lambda_hat_matrix(self):
+        """Return :math:`\\hat\\Lambda = \\hat\\Omega \\hat\\Omega^T`."""
+        if self.omega_hat_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.omega_hat_ @ self.omega_hat_.T
+
+    def predict(self, X):
+        """Predict using exponential kernel distance in tangent space.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        lambda_hat = jnp.dot(self.omega_hat_, self.omega_hat_.T)
+        Lv = jnp.einsum('npd,de->npe', tangent_flat, lambda_hat)
+        vLv = jnp.sum(tangent_flat * Lv, axis=2)
+        vLv = jnp.clip(vLv, None, 20.0)
+        distances = jnp.maximum(jnp.exp(vLv) - 1.0, 0.0)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = {'prototypes_': self.prototypes_}
+        if self.omega_hat_ is not None:
+            attrs['omega_hat_'] = self.omega_hat_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_hat_ is not None:
+            arrays['omega_hat_'] = np.asarray(self.omega_hat_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_hat_' in arrays:
+            self.omega_hat_ = jnp.asarray(arrays['omega_hat_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['omega_hat_scale'] = self.omega_hat_scale
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp

--- a/prosemble/models/riemannian_dk_r_slng.py
+++ b/prosemble/models/riemannian_dk_r_slng.py
@@ -1,0 +1,352 @@
+"""
+Riemannian Differentiating Kernel Relevance SLNG (RiemannianDKRSLNG).
+
+Combines RiemannianSLNG (per-prototype local omega metric) with a
+relevance-weighted Gaussian kernel for adaptive per-prototype bandwidth
+and per-feature weighting in the projected space:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\sum_j \\lambda_j (\\Omega_k \\cdot v)_j^2}
+              {2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`,
+:math:`\\Omega_k` is the per-prototype metric matrix, and
+:math:`\\lambda = \\text{softmax}(\\text{relevances})` weights features
+in the projected (latent) space.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_slng import RiemannianSLNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKRSLNG(RiemannianSLNG):
+    """Riemannian Differentiating Kernel Relevance SLNG.
+
+    Extends RiemannianSLNG with a relevance-weighted Gaussian kernel in
+    the per-prototype omega-projected tangent space. Each prototype has
+    its own metric matrix :math:`\\Omega_k` and bandwidth :math:`\\sigma_k`,
+    plus a shared relevance vector :math:`\\lambda`:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\sum_j \\lambda_j (\\Omega_k \\cdot v)_j^2}
+                  {2\\sigma_k^2}
+        \\right)\\right)
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median of relevance-weighted distances.
+        'mean': per-class mean.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma. Default: 1e-3.
+    latent_dim : int, optional
+        Projection dimensionality for local omegas. Default: d_flat.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSLNG : Base Riemannian localized matrix Neural Gas.
+    RiemannianDKSLNG : Gaussian kernel variant (no relevance weighting).
+    RiemannianDKRSMNG : Global omega + relevance kernel variant.
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 latent_dim=None, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, latent_dim=latent_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+        self.relevances_ = None
+
+    def _estimate_sigmas(self, X, y, params, proto_labels):
+        """Estimate per-prototype bandwidths from local-omega distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(params['prototypes'].shape[0], float(self.sigma_init))
+
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, omegas)
+        # At init, relevances are uniform → mean of projected²
+        raw_distances = jnp.mean(projected ** 2, axis=2)  # (n, p)
+
+        sigmas = []
+        for k in range(p):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(raw_distances[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        base['relevances'] = self.relevances_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        # Determine latent dimension from omegas shape: (p, d_flat, latent_dim)
+        latent_dim = params['omegas'].shape[2]
+        sigmas = self._estimate_sigmas(X, y, params, proto_labels)
+        relevances = jnp.zeros(latent_dim)  # uniform under softmax
+
+        params = {**params, 'sigmas': sigmas, 'relevances': relevances}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        lam = jax.nn.softmax(params['relevances'])
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Per-prototype omega-projected tangent vectors
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, omegas)  # (n, p, L)
+
+        # 2. Relevance-weighted squared norms in projected space
+        weighted_sq = jnp.sum(
+            lam[None, None, :] * projected ** 2, axis=2
+        )  # (n, p)
+
+        # 3. Apply Gaussian kernel
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 4. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+        self.relevances_ = params['relevances']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    @property
+    def relevance_profile(self):
+        """Return the learned relevance weights (normalized via softmax)."""
+        if self.relevances_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return jax.nn.softmax(self.relevances_)
+
+    def predict(self, X):
+        """Predict using relevance-weighted kernel in local-omega space.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, self.omegas_)
+        lam = jax.nn.softmax(self.relevances_)
+        weighted_sq = jnp.sum(lam[None, None, :] * projected ** 2, axis=2)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.sigmas_ is not None:
+                attrs['sigmas_'] = self.sigmas_
+            if self.relevances_ is not None:
+                attrs['relevances_'] = self.relevances_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        if self.relevances_ is not None:
+            arrays['relevances_'] = np.asarray(self.relevances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+        if 'relevances_' in arrays:
+            self.relevances_ = jnp.asarray(arrays['relevances_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/riemannian_dk_r_smng.py
+++ b/prosemble/models/riemannian_dk_r_smng.py
@@ -1,0 +1,353 @@
+"""
+Riemannian Differentiating Kernel Relevance SMNG (RiemannianDKRSMNG).
+
+Combines RiemannianSMNG (global omega metric in tangent space) with a
+relevance-weighted Gaussian kernel for adaptive per-prototype bandwidth
+and per-feature weighting in the projected space:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\sum_j \\lambda_j (\\Omega \\cdot v)_j^2}
+              {2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`,
+:math:`\\Omega` is the global metric matrix, and
+:math:`\\lambda = \\text{softmax}(\\text{relevances})` weights features
+in the projected (latent) space.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_smng import RiemannianSMNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKRSMNG(RiemannianSMNG):
+    """Riemannian Differentiating Kernel Relevance SMNG.
+
+    Extends RiemannianSMNG with a relevance-weighted Gaussian kernel in
+    the omega-projected tangent space. Each prototype has a learnable
+    bandwidth :math:`\\sigma_k`, and a shared relevance vector
+    :math:`\\lambda` weights the projected features:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\sum_j \\lambda_j (\\Omega \\cdot v)_j^2}
+                  {2\\sigma_k^2}
+        \\right)\\right)
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median of relevance-weighted distances.
+        'mean': per-class mean.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma. Default: 1e-3.
+    latent_dim : int, optional
+        Projection dimensionality for omega. Default: d_flat.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSMNG : Base Riemannian matrix Neural Gas.
+    RiemannianDKSMNG : Gaussian kernel variant (no relevance weighting).
+    RiemannianDKGRLVQ : Relevance kernel on geodesic distance (no omega).
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 latent_dim=None, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, latent_dim=latent_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+        self.relevances_ = None
+
+    def _estimate_sigmas(self, X, y, params, proto_labels):
+        """Estimate per-prototype bandwidths from omega-projected distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(params['prototypes'].shape[0], float(self.sigma_init))
+
+        prototypes = params['prototypes']
+        omega = params['omega']
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, omega)
+        # At init, relevances are uniform (zeros → softmax → 1/L)
+        # so weighted distance = (1/L) * sum(proj²) = mean(proj²)
+        raw_distances = jnp.mean(projected ** 2, axis=2)  # (n, p)
+
+        sigmas = []
+        for k in range(p):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(raw_distances[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        base['relevances'] = self.relevances_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        # Determine latent dimension from omega shape
+        latent_dim = params['omega'].shape[1]
+        sigmas = self._estimate_sigmas(X, y, params, proto_labels)
+        relevances = jnp.zeros(latent_dim)  # uniform under softmax
+
+        params = {**params, 'sigmas': sigmas, 'relevances': relevances}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omega = params['omega']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        lam = jax.nn.softmax(params['relevances'])
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Omega-projected tangent vectors
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, omega)  # (n, p, L)
+
+        # 2. Relevance-weighted squared norms in projected space
+        weighted_sq = jnp.sum(
+            lam[None, None, :] * projected ** 2, axis=2
+        )  # (n, p)
+
+        # 3. Apply Gaussian kernel
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 4. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+        self.relevances_ = params['relevances']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    @property
+    def relevance_profile(self):
+        """Return the learned relevance weights (normalized via softmax)."""
+        if self.relevances_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return jax.nn.softmax(self.relevances_)
+
+    def predict(self, X):
+        """Predict using relevance-weighted kernel in omega-projected space.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, self.omega_)
+        lam = jax.nn.softmax(self.relevances_)
+        weighted_sq = jnp.sum(lam[None, None, :] * projected ** 2, axis=2)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.sigmas_ is not None:
+                attrs['sigmas_'] = self.sigmas_
+            if self.relevances_ is not None:
+                attrs['relevances_'] = self.relevances_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        if self.relevances_ is not None:
+            arrays['relevances_'] = np.asarray(self.relevances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+        if 'relevances_' in arrays:
+            self.relevances_ = jnp.asarray(arrays['relevances_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/riemannian_dk_r_stng.py
+++ b/prosemble/models/riemannian_dk_r_stng.py
@@ -1,0 +1,359 @@
+"""
+Riemannian Differentiating Kernel Relevance STNG (RiemannianDKRSTNG).
+
+Combines RiemannianSTNG (tangent subspace projection) with a
+relevance-weighted Gaussian kernel on the subspace residual:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\sum_j \\lambda_j r_j^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`r = (I - \\Omega_k \\Omega_k^T) \\cdot v` is the subspace
+residual, :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`, and
+:math:`\\lambda = \\text{softmax}(\\text{relevances})` weights features
+of the residual vector.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_stng import RiemannianSTNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKRSTNG(RiemannianSTNG):
+    """Riemannian Differentiating Kernel Relevance STNG.
+
+    Extends RiemannianSTNG with a relevance-weighted Gaussian kernel on
+    the tangent subspace residual. Each prototype has an orthonormal
+    subspace basis :math:`\\Omega_k` and a learnable bandwidth
+    :math:`\\sigma_k`, plus a shared relevance vector :math:`\\lambda`
+    that weights features of the residual:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\sum_j \\lambda_j r_j^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    where :math:`r = (I - \\Omega_k \\Omega_k^T) \\cdot v`.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median of relevance-weighted residuals.
+        'mean': per-class mean.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma. Default: 1e-3.
+    subspace_dim : int, optional
+        Tangent subspace dimensionality. Default: d_flat - 1.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSTNG : Base Riemannian tangent Neural Gas.
+    RiemannianDKSTNG : Gaussian kernel variant (no relevance weighting).
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 subspace_dim=None, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, subspace_dim=subspace_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+        self.relevances_ = None
+
+    def _estimate_sigmas(self, X, y, params, proto_labels):
+        """Estimate per-prototype bandwidths from subspace residual distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(params['prototypes'].shape[0], float(self.sigma_init))
+
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        # Subspace residual: (I - Omega_k Omega_k^T) * v
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, omegas)
+        recon = jnp.einsum('nps,pds->npd', proj, omegas)
+        residual = tangent_flat - recon
+        # At init, relevances are uniform → mean of residual²
+        raw_distances = jnp.mean(residual ** 2, axis=2)  # (n, p)
+
+        sigmas = []
+        for k in range(p):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(raw_distances[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        base['relevances'] = self.relevances_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        d_flat = X.shape[1]
+        sigmas = self._estimate_sigmas(X, y, params, proto_labels)
+        # Relevance over d_flat features (residual lives in d_flat space)
+        relevances = jnp.zeros(d_flat)  # uniform under softmax
+
+        params = {**params, 'sigmas': sigmas, 'relevances': relevances}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        lam = jax.nn.softmax(params['relevances'])
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Tangent subspace residual
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, omegas)
+        recon = jnp.einsum('nps,pds->npd', proj, omegas)
+        residual = tangent_flat - recon  # (n, p, d_flat)
+
+        # 2. Relevance-weighted squared norms of residual
+        weighted_sq = jnp.sum(
+            lam[None, None, :] * residual ** 2, axis=2
+        )  # (n, p)
+
+        # 3. Apply Gaussian kernel
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 4. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+        self.relevances_ = params['relevances']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    @property
+    def relevance_profile(self):
+        """Return the learned relevance weights (normalized via softmax)."""
+        if self.relevances_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return jax.nn.softmax(self.relevances_)
+
+    def predict(self, X):
+        """Predict using relevance-weighted kernel on subspace residual.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, self.omegas_)
+        recon = jnp.einsum('nps,pds->npd', proj, self.omegas_)
+        residual = tangent_flat - recon
+
+        lam = jax.nn.softmax(self.relevances_)
+        weighted_sq = jnp.sum(lam[None, None, :] * residual ** 2, axis=2)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.sigmas_ is not None:
+                attrs['sigmas_'] = self.sigmas_
+            if self.relevances_ is not None:
+                attrs['relevances_'] = self.relevances_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        if self.relevances_ is not None:
+            arrays['relevances_'] = np.asarray(self.relevances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+        if 'relevances_' in arrays:
+            self.relevances_ = jnp.asarray(arrays['relevances_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/riemannian_dk_relevance_lvq.py
+++ b/prosemble/models/riemannian_dk_relevance_lvq.py
@@ -1,0 +1,380 @@
+"""
+Riemannian Differentiating Kernel GRLVQ (RiemannianDKGRLVQ).
+
+Combines Riemannian manifold geometry with relevance-weighted Gaussian
+kernel distance in tangent space:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\sum_j \\lambda_j v_j^2}{2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}` is the tangent vector,
+:math:`\\lambda = \\text{softmax}(\\text{relevances})`, and :math:`\\sigma_k`
+is a per-prototype bandwidth.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_srng import RiemannianSRNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.competitions import wtac
+from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.models.riemannian_srng import (
+    _so_log_map_diff, _spd_log_map_diff, _grassmannian_log_map_diff,
+)
+
+
+class RiemannianDKGRLVQ(RiemannianSRNG):
+    """Riemannian Differentiating Kernel GRLVQ.
+
+    Extends RiemannianSRNG with relevance-weighted Gaussian kernel
+    distance in tangent space. Each prototype :math:`w_k` has a learnable
+    bandwidth :math:`\\sigma_k`, and a shared relevance vector
+    :math:`\\lambda` weights the tangent space features.
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\sum_j \\lambda_j v_j^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance defining the geometry.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median geodesic distance.
+        'mean': per-class mean geodesic distance.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma to prevent bandwidth collapse. Default: 1e-3.
+    beta : float
+        Transfer function steepness parameter.
+    gamma_init : float, optional
+        Initial neighborhood range for NG cooperation.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step multiplicative decay factor for gamma.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold on loss change.
+    random_seed : int
+        Random seed for reproducibility.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping.
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        List of Callback objects.
+    use_scan : bool
+        If True, use jax.lax.scan. Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Keyword arguments for the learning rate scheduler.
+    prototypes_initializer : str or callable, optional
+        How to initialize prototypes.
+    patience : int, optional
+        Epochs with no improvement before stopping.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation steps.
+    ema_decay : float, optional
+        EMA decay for parameters.
+    freeze_params : list of str, optional
+        Parameter groups to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSRNG : Base Riemannian supervised Neural Gas.
+    RiemannianDKGLVQ : Gaussian kernel variant without relevance weighting.
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 beta=10.0, gamma_init=None, gamma_final=0.01,
+                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=False, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+        self.relevances_ = None
+
+    def _diff_log_map(self, w, x):
+        """Differentiable log map for a single (base, target) pair."""
+        if isinstance(self.manifold, SO):
+            return _so_log_map_diff(w, x)
+        elif isinstance(self.manifold, SPD):
+            return _spd_log_map_diff(w, x)
+        elif isinstance(self.manifold, Grassmannian):
+            return _grassmannian_log_map_diff(w, x)
+        else:
+            return self.manifold.log_map(w, x)
+
+    def _compute_tangent_vectors(self, X_manifold, W_manifold):
+        """Compute tangent vectors from prototypes to data via log map.
+
+        Parameters
+        ----------
+        X_manifold : array of shape (n_samples, *point_shape)
+        W_manifold : array of shape (n_prototypes, *point_shape)
+
+        Returns
+        -------
+        tangents_flat : array of shape (n_samples, n_prototypes, d_flat)
+        """
+        log_to_all_x = jax.vmap(self._diff_log_map, in_axes=(None, 0))
+        log_matrix = jax.vmap(log_to_all_x, in_axes=(0, None))
+        tangents = log_matrix(W_manifold, X_manifold)
+        tangents = jnp.moveaxis(tangents, 0, 1)
+        n = X_manifold.shape[0]
+        p = W_manifold.shape[0]
+        return tangents.reshape(n, p, -1)
+
+    def _estimate_sigmas(self, X_flat, y, prototypes_flat, proto_labels):
+        """Estimate per-prototype bandwidths from manifold distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(prototypes_flat.shape[0], float(self.sigma_init))
+
+        n_protos = prototypes_flat.shape[0]
+        n = X_flat.shape[0]
+        X_m = self._reshape_to_manifold(X_flat, n)
+        W_m = self._reshape_to_manifold(prototypes_flat, n_protos)
+
+        dist_matrix = self._geodesic_distances(X_m, W_m)
+
+        sigmas = []
+        for k in range(n_protos):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(dist_matrix[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        base['relevances'] = self.relevances_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        d_flat = X.shape[1]
+        sigmas = self._estimate_sigmas(X, y, params['prototypes'], proto_labels)
+        relevances = jnp.zeros(d_flat)  # uniform under softmax
+
+        params = {**params, 'sigmas': sigmas, 'relevances': relevances}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+        lam = jax.nn.softmax(params['relevances'])
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Tangent vectors via log map
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)  # (n, p, d_flat)
+
+        # 2. Relevance-weighted squared norms
+        weighted_sq = jnp.sum(
+            lam[None, None, :] * tangent_flat ** 2, axis=2
+        )  # (n, p)
+
+        # 3. Apply Gaussian kernel
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 4. Compute ranks within same-class prototypes
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        # 5. Neighborhood function h = exp(-rank / gamma)
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        # 6. Normalize per sample
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        # 7. Closest different-class prototype distance
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        # 8. GLVQ mu
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        # 9. Transfer function
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        # 10. Rank-weighted sum
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+        self.relevances_ = params['relevances']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    @property
+    def relevance_profile(self):
+        """Return the learned relevance weights (normalized via softmax)."""
+        if self.relevances_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return jax.nn.softmax(self.relevances_)
+
+    def predict(self, X):
+        """Predict using relevance-weighted kernel distance in tangent space.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        lam = jax.nn.softmax(self.relevances_)
+        weighted_sq = jnp.sum(
+            lam[None, None, :] * tangent_flat ** 2, axis=2
+        )
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-weighted_sq / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = {'prototypes_': self.prototypes_}
+        if self.sigmas_ is not None:
+            attrs['sigmas_'] = self.sigmas_
+        if self.relevances_ is not None:
+            attrs['relevances_'] = self.relevances_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        if self.relevances_ is not None:
+            arrays['relevances_'] = np.asarray(self.relevances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+        if 'relevances_' in arrays:
+            self.relevances_ = jnp.asarray(arrays['relevances_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/riemannian_dk_slng.py
+++ b/prosemble/models/riemannian_dk_slng.py
@@ -1,0 +1,319 @@
+"""
+Riemannian Differentiating Kernel SLNG (RiemannianDKSLNG).
+
+Combines RiemannianSLNG (per-prototype local omega metric in tangent space)
+with a Gaussian kernel wrapping for adaptive per-prototype bandwidth:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\|\\Omega_k \\cdot \\text{Log}_{w_k}(x)_{\\text{flat}}\\|^2}
+              {2\\sigma_k^2}
+    \\right)\\right)
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_slng import RiemannianSLNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKSLNG(RiemannianSLNG):
+    """Riemannian Differentiating Kernel SLNG.
+
+    Extends RiemannianSLNG with a Gaussian kernel wrapping the
+    per-prototype omega-projected tangent distance:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\|\\Omega_k \\cdot v\\|^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}` and each
+    prototype has its own metric matrix :math:`\\Omega_k` and bandwidth
+    :math:`\\sigma_k`.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median of local-omega distances.
+        'mean': per-class mean.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma. Default: 1e-3.
+    latent_dim : int, optional
+        Projection dimensionality for local omegas. Default: d_flat.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSLNG : Base Riemannian localized matrix Neural Gas.
+    RiemannianDKSMNG : Global omega + kernel variant.
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 latent_dim=None, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, latent_dim=latent_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+
+    def _estimate_sigmas(self, X, y, params, proto_labels):
+        """Estimate per-prototype bandwidths from local-omega distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(params['prototypes'].shape[0], float(self.sigma_init))
+
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, omegas)
+        raw_distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+
+        sigmas = []
+        for k in range(p):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(raw_distances[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        sigmas = self._estimate_sigmas(X, y, params, proto_labels)
+        params = {**params, 'sigmas': sigmas}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Per-prototype omega-projected tangent distance
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, omegas)
+        raw_distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+
+        # 2. Apply Gaussian kernel
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 3. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    def predict(self, X):
+        """Predict using kernel-wrapped local-omega tangent distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,pdl->npl', tangent_flat, self.omegas_)
+        raw_distances = jnp.sum(projected ** 2, axis=2)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.sigmas_ is not None:
+                attrs['sigmas_'] = self.sigmas_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/riemannian_dk_smng.py
+++ b/prosemble/models/riemannian_dk_smng.py
@@ -1,0 +1,319 @@
+"""
+Riemannian Differentiating Kernel SMNG (RiemannianDKSMNG).
+
+Combines RiemannianSMNG (global omega metric in tangent space) with a
+Gaussian kernel wrapping for adaptive per-prototype bandwidth:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\|\\Omega \\cdot \\text{Log}_{w_k}(x)_{\\text{flat}}\\|^2}
+              {2\\sigma_k^2}
+    \\right)\\right)
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_smng import RiemannianSMNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKSMNG(RiemannianSMNG):
+    """Riemannian Differentiating Kernel SMNG.
+
+    Extends RiemannianSMNG with a Gaussian kernel wrapping the
+    omega-projected tangent distance. Each prototype has a learnable
+    bandwidth :math:`\\sigma_k`:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\|\\Omega \\cdot v\\|^2}{2\\sigma_k^2}
+        \\right)\\right)
+
+    where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}`.
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median of omega-projected distances.
+        'mean': per-class mean.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma. Default: 1e-3.
+    latent_dim : int, optional
+        Projection dimensionality for omega. Default: d_flat.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSMNG : Base Riemannian matrix Neural Gas.
+    RiemannianDKGLVQ : Gaussian kernel on geodesic distance (no omega).
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 latent_dim=None, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, latent_dim=latent_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+
+    def _estimate_sigmas(self, X, y, params, proto_labels):
+        """Estimate per-prototype bandwidths from omega-projected distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(params['prototypes'].shape[0], float(self.sigma_init))
+
+        prototypes = params['prototypes']
+        omega = params['omega']
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, omega)
+        raw_distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+
+        sigmas = []
+        for k in range(p):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(raw_distances[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        sigmas = self._estimate_sigmas(X, y, params, proto_labels)
+        params = {**params, 'sigmas': sigmas}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omega = params['omega']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Omega-projected tangent distance
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, omega)
+        raw_distances = jnp.sum(projected ** 2, axis=2)  # (n, p)
+
+        # 2. Apply Gaussian kernel
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 3. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    def predict(self, X):
+        """Predict using kernel-wrapped omega-projected tangent distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        projected = jnp.einsum('npd,dl->npl', tangent_flat, self.omega_)
+        raw_distances = jnp.sum(projected ** 2, axis=2)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.sigmas_ is not None:
+                attrs['sigmas_'] = self.sigmas_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/prosemble/models/riemannian_dk_stng.py
+++ b/prosemble/models/riemannian_dk_stng.py
@@ -1,0 +1,328 @@
+"""
+Riemannian Differentiating Kernel STNG (RiemannianDKSTNG).
+
+Combines RiemannianSTNG (tangent subspace projection) with a Gaussian
+kernel wrapping for adaptive per-prototype bandwidth:
+
+.. math::
+
+    d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+        -\\frac{\\|(I - \\Omega_k \\Omega_k^T) \\cdot v\\|^2}
+              {2\\sigma_k^2}
+    \\right)\\right)
+
+where :math:`v = \\text{Log}_{w_k}(x)_{\\text{flat}}` and
+:math:`\\Omega_k` is the orthonormal tangent subspace basis.
+
+References
+----------
+.. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+       quantization in gradient-descent learning. Neurocomputing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.riemannian_stng import RiemannianSTNG
+from prosemble.models.prototype_base import SupervisedState
+from prosemble.core.activations import sigmoid_beta
+from prosemble.core.competitions import wtac
+
+
+class RiemannianDKSTNG(RiemannianSTNG):
+    """Riemannian Differentiating Kernel STNG.
+
+    Extends RiemannianSTNG with a Gaussian kernel wrapping the tangent
+    subspace residual distance. Each prototype has an orthonormal
+    subspace basis :math:`\\Omega_k` and a learnable bandwidth
+    :math:`\\sigma_k`:
+
+    .. math::
+
+        d_\\kappa^2(x, w_k) = 2\\left(1 - \\exp\\left(
+            -\\frac{\\|(I - \\Omega_k \\Omega_k^T) \\cdot v\\|^2}
+                  {2\\sigma_k^2}
+        \\right)\\right)
+
+    Parameters
+    ----------
+    manifold : SO, SPD, or Grassmannian
+        Riemannian manifold instance.
+    sigma_init : str or float
+        Initialization strategy for per-prototype bandwidths.
+        'median' (default): per-class median of subspace residual distances.
+        'mean': per-class mean.
+        float: fixed value for all prototypes.
+    sigma_min : float
+        Lower bound for sigma. Default: 1e-3.
+    subspace_dim : int, optional
+        Tangent subspace dimensionality. Default: d_flat - 1.
+    beta : float
+        Transfer function steepness.
+    gamma_init : float, optional
+        Initial neighborhood range.
+    gamma_final : float
+        Final neighborhood range. Default: 0.01.
+    gamma_decay : float, optional
+        Per-step decay factor.
+    tau : float
+        Injectivity radius safety factor. Default: 0.95.
+    n_prototypes_per_class : int
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer, optional
+        Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Callback objects.
+    use_scan : bool
+        Default: False.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        LR scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters. Default: False.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameters.
+    lookahead : dict, optional
+        Lookahead config.
+    mixed_precision : str or None, optional
+        Mixed precision dtype.
+
+    References
+    ----------
+    .. [1] Villmann, T., Haase, S., & Kaden, M. (2015). Kernelized vector
+           quantization in gradient-descent learning. Neurocomputing.
+
+    See Also
+    --------
+    RiemannianSTNG : Base Riemannian tangent Neural Gas.
+    RiemannianDKSMNG : Global omega + kernel variant.
+    RiemannianDKSLNG : Local omega + kernel variant.
+    """
+
+    def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
+                 subspace_dim=None, beta=10.0, gamma_init=None,
+                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 n_prototypes_per_class=1, max_iter=100, lr=0.01,
+                 epsilon=1e-6, random_seed=42, optimizer='adam',
+                 transfer_fn=None, margin=0.0, callbacks=None,
+                 use_scan=False, batch_size=None, lr_scheduler=None,
+                 lr_scheduler_kwargs=None, prototypes_initializer=None,
+                 patience=None, restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            manifold=manifold, subspace_dim=subspace_dim, beta=beta,
+            gamma_init=gamma_init, gamma_final=gamma_final,
+            gamma_decay=gamma_decay, tau=tau,
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, optimizer=optimizer,
+            transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan,
+            batch_size=batch_size, lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.sigma_init = sigma_init
+        self.sigma_min = sigma_min
+        self.sigmas_ = None
+
+    def _estimate_sigmas(self, X, y, params, proto_labels):
+        """Estimate per-prototype bandwidths from subspace residual distances."""
+        if isinstance(self.sigma_init, (int, float)):
+            return jnp.full(params['prototypes'].shape[0], float(self.sigma_init))
+
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, omegas)
+        recon = jnp.einsum('nps,pds->npd', proj, omegas)
+        residual = tangent_flat - recon
+        raw_distances = jnp.sum(residual ** 2, axis=2)  # (n, p)
+
+        sigmas = []
+        for k in range(p):
+            label_k = proto_labels[k]
+            class_mask = (y == label_k)
+            dists_k = jnp.sqrt(jnp.maximum(raw_distances[class_mask, k], 0.0))
+            if self.sigma_init == 'median':
+                sigma_k = jnp.median(dists_k)
+            else:
+                sigma_k = jnp.mean(dists_k)
+            sigmas.append(jnp.maximum(sigma_k, self.sigma_min))
+        return jnp.array(sigmas)
+
+    def _get_resume_params(self, params):
+        base = super()._get_resume_params(params)
+        base['sigmas'] = self.sigmas_
+        return base
+
+    def _init_state(self, X, y, key):
+        state, params, proto_labels = super()._init_state(X, y, key)
+
+        sigmas = self._estimate_sigmas(X, y, params, proto_labels)
+        params = {**params, 'sigmas': sigmas}
+
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=params['prototypes'],
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        prototypes = params['prototypes']
+        omegas = params['omegas']
+        gamma = params['gamma']
+        sigmas = jnp.maximum(params['sigmas'], self.sigma_min)
+
+        n = X.shape[0]
+        p = prototypes.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(prototypes, p)
+
+        # 1. Tangent subspace residual distance
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, omegas)
+        recon = jnp.einsum('nps,pds->npd', proj, omegas)
+        residual = tangent_flat - recon
+        raw_distances = jnp.sum(residual ** 2, axis=2)  # (n, p)
+
+        # 2. Apply Gaussian kernel
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        # 3. NG ranking + GLVQ loss
+        same_class = (y[:, None] == proto_labels[None, :])
+        INF = jnp.finfo(distances.dtype).max
+        d_same = jnp.where(same_class, distances, INF)
+
+        order = jnp.argsort(d_same, axis=1)
+        ranks = jnp.argsort(order, axis=1).astype(jnp.float32)
+
+        h = jnp.exp(-ranks / (gamma + 1e-10))
+        h = jnp.where(same_class, h, 0.0)
+
+        C = jnp.sum(h, axis=1, keepdims=True)
+        h_normalized = h / (C + 1e-10)
+
+        d_diff = jnp.where(~same_class, distances, INF)
+        dm = jnp.min(d_diff, axis=1)
+
+        mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
+
+        transfer = self.transfer_fn or sigmoid_beta
+        cost = transfer(mu + self.margin, self.beta)
+
+        weighted_cost = jnp.sum(h_normalized * cost, axis=1)
+        return jnp.mean(weighted_cost)
+
+    def _post_update(self, params):
+        params = super()._post_update(params)
+        params['sigmas'] = jnp.maximum(params['sigmas'], self.sigma_min)
+        return params
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.sigmas_ = params['sigmas']
+
+    @property
+    def kernel_bandwidths(self):
+        """Return the learned per-prototype bandwidths."""
+        if self.sigmas_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.sigmas_
+
+    def predict(self, X):
+        """Predict using kernel-wrapped subspace residual distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features_flat)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        n = X.shape[0]
+        p = self.prototypes_.shape[0]
+        X_m = self._reshape_to_manifold(X, n)
+        W_m = self._reshape_to_manifold(self.prototypes_, p)
+
+        tangent_flat = self._compute_tangent_vectors(X_m, W_m)
+        proj = jnp.einsum('npd,pds->nps', tangent_flat, self.omegas_)
+        recon = jnp.einsum('nps,pds->npd', proj, self.omegas_)
+        residual = tangent_flat - recon
+        raw_distances = jnp.sum(residual ** 2, axis=2)
+
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        K = jnp.exp(-raw_distances / (2.0 * sigmas[None, :] ** 2))
+        distances = 2.0 * (1.0 - K)
+
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if isinstance(attrs, dict):
+            if self.sigmas_ is not None:
+                attrs['sigmas_'] = self.sigmas_
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.sigmas_ is not None:
+            arrays['sigmas_'] = np.asarray(self.sigmas_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'sigmas_' in arrays:
+            self.sigmas_ = jnp.asarray(arrays['sigmas_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['sigma_init'] = self.sigma_init
+        hp['sigma_min'] = self.sigma_min
+        return hp

--- a/sphinx-docs/api/models.rst
+++ b/sphinx-docs/api/models.rst
@@ -450,6 +450,57 @@ Riemannian Models
    :members: fit, predict, transform
    :undoc-members:
 
+Riemannian Differentiating Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: prosemble.models.RiemannianDKGLVQ
+   :members: fit, predict, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKGRLVQ
+   :members: fit, predict, kernel_bandwidths, relevance_profile
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKGMLVQ
+   :members: fit, predict, omega_hat_matrix, lambda_hat_matrix
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKSMNG
+   :members: fit, predict, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKSLNG
+   :members: fit, predict, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKSTNG
+   :members: fit, predict, kernel_bandwidths
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKRSMNG
+   :members: fit, predict, kernel_bandwidths, relevance_profile
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKMSMNG
+   :members: fit, predict, omega_hat_matrix, lambda_hat_matrix
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKRSLNG
+   :members: fit, predict, kernel_bandwidths, relevance_profile
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKMSLNG
+   :members: fit, predict, omega_hat_matrix, lambda_hat_matrix
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKRSTNG
+   :members: fit, predict, kernel_bandwidths, relevance_profile
+   :undoc-members:
+
+.. autoclass:: prosemble.models.RiemannianDKMSTNG
+   :members: fit, predict, omega_hat_matrix, lambda_hat_matrix
+   :undoc-members:
+
 Utility Models
 --------------
 

--- a/sphinx-docs/guides/differentiating_kernels.rst
+++ b/sphinx-docs/guides/differentiating_kernels.rst
@@ -513,6 +513,80 @@ Choosing a Model
      - :math:`w_k`
      - Principled SOM with kernel distance
 
+Riemannian Variants
+-------------------
+
+Differentiating kernel distances can also be applied on Riemannian manifolds.
+Three models combine the RiemannianSRNG framework (prototypes on manifold,
+NG rank cooperation, manifold projection) with kernel distance formulas:
+
+- **RiemannianDKGLVQ** — Gaussian kernel on geodesic distance:
+  :math:`d_\kappa^2(x, w_k) = 2(1 - \exp(-d_{\text{geo}}^2(x, w_k) / 2\sigma_k^2))`
+- **RiemannianDKGRLVQ** — Relevance-weighted kernel in tangent space:
+  :math:`d_\kappa^2(x, w_k) = 2(1 - \exp(-\sum_j \lambda_j v_j^2 / 2\sigma_k^2))`
+  where :math:`v = \text{Log}_{w_k}(x)_{\text{flat}}`
+- **RiemannianDKGMLVQ** — Exponential kernel in tangent space:
+  :math:`d_\kappa^2(x, w_k) = \exp(v^T \hat\Lambda v) - 1`
+  where :math:`\hat\Lambda = \hat\Omega \hat\Omega^T`
+
+All three support SO(n), SPD(n), and Grassmannian(n,k) manifolds.
+
+.. code-block:: python
+
+   from prosemble.core.manifolds import SO
+   from prosemble.models import RiemannianDKGLVQ
+
+   manifold = SO(3)
+   model = RiemannianDKGLVQ(
+       manifold=manifold, n_prototypes_per_class=2,
+       max_iter=100, lr=0.01, use_scan=False,
+   )
+   model.fit(X_train, y_train)
+   preds = model.predict(X_test)
+
+   # Inspect learned bandwidths
+   print(model.kernel_bandwidths)
+
+Riemannian Metric-Adapted DK Variants
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Nine additional models combine metric adaptation (global/local/subspace) with
+kernel distance learning on Riemannian manifolds, completing a 3x3 grid
+(Gaussian/Relevance/Matrix kernels x SMNG/SLNG/STNG bases):
+
+**Gaussian kernel variants** (per-prototype :math:`\sigma_k`):
+
+- **RiemannianDKSMNG** — :math:`d_\kappa^2 = 2(1 - \exp(-\|\Omega \cdot v\|^2 / 2\sigma_k^2))`
+- **RiemannianDKSLNG** — :math:`d_\kappa^2 = 2(1 - \exp(-\|\Omega_k \cdot v\|^2 / 2\sigma_k^2))`
+- **RiemannianDKSTNG** — :math:`d_\kappa^2 = 2(1 - \exp(-\|(I - \Omega_k\Omega_k^T) \cdot v\|^2 / 2\sigma_k^2))`
+
+**Relevance kernel variants** (:math:`\sigma_k` + relevance :math:`\lambda`):
+
+- **RiemannianDKRSMNG** — :math:`d_\kappa^2 = 2(1 - \exp(-\sum_j \lambda_j (\Omega \cdot v)_j^2 / 2\sigma_k^2))`
+- **RiemannianDKRSLNG** — :math:`d_\kappa^2 = 2(1 - \exp(-\sum_j \lambda_j (\Omega_k \cdot v)_j^2 / 2\sigma_k^2))`
+- **RiemannianDKRSTNG** — :math:`d_\kappa^2 = 2(1 - \exp(-\sum_j \lambda_j r_j^2 / 2\sigma_k^2))`
+
+**Matrix kernel variants** (exponential with :math:`\hat\Lambda = \hat\Omega\hat\Omega^T`):
+
+- **RiemannianDKMSMNG** — :math:`d_\kappa^2 = \exp((\Omega \cdot v)^T \hat\Lambda (\Omega \cdot v)) - 1`
+- **RiemannianDKMSLNG** — :math:`d_\kappa^2 = \exp((\Omega_k \cdot v)^T \hat\Lambda (\Omega_k \cdot v)) - 1`
+- **RiemannianDKMSTNG** — :math:`d_\kappa^2 = \exp(r^T \hat\Lambda r) - 1`
+
+.. code-block:: python
+
+   from prosemble.core.manifolds import Grassmannian
+   from prosemble.models import RiemannianDKRSMNG
+
+   manifold = Grassmannian(4, 2)
+   model = RiemannianDKRSMNG(
+       manifold=manifold, n_prototypes_per_class=2,
+       max_iter=100, lr=0.01, use_scan=False,
+   )
+   model.fit(X_train, y_train)
+   preds = model.predict(X_test)
+   print(model.kernel_bandwidths)
+   print(model.relevance_profile)
+
 ONNX Export
 -----------
 

--- a/tests/test_riemannian_dk_models.py
+++ b/tests/test_riemannian_dk_models.py
@@ -1,0 +1,1043 @@
+"""Tests for Riemannian Differentiating Kernel models."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tempfile
+import os
+
+from prosemble.core.manifolds import SO, Grassmannian
+from prosemble.models import (
+    RiemannianDKGLVQ, RiemannianDKGRLVQ, RiemannianDKGMLVQ,
+    RiemannianDKSMNG, RiemannianDKSLNG, RiemannianDKSTNG,
+    RiemannianDKRSMNG, RiemannianDKMSMNG,
+    RiemannianDKRSLNG, RiemannianDKMSLNG,
+    RiemannianDKRSTNG, RiemannianDKMSTNG,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: generate labeled manifold data
+# ---------------------------------------------------------------------------
+
+def _make_so3_data(n_per_class=10, seed=0):
+    """Two classes of SO(3) rotations."""
+    manifold = SO(3)
+    keys = jax.random.split(jax.random.PRNGKey(seed), n_per_class * 2)
+    points = jnp.stack([manifold.random_point(k) for k in keys])
+    X_flat = points.reshape(n_per_class * 2, -1)
+    y = jnp.array([0] * n_per_class + [1] * n_per_class)
+    return manifold, X_flat, y
+
+
+def _make_gr42_data(n_per_class=10, seed=0):
+    """Two classes of Grassmannian(4,2) points."""
+    manifold = Grassmannian(4, 2)
+    keys = jax.random.split(jax.random.PRNGKey(seed), n_per_class * 2)
+    points = jnp.stack([manifold.random_point(k) for k in keys])
+    X_flat = points.reshape(n_per_class * 2, -1)
+    y = jnp.array([0] * n_per_class + [1] * n_per_class)
+    return manifold, X_flat, y
+
+
+MANIFOLD_DATA = [
+    pytest.param(_make_so3_data, id='SO3'),
+    pytest.param(_make_gr42_data, id='Gr42'),
+]
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKGLVQ
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKGLVQ:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_prototypes_on_manifold(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos_m = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            projected = manifold.project(protos_m[i])
+            np.testing.assert_allclose(
+                np.asarray(protos_m[i]), np.asarray(projected),
+                atol=1e-4,
+            )
+
+    def test_gamma_decays(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+            gamma_init=5.0, gamma_final=0.01,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 5.0
+        assert model.gamma_ >= 0.01
+
+    def test_sigmas_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)  # 2 protos * 2 classes
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_sigma_init_fixed(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+            sigma_init=1.0,
+        )
+        model.fit(X, y)
+        assert model.sigmas_ is not None
+
+    def test_kernel_bandwidths_property(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (2,)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKGLVQ.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKGRLVQ
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKGRLVQ:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_prototypes_on_manifold(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos_m = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            projected = manifold.project(protos_m[i])
+            np.testing.assert_allclose(
+                np.asarray(protos_m[i]), np.asarray(projected),
+                atol=1e-4,
+            )
+
+    def test_gamma_decays(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+            gamma_init=5.0, gamma_final=0.01,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 5.0
+        assert model.gamma_ >= 0.01
+
+    def test_sigmas_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_relevances_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        d_flat = X.shape[1]
+        assert model.relevances_.shape == (d_flat,)
+
+    def test_relevance_profile_sums_to_one(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        profile = model.relevance_profile
+        np.testing.assert_allclose(float(jnp.sum(profile)), 1.0, atol=1e-5)
+
+    def test_kernel_bandwidths_property(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (2,)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGRLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKGRLVQ.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKGMLVQ
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKGMLVQ:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_prototypes_on_manifold(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos_m = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            projected = manifold.project(protos_m[i])
+            np.testing.assert_allclose(
+                np.asarray(protos_m[i]), np.asarray(projected),
+                atol=1e-4,
+            )
+
+    def test_gamma_decays(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+            gamma_init=5.0, gamma_final=0.01,
+        )
+        model.fit(X, y)
+        assert model.gamma_ < 5.0
+        assert model.gamma_ >= 0.01
+
+    def test_omega_hat_learned(self):
+        manifold, X, y = _make_so3_data()
+        d_flat = X.shape[1]
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_hat_.shape == (d_flat, d_flat)
+
+    def test_omega_hat_matrix_property(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        oh = model.omega_hat_matrix
+        assert oh.shape[0] == X.shape[1]
+
+    def test_lambda_hat_psd(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        lh = model.lambda_hat_matrix
+        eigvals = jnp.linalg.eigvalsh(lh)
+        assert jnp.all(eigvals >= -1e-6)
+
+    def test_latent_dim(self):
+        manifold, X, y = _make_so3_data()
+        d_flat = X.shape[1]
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+            latent_dim=4,
+        )
+        model.fit(X, y)
+        assert model.omega_hat_.shape == (d_flat, 4)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKGMLVQ(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKGMLVQ.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKSMNG
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKSMNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKSMNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_sigmas_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSMNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_omega_and_sigmas_both_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_ is not None
+        assert model.sigmas_ is not None
+
+    def test_kernel_bandwidths_property(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (2,)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKSMNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKSLNG
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKSLNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKSLNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_sigmas_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSLNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_omegas_and_sigmas_both_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omegas_ is not None
+        assert model.sigmas_ is not None
+
+    def test_kernel_bandwidths_property(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (2,)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKSLNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKSTNG
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKSTNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKSTNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_sigmas_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSTNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+
+    def test_omegas_and_sigmas_both_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omegas_ is not None
+        assert model.sigmas_ is not None
+
+    def test_kernel_bandwidths_property(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=5, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        bw = model.kernel_bandwidths
+        assert bw.shape == (2,)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKSTNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKRSMNG (Relevance kernel + SMNG base)
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKRSMNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKRSMNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKRSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_sigmas_and_relevances_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSMNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+        assert model.relevances_ is not None
+
+    def test_relevance_profile_sums_to_one(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        profile = model.relevance_profile
+        np.testing.assert_allclose(float(jnp.sum(profile)), 1.0, atol=1e-5)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKRSMNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKMSMNG (Matrix kernel + SMNG base)
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKMSMNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKMSMNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKMSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_omega_hat_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_hat_ is not None
+        # omega_hat operates in projected (latent) space
+        proj_dim = model.omega_.shape[1]
+        assert model.omega_hat_.shape == (proj_dim, proj_dim)
+
+    def test_lambda_hat_psd(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        lh = model.lambda_hat_matrix
+        eigvals = jnp.linalg.eigvalsh(lh)
+        assert jnp.all(eigvals >= -1e-6)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKMSMNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKRSLNG (Relevance kernel + SLNG base)
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKRSLNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKRSLNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKRSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_sigmas_and_relevances_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSLNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+        assert model.relevances_ is not None
+
+    def test_relevance_profile_sums_to_one(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        profile = model.relevance_profile
+        np.testing.assert_allclose(float(jnp.sum(profile)), 1.0, atol=1e-5)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKRSLNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKMSLNG (Matrix kernel + SLNG base)
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKMSLNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKMSLNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKMSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_omega_hat_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_hat_ is not None
+        # omega_hat operates in projected (latent) space
+        proj_dim = model.omegas_.shape[2]
+        assert model.omega_hat_.shape == (proj_dim, proj_dim)
+
+    def test_lambda_hat_psd(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        lh = model.lambda_hat_matrix
+        eigvals = jnp.linalg.eigvalsh(lh)
+        assert jnp.all(eigvals >= -1e-6)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSLNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKMSLNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKRSTNG (Relevance kernel + STNG base)
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKRSTNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKRSTNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKRSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_sigmas_and_relevances_learned(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSTNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.sigmas_.shape == (4,)
+        assert jnp.all(model.sigmas_ > 0)
+        assert model.relevances_ is not None
+        d_flat = X.shape[1]
+        assert model.relevances_.shape == (d_flat,)
+
+    def test_relevance_profile_sums_to_one(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        profile = model.relevance_profile
+        np.testing.assert_allclose(float(jnp.sum(profile)), 1.0, atol=1e-5)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKRSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKRSTNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )
+
+
+# ---------------------------------------------------------------------------
+# RiemannianDKMSTNG (Matrix kernel + STNG base)
+# ---------------------------------------------------------------------------
+
+class TestRiemannianDKMSTNG:
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_fit_loss_decreases(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKMSTNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    @pytest.mark.parametrize('make_data', MANIFOLD_DATA)
+    def test_predict_returns_valid_labels(self, make_data):
+        manifold, X, y = make_data()
+        model = RiemannianDKMSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        assert set(np.asarray(preds)).issubset({0, 1})
+
+    def test_omega_hat_learned(self):
+        manifold, X, y = _make_so3_data()
+        d_flat = X.shape[1]
+        model = RiemannianDKMSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_hat_ is not None
+        # omega_hat operates on residual (d_flat space)
+        assert model.omega_hat_.shape == (d_flat, d_flat)
+
+    def test_lambda_hat_psd(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        lh = model.lambda_hat_matrix
+        eigvals = jnp.linalg.eigvalsh(lh)
+        assert jnp.all(eigvals >= -1e-6)
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_so3_data()
+        model = RiemannianDKMSTNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.pkl')
+            model.save(path)
+            loaded = RiemannianDKMSTNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(
+            np.asarray(preds_before), np.asarray(preds_after)
+        )


### PR DESCRIPTION
## Summary

- Implements the full 3×4 grid of Riemannian Differentiating Kernel models combining 3 kernel types (Gaussian, Relevance, Matrix) with 4 base models (SRNG, SMNG, SLNG, STNG)
- All 12 models support SO(n), SPD(n), and Grassmannian(n,k) manifolds
- Matrix kernel variants include exponent clamping (`jnp.clip(exponent, None, 20.0)`) for numerical stability

### Models Added

| Base \ Kernel | Gaussian (σ) | Relevance (σ+λ) | Matrix (Ω̂) |
|---|---|---|---|
| SRNG | RiemannianDKGLVQ | RiemannianDKGRLVQ | RiemannianDKGMLVQ |
| SMNG | RiemannianDKSMNG | RiemannianDKRSMNG | RiemannianDKMSMNG |
| SLNG | RiemannianDKSLNG | RiemannianDKRSLNG | RiemannianDKMSLNG |
| STNG | RiemannianDKSTNG | RiemannianDKRSTNG | RiemannianDKMSTNG |

### Files Changed

- 12 new model files in `prosemble/models/`
- `prosemble/models/__init__.py` — imports, registry, exports
- `tests/test_riemannian_dk_models.py` — 101 tests (all passing)
- `sphinx-docs/api/models.rst` — API reference entries
- `sphinx-docs/guides/differentiating_kernels.rst` — user guide section

## Test plan

- [x] All 101 Riemannian DK model tests pass (`pytest tests/test_riemannian_dk_models.py`)
- [x] Loss decreases during training for all models on SO(3) and Grassmannian(4,2)
- [x] Predictions return valid class labels
- [x] Model-specific properties verified (sigma positivity, relevance sums to 1, lambda_hat PSD)
- [x] Save/load roundtrip works for all models
- [x] Numerical stability verified at 200 iterations (no NaN)