### PR TITLE
feat: ONNX export with reject option for supervised models

### DIFF
--- a/prosemble/core/onnx_export.py
+++ b/prosemble/core/onnx_export.py
@@ -1457,6 +1457,121 @@ def _wtac_onnx_nodes(dist_name, proto_labels_name):
     return nodes, []
 
 
+def _wtac_with_rejection_onnx_nodes(dist_name, proto_labels_name, threshold):
+    """WTAC with reject option: confidence-based rejection.
+
+    Computes:
+        winner_label = proto_labels[argmin(distances, axis=1)]
+        d_plus = min distance to same-class prototype (winner's class)
+        d_minus = min distance to different-class prototype
+        confidence = (d_minus - d_plus) / (d_minus + d_plus + eps)
+        predictions = where(confidence >= threshold, winner_label, -1)
+
+    Outputs two tensors: 'predictions' (INT64) and 'confidence' (FLOAT).
+    """
+    import onnx.helper as oh
+    from onnx import TensorProto
+
+    nodes = []
+    inits = []
+
+    # Constants
+    inits.extend([
+        oh.make_tensor('_rej_eps', TensorProto.FLOAT, [], [1e-10]),
+        oh.make_tensor('_rej_threshold', TensorProto.FLOAT, [], [float(threshold)]),
+        oh.make_tensor('_rej_inf', TensorProto.FLOAT, [], [1e30]),
+        oh.make_tensor('_rej_neg_one', TensorProto.INT64, [], [-1]),
+    ])
+
+    # Step 1: winner_idx = argmin(distances, axis=1) → (batch,)
+    nodes.append(oh.make_node(
+        'ArgMin', [dist_name], ['_rej_winner_idx'],
+        axis=1, keepdims=0,
+    ))
+    nodes.append(oh.make_node(
+        'Cast', ['_rej_winner_idx'], ['_rej_winner_idx_i64'],
+        to=TensorProto.INT64,
+    ))
+
+    # Step 2: winner_label = proto_labels[winner_idx] → (batch,)
+    nodes.append(oh.make_node(
+        'Gather', [proto_labels_name, '_rej_winner_idx_i64'], ['_rej_winner_label'],
+        axis=0,
+    ))
+
+    # Step 3: Build same-class mask
+    # Unsqueeze winner_label to (batch, 1) for broadcasting
+    nodes.append(oh.make_node(
+        'Unsqueeze', ['_rej_winner_label', '_rej_unsqueeze_axis'], ['_rej_winner_label_2d'],
+    ))
+    inits.append(
+        oh.make_tensor('_rej_unsqueeze_axis', TensorProto.INT64, [1], [1]),
+    )
+    # Unsqueeze proto_labels to (1, n_protos) for broadcasting
+    nodes.append(oh.make_node(
+        'Unsqueeze', [proto_labels_name, '_rej_unsqueeze_axis0'], ['_rej_proto_labels_2d'],
+    ))
+    inits.append(
+        oh.make_tensor('_rej_unsqueeze_axis0', TensorProto.INT64, [1], [0]),
+    )
+    # same_mask = (winner_label == proto_labels) → (batch, n_protos)
+    nodes.append(oh.make_node(
+        'Equal', ['_rej_winner_label_2d', '_rej_proto_labels_2d'], ['_rej_same_mask'],
+    ))
+    # diff_mask = NOT same_mask
+    nodes.append(oh.make_node(
+        'Not', ['_rej_same_mask'], ['_rej_diff_mask'],
+    ))
+
+    # Step 4: d_plus = min(where(same_mask, distances, INF), axis=1)
+    # Use Add with large constant to create INF-filled tensor matching dist shape
+    # Where broadcasts scalars automatically against the mask shape
+    nodes.append(oh.make_node(
+        'Where', ['_rej_same_mask', dist_name, '_rej_inf'],
+        ['_rej_dist_same'],
+    ))
+    nodes.append(oh.make_node(
+        'ReduceMin', ['_rej_dist_same'], ['_rej_d_plus'],
+        axes=[1], keepdims=0,
+    ))
+
+    # Step 5: d_minus = min(where(diff_mask, distances, INF), axis=1)
+    nodes.append(oh.make_node(
+        'Where', ['_rej_diff_mask', dist_name, '_rej_inf'],
+        ['_rej_dist_diff'],
+    ))
+    nodes.append(oh.make_node(
+        'ReduceMin', ['_rej_dist_diff'], ['_rej_d_minus'],
+        axes=[1], keepdims=0,
+    ))
+
+    # Step 6: confidence = (d_minus - d_plus) / (d_minus + d_plus + eps)
+    nodes.append(oh.make_node(
+        'Sub', ['_rej_d_minus', '_rej_d_plus'], ['_rej_numerator'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_rej_d_minus', '_rej_d_plus'], ['_rej_denom_raw'],
+    ))
+    nodes.append(oh.make_node(
+        'Add', ['_rej_denom_raw', '_rej_eps'], ['_rej_denominator'],
+    ))
+    nodes.append(oh.make_node(
+        'Div', ['_rej_numerator', '_rej_denominator'], ['confidence'],
+    ))
+
+    # Step 7: predictions = where(confidence >= threshold, winner_label, -1)
+    nodes.append(oh.make_node(
+        'GreaterOrEqual', ['confidence', '_rej_threshold'], ['_rej_accept_mask'],
+    ))
+    # Where broadcasts scalar _rej_neg_one against _rej_winner_label shape
+    nodes.append(oh.make_node(
+        'Where', ['_rej_accept_mask', '_rej_winner_label', '_rej_neg_one'],
+        ['predictions'],
+    ))
+
+    return nodes, inits
+
+
 def _argmin_onnx_nodes(dist_name):
     """Unsupervised: predictions = argmin(distances, axis=1)."""
     import onnx.helper as oh
@@ -2374,6 +2489,7 @@ def export_onnx(
     batch_size: int = 1,
     opset_version: int = 17,
     path: str | None = None,
+    reject_threshold: float | None = None,
 ):
     """Export a fitted model's predict function to ONNX format.
 
@@ -2396,6 +2512,13 @@ def export_onnx(
         ONNX opset version.  Default: 17.
     path : str, optional
         If provided, save the ONNX model to this file path.
+    reject_threshold : float, optional
+        If provided, enables reject option for supervised models.
+        Samples with confidence below this threshold are assigned
+        prediction -1 (rejected). The exported model produces two
+        outputs: ``predictions`` (INT64, with -1 for rejected) and
+        ``confidence`` (FLOAT, in [-1, 1]).
+        Only supported for supervised models (WTAC decision).
 
     Returns
     -------
@@ -2409,6 +2532,8 @@ def export_onnx(
         supported.
     ImportError
         If the ``onnx`` package is not installed.
+    ValueError
+        If ``reject_threshold`` is used with a non-supervised model.
     """
     _check_onnx_installed()
     import onnx
@@ -2649,7 +2774,18 @@ def export_onnx(
     initializers.extend(extra_inits)
 
     # --- Decision / competition nodes ---
-    if model_type == 'supervised':
+    use_rejection = reject_threshold is not None
+
+    if use_rejection:
+        if model_type != 'supervised':
+            raise ValueError(
+                "reject_threshold is only supported for supervised models "
+                f"(WTAC decision), got model_type='{model_type}'."
+            )
+        comp_nodes, comp_inits = _wtac_with_rejection_onnx_nodes(
+            dist_out, 'proto_labels', reject_threshold,
+        )
+    elif model_type == 'supervised':
         comp_nodes, comp_inits = _wtac_onnx_nodes(dist_out, 'proto_labels')
     elif model_type == 'unsupervised':
         comp_nodes, comp_inits = _argmin_onnx_nodes(dist_out)
@@ -2687,11 +2823,18 @@ def export_onnx(
         'predictions', output_dtype, [batch_dim],
     )
 
+    outputs = [Y_output]
+    if use_rejection:
+        conf_output = oh.make_tensor_value_info(
+            'confidence', TensorProto.FLOAT, [batch_dim],
+        )
+        outputs.append(conf_output)
+
     graph = oh.make_graph(
         all_nodes,
         'prosemble_predict',
         [X_input],
-        [Y_output],
+        outputs,
         initializer=initializers,
     )
 

--- a/prosemble/models/dk_glvq.py
+++ b/prosemble/models/dk_glvq.py
@@ -212,6 +212,11 @@ class DKGLVQ(SupervisedPrototypeModel):
             raise ValueError("Model not fitted. Call fit() first.")
         return self.sigmas_
 
+    def _compute_distances_for_rejection(self, X):
+        """Kernel distances for reject option."""
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        return kernel_distance_squared_per_proto(X, self.prototypes_, sigmas)
+
     def predict(self, X):
         """Predict using learned kernel distance."""
         self._check_fitted()

--- a/prosemble/models/dk_glvq_ng.py
+++ b/prosemble/models/dk_glvq_ng.py
@@ -303,6 +303,11 @@ class DKGLVQ_NG(SupervisedPrototypeModel):
         self.sigmas_ = params['sigmas']
         self.gamma_ = float(params['gamma'])
 
+    def _compute_distances_for_rejection(self, X):
+        """Kernel distances for reject option."""
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        return kernel_distance_squared_per_proto(X, self.prototypes_, sigmas)
+
     def predict(self, X):
         """Predict using learned kernel distance."""
         self._check_fitted()

--- a/prosemble/models/dk_matrix_lvq.py
+++ b/prosemble/models/dk_matrix_lvq.py
@@ -214,6 +214,10 @@ class DKGMLVQ(SupervisedPrototypeModel):
             raise ValueError("Model not fitted.")
         return self.omega_hat_ @ self.omega_hat_.T
 
+    def _compute_distances_for_rejection(self, X):
+        """Exponential kernel distances for reject option."""
+        return exponential_kernel_distance_squared(X, self.prototypes_, self.omega_hat_)
+
     def predict(self, X):
         """Predict using learned exponential kernel distance."""
         self._check_fitted()

--- a/prosemble/models/dk_matrix_lvq_ng.py
+++ b/prosemble/models/dk_matrix_lvq_ng.py
@@ -277,6 +277,10 @@ class DKGMLVQ_NG(SupervisedPrototypeModel):
         self.omega_hat_ = params['omega_hat']
         self.gamma_ = float(params['gamma'])
 
+    def _compute_distances_for_rejection(self, X):
+        """Exponential kernel distances for reject option."""
+        return exponential_kernel_distance_squared(X, self.prototypes_, self.omega_hat_)
+
     def predict(self, X):
         """Predict using learned exponential kernel distance."""
         self._check_fitted()

--- a/prosemble/models/dk_relevance_lvq.py
+++ b/prosemble/models/dk_relevance_lvq.py
@@ -234,6 +234,12 @@ class DKGRLVQ(SupervisedPrototypeModel):
             raise ValueError("Model not fitted. Call fit() first.")
         return self.sigmas_
 
+    def _compute_distances_for_rejection(self, X):
+        """Relevance kernel distances for reject option."""
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        lam = jax.nn.softmax(self.relevances_)
+        return kernel_distance_squared_relevance(X, self.prototypes_, sigmas, lam)
+
     def predict(self, X):
         """Predict using learned kernel distance with relevance weighting."""
         self._check_fitted()

--- a/prosemble/models/dk_relevance_lvq_ng.py
+++ b/prosemble/models/dk_relevance_lvq_ng.py
@@ -309,6 +309,12 @@ class DKGRLVQ_NG(SupervisedPrototypeModel):
         self.relevances_ = params['relevances']  # raw logits
         self.gamma_ = float(params['gamma'])
 
+    def _compute_distances_for_rejection(self, X):
+        """Relevance kernel distances for reject option."""
+        sigmas = jnp.maximum(self.sigmas_, self.sigma_min)
+        lam = jax.nn.softmax(self.relevances_)
+        return kernel_distance_squared_relevance(X, self.prototypes_, sigmas, lam)
+
     def predict(self, X):
         """Predict using learned relevance-weighted kernel distance."""
         self._check_fitted()

--- a/prosemble/models/local_matrix_lvq.py
+++ b/prosemble/models/local_matrix_lvq.py
@@ -196,6 +196,12 @@ class LGMLVQ(SupervisedPrototypeModel):
             beta=self.beta,
         )
 
+    def _compute_distances_for_rejection(self, X):
+        """Local omega-projected distances for reject option."""
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        projected = jnp.einsum('npd,pdl->npl', diff, self.omegas_)
+        return jnp.sum(projected ** 2, axis=2)
+
     def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
         super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
         self.omegas_ = params['omegas']

--- a/prosemble/models/matrix_lvq.py
+++ b/prosemble/models/matrix_lvq.py
@@ -200,6 +200,12 @@ class GMLVQ(SupervisedPrototypeModel):
             beta=self.beta,
         )
 
+    def _compute_distances_for_rejection(self, X):
+        """Omega-projected distances for reject option."""
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        projected = jnp.einsum('npd,dl->npl', diff, self.omega_)
+        return jnp.sum(projected ** 2, axis=2)
+
     def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
         super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
         self.omega_ = params['omega']

--- a/prosemble/models/relevance_lvq.py
+++ b/prosemble/models/relevance_lvq.py
@@ -175,6 +175,11 @@ class GRLVQ(SupervisedPrototypeModel):
             beta=self.beta,
         )
 
+    def _compute_distances_for_rejection(self, X):
+        """Relevance-weighted distances for reject option."""
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        return jnp.sum(self.relevances_[None, None, :] * diff ** 2, axis=2)
+
     def _post_update(self, params):
         # No explicit constraint needed since we use softmax in loss
         return params

--- a/prosemble/models/tangent_lvq.py
+++ b/prosemble/models/tangent_lvq.py
@@ -211,6 +211,14 @@ class GTLVQ(SupervisedPrototypeModel):
         omegas = jax.vmap(orthogonalize)(params['omegas'])
         return {**params, 'omegas': omegas}
 
+    def _compute_distances_for_rejection(self, X):
+        """Tangent distances for reject option."""
+        diff = X[:, None, :] - self.prototypes_[None, :, :]
+        proj_onto_subspace = jnp.einsum('npd,pds->nps', diff, self.omegas_)
+        reconstruction = jnp.einsum('nps,pds->npd', proj_onto_subspace, self.omegas_)
+        tangent_diff = diff - reconstruction
+        return jnp.sum(tangent_diff ** 2, axis=2)
+
     def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
         super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
         self.omegas_ = params['omegas']

--- a/sphinx-docs/guides/onnx.rst
+++ b/sphinx-docs/guides/onnx.rst
@@ -39,6 +39,7 @@ The ``export_onnx`` function accepts:
   dynamic batch size)
 - ``opset_version`` — ONNX opset version (default ``17``)
 - ``path`` — optional file path to save the ONNX model
+- ``reject_threshold`` — optional float to enable reject option (see below)
 
 Running with ONNX Runtime
 --------------------------
@@ -274,3 +275,53 @@ Not Supported
    * - Utility (KMeansPlusPlus, Kmeans, SOM, BGPC)
      - 4
      - Not prototype model base classes
+
+Export with Reject Option
+--------------------------
+
+Supervised models can be exported with a built-in reject option. When
+``reject_threshold`` is provided, the ONNX model outputs two tensors:
+
+- ``predictions`` (INT64): class labels with ``-1`` for rejected samples
+- ``confidence`` (FLOAT): confidence scores in ``[-1, 1]``
+
+The confidence is the GLVQ relative margin:
+
+.. math::
+
+   \text{confidence}(x) = \frac{d^-(x) - d^+(x)}{d^-(x) + d^+(x)}
+
+Samples with confidence below the threshold are rejected (prediction = -1).
+
+.. code-block:: python
+
+   from prosemble.models import GLVQ
+   from prosemble.core.onnx_export import export_onnx
+
+   model = GLVQ(n_prototypes_per_class=2, max_iter=100, lr=0.01)
+   model.fit(X_train, y_train)
+
+   # Export with reject option (threshold = 0.2)
+   onnx_model = export_onnx(
+       model, batch_size=-1, reject_threshold=0.2, path='glvq_reject.onnx',
+   )
+
+   # Run with ONNX Runtime
+   import onnxruntime as ort
+   import numpy as np
+
+   session = ort.InferenceSession('glvq_reject.onnx')
+   results = session.run(None, {'X': X_test_np})
+
+   predictions = results[0]   # class labels or -1
+   confidence = results[1]    # confidence scores
+
+   # Analyze
+   rejected = predictions == -1
+   print(f"Rejected: {rejected.sum()} / {len(predictions)}")
+   print(f"Accuracy on accepted: {(predictions[~rejected] == y_test[~rejected]).mean():.3f}")
+
+Works with all supervised model distance types: Euclidean, relevance-weighted,
+omega-projected, local omega, tangent, and all differentiating kernel variants.
+
+Not supported for one-class or unsupervised models (raises ``ValueError``).

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -1728,3 +1728,93 @@ class TestOCDKGMLVQNGExport:
         jax_preds = np.asarray(model.predict(X))
         ort_preds = _onnx_predict(model, X)
         npt.assert_array_equal(jax_preds, ort_preds)
+
+
+# ---------------------------------------------------------------------------
+# Reject Option ONNX Export
+# ---------------------------------------------------------------------------
+
+class TestRejectOptionExport:
+    """Test ONNX export with reject_threshold parameter."""
+
+    @pytest.fixture
+    def fitted_glvq(self):
+        X, y = _make_supervised_data(n=60, d=4, n_classes=2)
+        model = GLVQ(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        return model, X, y
+
+    @pytest.fixture
+    def fitted_gmlvq(self):
+        X, y = _make_supervised_data(n=60, d=4, n_classes=2)
+        model = GMLVQ(n_prototypes_per_class=2, max_iter=50, lr=0.01)
+        model.fit(X, y)
+        return model, X, y
+
+    def test_reject_export_has_two_outputs(self, fitted_glvq):
+        model, X, y = fitted_glvq
+        from prosemble.core.onnx_export import export_onnx
+        onnx_model = export_onnx(model, batch_size=60, reject_threshold=0.1)
+        output_names = [o.name for o in onnx_model.graph.output]
+        assert output_names == ['predictions', 'confidence']
+
+    def test_reject_glvq_predictions_match(self, fitted_glvq):
+        model, X, y = fitted_glvq
+        from prosemble.core.onnx_export import export_onnx
+        threshold = 0.3
+        onnx_model = export_onnx(model, batch_size=60, reject_threshold=threshold)
+        sess = ort.InferenceSession(onnx_model.SerializeToString())
+        results = sess.run(None, {'X': np.asarray(X)})
+        onnx_preds = results[0]
+        jax_preds = np.asarray(model.predict_with_rejection(X, threshold=threshold))
+        npt.assert_array_equal(onnx_preds, jax_preds)
+
+    def test_reject_glvq_confidence_match(self, fitted_glvq):
+        model, X, y = fitted_glvq
+        from prosemble.core.onnx_export import export_onnx
+        onnx_model = export_onnx(model, batch_size=60, reject_threshold=0.1)
+        sess = ort.InferenceSession(onnx_model.SerializeToString())
+        results = sess.run(None, {'X': np.asarray(X)})
+        onnx_conf = results[1]
+        jax_conf = np.asarray(model.confidence(X))
+        npt.assert_allclose(onnx_conf, jax_conf, atol=1e-5)
+
+    def test_reject_gmlvq_predictions_match(self, fitted_gmlvq):
+        model, X, y = fitted_gmlvq
+        from prosemble.core.onnx_export import export_onnx
+        threshold = 0.2
+        onnx_model = export_onnx(model, batch_size=60, reject_threshold=threshold)
+        sess = ort.InferenceSession(onnx_model.SerializeToString())
+        results = sess.run(None, {'X': np.asarray(X)})
+        onnx_preds = results[0]
+        jax_preds = np.asarray(model.predict_with_rejection(X, threshold=threshold))
+        npt.assert_array_equal(onnx_preds, jax_preds)
+
+    def test_reject_gmlvq_confidence_match(self, fitted_gmlvq):
+        model, X, y = fitted_gmlvq
+        from prosemble.core.onnx_export import export_onnx
+        onnx_model = export_onnx(model, batch_size=60, reject_threshold=0.2)
+        sess = ort.InferenceSession(onnx_model.SerializeToString())
+        results = sess.run(None, {'X': np.asarray(X)})
+        onnx_conf = results[1]
+        jax_conf = np.asarray(model.confidence(X))
+        npt.assert_allclose(onnx_conf, jax_conf, atol=1e-5)
+
+    def test_high_threshold_produces_rejections(self, fitted_glvq):
+        model, X, y = fitted_glvq
+        from prosemble.core.onnx_export import export_onnx
+        onnx_model = export_onnx(model, batch_size=60, reject_threshold=0.9)
+        sess = ort.InferenceSession(onnx_model.SerializeToString())
+        results = sess.run(None, {'X': np.asarray(X)})
+        n_rejected = (results[0] == -1).sum()
+        # With threshold 0.9, some samples should be rejected
+        assert n_rejected > 0
+
+    def test_reject_not_supported_for_unsupervised(self):
+        from prosemble.models import NeuralGas
+        from prosemble.core.onnx_export import export_onnx
+        X = jnp.array(np.random.randn(30, 4).astype(np.float32))
+        model = NeuralGas(n_prototypes=3, max_iter=10, lr=0.1)
+        model.fit(X)
+        with pytest.raises(ValueError, match="reject_threshold is only supported"):
+            export_onnx(model, batch_size=30, reject_threshold=0.1)


### PR DESCRIPTION
## Summary
- Add `reject_threshold` parameter to `export_onnx()` enabling confidence-based rejection in ONNX graphs
- ONNX model outputs both `predictions` (INT64, -1 for rejected) and `confidence` (FLOAT, [-1, 1])
- Add `_compute_distances_for_rejection()` overrides to 10 adapted-distance models (GRLVQ, GMLVQ, LGMLVQ, GTLVQ, DKGLVQ, DKGRLVQ, DKGMLVQ, DKGLVQ_NG, DKGRLVQ_NG, DKGMLVQ_NG) fixing a bug where RejectOptionMixin used plain Euclidean for all models
- Validated exact numerical match between JAX and ONNX Runtime across all supervised distance types
- 7 new tests, 140 total ONNX tests passing

## Test plan
- [x] All 7 new reject option ONNX tests pass
- [x] All 133 existing ONNX tests pass (no regressions)
- [x] Verified GLVQ, GRLVQ, GMLVQ, LGMLVQ, GTLVQ, CELVQ + all 6 DK models match JAX exactly
- [x] ValueError raised for unsupervised/one-class models