### PR TITLE
feat: Add Wasserstein LVQ and HyperbolicPoincare manifold

### DIFF
--- a/prosemble/core/distance.py
+++ b/prosemble/core/distance.py
@@ -432,6 +432,185 @@ def tangent_distance_matrix(
 
 
 # ============================================================================
+# Wasserstein Distance Functions
+# ============================================================================
+
+
+@jit
+def wasserstein2_distance_matrix(
+    X: chex.Array,
+    means: chex.Array,
+    log_variances: chex.Array
+) -> chex.Array:
+    """
+    Compute pairwise squared 2-Wasserstein distances from points to Gaussian prototypes.
+
+    Each prototype is a diagonal Gaussian :math:`\\mathcal{N}(\\mu_k, \\text{diag}(\\sigma_k^2))`.
+    Each input point :math:`x` is treated as a Dirac delta distribution :math:`\\delta_x`.
+
+    The squared 2-Wasserstein distance from a point to a diagonal Gaussian is:
+
+    .. math::
+
+        W_2^2(\\delta_x, \\mathcal{N}(\\mu_k, \\text{diag}(\\sigma_k^2)))
+        = \\sum_j (x_j - \\mu_{kj})^2 + \\sum_j \\sigma_{kj}^2
+
+    This decomposes into the squared Euclidean distance from the point to the
+    mean, plus the total variance (trace of covariance). Prototypes with
+    smaller variance are effectively "more certain" and attract nearby points
+    more strongly.
+
+    Parameters
+    ----------
+    X : array of shape (n, d)
+        Data points.
+    means : array of shape (p, d)
+        Prototype mean vectors.
+    log_variances : array of shape (p, d)
+        Log of prototype variances (ensures positivity via ``exp``).
+
+    Returns
+    -------
+    D : array of shape (n, p)
+        Squared 2-Wasserstein distances.
+
+    References
+    ----------
+    .. [1] Villani, C. (2009). Optimal Transport: Old and New.
+           Springer. Chapter 2.
+    .. [2] Givens, C. R. & Shortt, R. M. (1984). A class of Wasserstein
+           metrics for probability distributions. Michigan Math. J., 31(2).
+    """
+    chex.assert_rank(X, 2)
+    chex.assert_rank(means, 2)
+    chex.assert_rank(log_variances, 2)
+    chex.assert_equal(X.shape[1], means.shape[1])
+    chex.assert_equal(means.shape, log_variances.shape)
+
+    # Squared Euclidean from points to means
+    eucl = squared_euclidean_distance_matrix(X, means)  # (n, p)
+
+    # Variance spread penalty per prototype
+    variances = jnp.exp(log_variances)  # (p, d)
+    spread = jnp.sum(variances, axis=1)  # (p,)
+
+    return eucl + spread[None, :]
+
+
+@jit
+def wasserstein2_omega_distance_matrix(
+    X: chex.Array,
+    means: chex.Array,
+    log_variances: chex.Array,
+    omega: chex.Array
+) -> chex.Array:
+    """
+    Squared 2-Wasserstein distance with global metric adaptation.
+
+    Projects data and means through :math:`\\Omega` before computing
+    the Euclidean component, while variances contribute directly:
+
+    .. math::
+
+        W_2^2(x, k) = \\|\\Omega(x - \\mu_k)\\|^2 + \\sum_j \\sigma_{kj}^2
+
+    Parameters
+    ----------
+    X : array of shape (n, d)
+        Data points.
+    means : array of shape (p, d)
+        Prototype mean vectors.
+    log_variances : array of shape (p, d)
+        Log of prototype variances.
+    omega : array of shape (d, l)
+        Global projection matrix.
+
+    Returns
+    -------
+    D : array of shape (n, p)
+        Squared 2-Wasserstein distances in projected space.
+    """
+    chex.assert_rank(X, 2)
+    chex.assert_rank(means, 2)
+    chex.assert_rank(log_variances, 2)
+    chex.assert_rank(omega, 2)
+    chex.assert_equal(X.shape[1], means.shape[1])
+    chex.assert_equal(means.shape, log_variances.shape)
+    chex.assert_equal(X.shape[1], omega.shape[0])
+
+    # Project and compute squared Euclidean in projected space
+    X_proj = X @ omega  # (n, l)
+    M_proj = means @ omega  # (p, l)
+    eucl = squared_euclidean_distance_matrix(X_proj, M_proj)  # (n, p)
+
+    # Variance spread penalty
+    variances = jnp.exp(log_variances)  # (p, d)
+    spread = jnp.sum(variances, axis=1)  # (p,)
+
+    return eucl + spread[None, :]
+
+
+@jit
+def wasserstein2_relevance_distance_matrix(
+    X: chex.Array,
+    means: chex.Array,
+    log_variances: chex.Array,
+    relevances: chex.Array
+) -> chex.Array:
+    """
+    Squared 2-Wasserstein distance with feature relevance weighting.
+
+    Applies per-feature relevance weights :math:`\\lambda_j` to the
+    Euclidean component:
+
+    .. math::
+
+        W_2^2(x, k) = \\sum_j \\lambda_j (x_j - \\mu_{kj})^2 + \\sum_j \\sigma_{kj}^2
+
+    where :math:`\\lambda_j = \\text{softmax}(r)_j` ensures non-negative
+    weights that sum to 1.
+
+    Parameters
+    ----------
+    X : array of shape (n, d)
+        Data points.
+    means : array of shape (p, d)
+        Prototype mean vectors.
+    log_variances : array of shape (p, d)
+        Log of prototype variances.
+    relevances : array of shape (d,)
+        Raw relevance logits (softmax applied internally).
+
+    Returns
+    -------
+    D : array of shape (n, p)
+        Relevance-weighted squared 2-Wasserstein distances.
+    """
+    chex.assert_rank(X, 2)
+    chex.assert_rank(means, 2)
+    chex.assert_rank(log_variances, 2)
+    chex.assert_rank(relevances, 1)
+    chex.assert_equal(X.shape[1], means.shape[1])
+    chex.assert_equal(means.shape, log_variances.shape)
+    chex.assert_equal(X.shape[1], relevances.shape[0])
+
+    # Softmax relevance weights
+    lambdas = jax.nn.softmax(relevances)  # (d,)
+
+    # Weighted squared differences
+    # (n, 1, d) - (1, p, d) -> (n, p, d)
+    diff_sq = (X[:, None, :] - means[None, :, :]) ** 2
+    weighted = diff_sq * lambdas[None, None, :]  # (n, p, d)
+    eucl = jnp.sum(weighted, axis=2)  # (n, p)
+
+    # Variance spread penalty
+    variances = jnp.exp(log_variances)  # (p, d)
+    spread = jnp.sum(variances, axis=1)  # (p,)
+
+    return eucl + spread[None, :]
+
+
+# ============================================================================
 # Kernel Functions
 # ============================================================================
 
@@ -764,6 +943,10 @@ __all__ = [
     'omega_distance_matrix',
     'lomega_distance_matrix',
     'tangent_distance_matrix',
+    # Wasserstein distance functions
+    'wasserstein2_distance_matrix',
+    'wasserstein2_omega_distance_matrix',
+    'wasserstein2_relevance_distance_matrix',
     # Kernel functions
     'gaussian_kernel_matrix',
     'polynomial_kernel_matrix',

--- a/prosemble/core/manifolds.py
+++ b/prosemble/core/manifolds.py
@@ -7,6 +7,7 @@ for manifolds commonly arising in machine learning:
 - SO(n): Special orthogonal group (rotation matrices)
 - SPD(n): Symmetric positive definite matrices
 - Grassmannian Gr(n, k): k-dimensional subspaces of R^n
+- HyperbolicPoincare(d): Poincare ball model of hyperbolic space
 
 All operations are JIT-compilable and vmap-compatible.
 
@@ -15,6 +16,9 @@ References
 Schwarz, Psenickova, Villmann, Röhrbein (2026).
 Topology-Preserving Prototype Learning on Riemannian Manifolds.
 ESANN 2026.
+
+Ganea, O., Becigneul, G., & Hofmann, T. (2018). Hyperbolic Neural
+Networks. NeurIPS 2018.
 """
 
 from __future__ import annotations
@@ -323,3 +327,165 @@ class Grassmannian:
     def injectivity_radius(self, Q):
         """Injectivity radius of Gr(n,k) is :math:`\\pi/2`."""
         return jnp.pi / 2.0
+
+
+# ---------------------------------------------------------------------------
+# HyperbolicPoincare(d) — Poincaré Ball Model of Hyperbolic Space
+# ---------------------------------------------------------------------------
+
+def _mobius_add(x, y, eps=1e-7):
+    """Möbius addition in the Poincaré ball.
+
+    .. math::
+
+        x \\oplus y = \\frac{(1 + 2\\langle x, y\\rangle + \\|y\\|^2) x
+                           + (1 - \\|x\\|^2) y}
+                          {1 + 2\\langle x, y\\rangle + \\|x\\|^2 \\|y\\|^2}
+
+    Parameters
+    ----------
+    x, y : arrays of shape (d,)
+
+    Returns
+    -------
+    result : array of shape (d,)
+    """
+    x_sq = jnp.sum(x ** 2)
+    y_sq = jnp.sum(y ** 2)
+    xy = jnp.sum(x * y)
+    num = (1.0 + 2.0 * xy + y_sq) * x + (1.0 - x_sq) * y
+    denom = 1.0 + 2.0 * xy + x_sq * y_sq
+    return num / (denom + eps)
+
+
+def _conformal_factor(x, eps=1e-7):
+    """Conformal factor :math:`\\lambda_x = 2 / (1 - \\|x\\|^2)`.
+
+    Parameters
+    ----------
+    x : array of shape (d,)
+
+    Returns
+    -------
+    scalar
+    """
+    return 2.0 / (1.0 - jnp.sum(x ** 2) + eps)
+
+
+class HyperbolicPoincare:
+    """Poincaré ball model of hyperbolic space :math:`\\mathbb{H}^d`.
+
+    Points are vectors in :math:`\\mathbb{B}^d = \\{x \\in \\mathbb{R}^d : \\|x\\| < 1\\}`.
+    The Riemannian metric is :math:`g_x = \\lambda_x^2 g_E` where
+    :math:`\\lambda_x = 2/(1-\\|x\\|^2)` is the conformal factor.
+
+    This manifold is the natural geometry for hierarchical and
+    tree-structured data — it can embed trees with arbitrarily low
+    distortion (Sarkar 2011).
+
+    Parameters
+    ----------
+    d : int
+        Dimension of the hyperbolic space.
+    eps : float
+        Numerical safety margin for boundary clamping.
+    """
+
+    def __init__(self, d: int, eps: float = 1e-5):
+        self.d = d
+        self.eps = eps
+        self.point_shape = (d,)
+
+    def distance(self, x, y):
+        """Geodesic distance in the Poincaré ball.
+
+        .. math::
+
+            d(x, y) = \\operatorname{arcosh}\\!\\left(1 + \\frac{2\\|x - y\\|^2}
+                      {(1 - \\|x\\|^2)(1 - \\|y\\|^2)}\\right)
+        """
+        diff_sq = jnp.sum((x - y) ** 2)
+        x_sq = jnp.sum(x ** 2)
+        y_sq = jnp.sum(y ** 2)
+        denom = (1.0 - x_sq) * (1.0 - y_sq)
+        arg = 1.0 + 2.0 * diff_sq / (denom + self.eps)
+        # Stable arcosh with safe gradient: arcosh(z) = log(z + sqrt(z^2-1))
+        # Clamp arg >= 1 + eps to prevent gradient blow-up near z=1
+        arg = jnp.maximum(arg, 1.0 + 1e-6)
+        return jnp.arccosh(arg)
+
+    def distance_squared(self, x, y):
+        """Squared geodesic distance."""
+        d = self.distance(x, y)
+        return d ** 2
+
+    def log_map(self, x, y):
+        """Logarithmic map: tangent vector at x pointing toward y.
+
+        .. math::
+
+            \\text{Log}_x(y) = \\frac{2}{\\lambda_x}
+            \\operatorname{arctanh}(\\|-x \\oplus y\\|)
+            \\frac{-x \\oplus y}{\\|-x \\oplus y\\|}
+        """
+        neg_x = -x
+        add_result = _mobius_add(neg_x, y, eps=self.eps)
+        norm = jnp.linalg.norm(add_result)
+        norm_safe = jnp.maximum(norm, 1e-10)
+        # arctanh is only defined for |z| < 1, clamp
+        norm_clamped = jnp.minimum(norm, 1.0 - 1e-7)
+        lam_x = _conformal_factor(x, eps=self.eps)
+        scale = (2.0 / lam_x) * jnp.arctanh(norm_clamped)
+        return scale * add_result / norm_safe
+
+    def exp_map(self, x, v):
+        """Exponential map: move from x along tangent vector v.
+
+        .. math::
+
+            \\text{Exp}_x(v) = x \\oplus \\left(
+            \\tanh\\!\\left(\\frac{\\lambda_x \\|v\\|}{2}\\right)
+            \\frac{v}{\\|v\\|}\\right)
+        """
+        v_norm = jnp.linalg.norm(v)
+        v_norm_safe = jnp.maximum(v_norm, 1e-10)
+        lam_x = _conformal_factor(x, eps=self.eps)
+        direction = v / v_norm_safe
+        t = jnp.tanh(lam_x * v_norm / 2.0) * direction
+        return _mobius_add(x, t, eps=self.eps)
+
+    def random_point(self, key):
+        """Generate a random point uniformly in the Poincaré ball.
+
+        Uses the radial transform: sample direction uniformly on S^{d-1},
+        then radius r ~ Beta(1, d) to get uniform distribution in B^d,
+        scaled to stay safely inside the ball.
+        """
+        key1, key2 = jax.random.split(key)
+        # Random direction on unit sphere
+        direction = jax.random.normal(key1, (self.d,))
+        direction = direction / (jnp.linalg.norm(direction) + 1e-10)
+        # Uniform radius in ball: r^d ~ U[0,1] => r = U^{1/d}
+        u = jax.random.uniform(key2, (), minval=0.01, maxval=0.95)
+        r = u ** (1.0 / self.d)
+        # Scale to stay inside ball with margin
+        r = r * (1.0 - self.eps)
+        return r * direction
+
+    def belongs(self, x):
+        """Check if x is in the Poincaré ball: :math:`\\|x\\| < 1`."""
+        return jnp.sum(x ** 2) < 1.0
+
+    def project(self, x):
+        """Project to the interior of the Poincaré ball.
+
+        Clamps the norm to be strictly less than 1.
+        """
+        max_norm = 1.0 - self.eps
+        norm = jnp.linalg.norm(x)
+        scale = jnp.minimum(max_norm / (norm + 1e-10), 1.0)
+        return x * scale
+
+    def injectivity_radius(self, x):
+        """Hyperbolic space has infinite injectivity radius."""
+        return jnp.inf

--- a/prosemble/models/__init__.py
+++ b/prosemble/models/__init__.py
@@ -117,6 +117,12 @@ try:
     from .dk_kohonen_som import DKKohonenSOM
     from .dk_heskes_som import DKHeskesSOM
 
+    # Wasserstein LVQ models
+    from .wasserstein_glvq import WGLVQ
+    from .wasserstein_gmlvq import WGMLVQ
+    from .wasserstein_grlvq import WGRLVQ
+
+
     # One-Class Differentiating Kernel models
     from .oc_dk_glvq import OCDKGLVQ
     from .oc_dk_relevance_lvq import OCDKGRLVQ
@@ -191,6 +197,8 @@ try:
         'OCDKGMLVQ': OCDKGMLVQ,
         'OCDKGLVQ_NG': OCDKGLVQ_NG, 'OCDKGRLVQ_NG': OCDKGRLVQ_NG,
         'OCDKGMLVQ_NG': OCDKGMLVQ_NG,
+        # Wasserstein LVQ
+        'WGLVQ': WGLVQ, 'WGMLVQ': WGMLVQ, 'WGRLVQ': WGRLVQ,
     }
 
     JAX_AVAILABLE = True
@@ -250,6 +258,8 @@ __all__ = [
     # One-Class Differentiating Kernel
     'OCDKGLVQ', 'OCDKGRLVQ', 'OCDKGMLVQ',
     'OCDKGLVQ_NG', 'OCDKGRLVQ_NG', 'OCDKGMLVQ_NG',
+    # Wasserstein LVQ
+    'WGLVQ', 'WGMLVQ', 'WGRLVQ',
     # Status
     'JAX_AVAILABLE',
 ]

--- a/prosemble/models/riemannian_dk_matrix_lvq.py
+++ b/prosemble/models/riemannian_dk_matrix_lvq.py
@@ -28,9 +28,10 @@ from prosemble.models.prototype_base import SupervisedState
 from prosemble.core.activations import sigmoid_beta
 from prosemble.core.initializers import identity_omega_init
 from prosemble.core.competitions import wtac
-from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.core.manifolds import SO, SPD, Grassmannian, HyperbolicPoincare
 from prosemble.models.riemannian_srng import (
     _so_log_map_diff, _spd_log_map_diff, _grassmannian_log_map_diff,
+    _hyperbolic_log_map_diff,
 )
 
 
@@ -172,6 +173,8 @@ class RiemannianDKGMLVQ(RiemannianSRNG):
             return _spd_log_map_diff(w, x)
         elif isinstance(self.manifold, Grassmannian):
             return _grassmannian_log_map_diff(w, x)
+        elif isinstance(self.manifold, HyperbolicPoincare):
+            return _hyperbolic_log_map_diff(w, x, eps=self.manifold.eps)
         else:
             return self.manifold.log_map(w, x)
 

--- a/prosemble/models/riemannian_dk_relevance_lvq.py
+++ b/prosemble/models/riemannian_dk_relevance_lvq.py
@@ -28,9 +28,10 @@ from prosemble.models.riemannian_srng import RiemannianSRNG
 from prosemble.models.prototype_base import SupervisedState
 from prosemble.core.activations import sigmoid_beta
 from prosemble.core.competitions import wtac
-from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.core.manifolds import SO, SPD, Grassmannian, HyperbolicPoincare
 from prosemble.models.riemannian_srng import (
     _so_log_map_diff, _spd_log_map_diff, _grassmannian_log_map_diff,
+    _hyperbolic_log_map_diff,
 )
 
 
@@ -170,6 +171,8 @@ class RiemannianDKGRLVQ(RiemannianSRNG):
             return _spd_log_map_diff(w, x)
         elif isinstance(self.manifold, Grassmannian):
             return _grassmannian_log_map_diff(w, x)
+        elif isinstance(self.manifold, HyperbolicPoincare):
+            return _hyperbolic_log_map_diff(w, x, eps=self.manifold.eps)
         else:
             return self.manifold.log_map(w, x)
 

--- a/prosemble/models/riemannian_neural_gas.py
+++ b/prosemble/models/riemannian_neural_gas.py
@@ -284,6 +284,8 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
             hp['manifold_n'] = manifold.n
         if hasattr(manifold, 'k'):
             hp['manifold_k'] = manifold.k
+        if hasattr(manifold, 'd'):
+            hp['manifold_d'] = manifold.d
         return hp
 
     def _get_fitted_arrays(self):
@@ -303,7 +305,7 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
     @classmethod
     def _reconstruct_manifold(cls, hp):
         """Reconstruct manifold from saved hyperparameters."""
-        from prosemble.core.manifolds import SO, SPD, Grassmannian
+        from prosemble.core.manifolds import SO, SPD, Grassmannian, HyperbolicPoincare
         mtype = hp.get('manifold_type', '')
         if mtype == 'SO':
             return SO(int(hp['manifold_n']))
@@ -311,6 +313,8 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
             return SPD(int(hp['manifold_n']))
         elif mtype == 'Grassmannian':
             return Grassmannian(int(hp['manifold_n']), int(hp['manifold_k']))
+        elif mtype == 'HyperbolicPoincare':
+            return HyperbolicPoincare(int(hp['manifold_d']))
         else:
             raise ValueError(f"Unknown manifold type: {mtype}")
 
@@ -320,5 +324,6 @@ class RiemannianNeuralGas(UnsupervisedPrototypeModel):
         hyperparams.pop('manifold_type', None)
         hyperparams.pop('manifold_n', None)
         hyperparams.pop('manifold_k', None)
+        hyperparams.pop('manifold_d', None)
         hyperparams['manifold'] = manifold
         return hyperparams

--- a/prosemble/models/riemannian_smng.py
+++ b/prosemble/models/riemannian_smng.py
@@ -134,9 +134,10 @@ class RiemannianSMNG(RiemannianSRNG):
         Dispatches to the appropriate differentiable log map based on
         manifold type.
         """
-        from prosemble.core.manifolds import SO, SPD, Grassmannian
+        from prosemble.core.manifolds import SO, SPD, Grassmannian, HyperbolicPoincare
         from prosemble.models.riemannian_srng import (
             _so_log_map_diff, _spd_log_map_diff, _grassmannian_log_map_diff,
+            _hyperbolic_log_map_diff,
         )
         if isinstance(self.manifold, SO):
             return _so_log_map_diff(w, x)
@@ -144,6 +145,8 @@ class RiemannianSMNG(RiemannianSRNG):
             return _spd_log_map_diff(w, x)
         elif isinstance(self.manifold, Grassmannian):
             return _grassmannian_log_map_diff(w, x)
+        elif isinstance(self.manifold, HyperbolicPoincare):
+            return _hyperbolic_log_map_diff(w, x, eps=self.manifold.eps)
         else:
             return self.manifold.log_map(w, x)
 

--- a/prosemble/models/riemannian_srng.py
+++ b/prosemble/models/riemannian_srng.py
@@ -6,7 +6,7 @@ using geodesic distances and Neural Gas neighborhood cooperation.
 Prototypes live on the manifold and are updated via projected gradient
 descent (Euclidean gradient + manifold projection).
 
-Supports SO(n), SPD(n), and Grassmannian(n,k) manifolds.
+Supports SO(n), SPD(n), Grassmannian(n,k), and HyperbolicPoincare(d) manifolds.
 """
 
 import jax
@@ -15,7 +15,7 @@ import numpy as np
 
 from prosemble.models.prototype_base import SupervisedPrototypeModel, SupervisedState
 from prosemble.core.activations import sigmoid_beta
-from prosemble.core.manifolds import SO, SPD, Grassmannian
+from prosemble.core.manifolds import SO, SPD, Grassmannian, HyperbolicPoincare
 from prosemble.core.protocols import Manifold
 
 
@@ -126,6 +126,79 @@ def _grassmannian_log_map_diff(Q1, Q2):
     smooth everywhere.
     """
     return Q2 - Q1 @ (Q1.T @ Q2)
+
+
+def _hyperbolic_distance_squared_diff(x, y, eps=1e-5):
+    """Differentiable squared geodesic distance on the Poincare ball.
+
+    .. math::
+
+        d^2(x, y) = \\left(\\text{arcosh}\\left(1 + \\frac{2\\|x - y\\|^2}
+        {(1 - \\|x\\|^2)(1 - \\|y\\|^2)}\\right)\\right)^2
+
+    Parameters
+    ----------
+    x : array of shape (d,)
+        Point in the Poincare ball.
+    y : array of shape (d,)
+        Point in the Poincare ball.
+    eps : float
+        Numerical stability constant.
+
+    Returns
+    -------
+    float
+        Squared geodesic distance.
+    """
+    diff_sq = jnp.sum((x - y) ** 2)
+    x_sq = jnp.sum(x ** 2)
+    y_sq = jnp.sum(y ** 2)
+    denom = (1.0 - x_sq) * (1.0 - y_sq)
+    arg = 1.0 + 2.0 * diff_sq / (denom + eps)
+    # Clamp arg >= 1 + eps to prevent gradient blow-up at z=1
+    # where d/dz arcosh(z) = 1/sqrt(z^2 - 1) diverges
+    arg = jnp.maximum(arg, 1.0 + 1e-6)
+    dist = jnp.arccosh(arg)
+    return dist ** 2
+
+
+def _hyperbolic_log_map_diff(x, y, eps=1e-5):
+    """Differentiable log map on the Poincare ball.
+
+    .. math::
+
+        \\text{Log}_x(y) = \\frac{2}{\\lambda_x} \\text{arctanh}(\\|-x \\oplus y\\|)
+        \\cdot \\frac{-x \\oplus y}{\\|-x \\oplus y\\|}
+
+    where :math:`\\lambda_x = 2 / (1 - \\|x\\|^2)` is the conformal factor
+    and :math:`\\oplus` is Mobius addition.
+
+    Parameters
+    ----------
+    x : array of shape (d,)
+        Base point in the Poincare ball.
+    y : array of shape (d,)
+        Target point in the Poincare ball.
+    eps : float
+        Numerical stability constant.
+
+    Returns
+    -------
+    array of shape (d,)
+        Tangent vector at x pointing toward y.
+    """
+    from prosemble.core.manifolds import _mobius_add, _conformal_factor
+    neg_x = -x
+    add_result = _mobius_add(neg_x, y, eps=eps)
+    # Gradient-safe norm: jnp.linalg.norm has 0/0 gradient at zero
+    norm_sq = jnp.sum(add_result ** 2)
+    norm = jnp.sqrt(norm_sq + 1e-16)
+    # Clamp norm for arctanh domain (-1, 1)
+    norm_clamped = jnp.minimum(norm, 1.0 - 1e-7)
+    lam_x = _conformal_factor(x, eps=eps)
+    # arctanh(t)/t → 1 as t → 0; use this limit to avoid 0/0 gradient
+    coeff = jnp.where(norm > 1e-7, jnp.arctanh(norm_clamped) / norm, 1.0)
+    return (2.0 / lam_x) * coeff * add_result
 
 
 class RiemannianSRNG(SupervisedPrototypeModel):
@@ -281,6 +354,8 @@ class RiemannianSRNG(SupervisedPrototypeModel):
             return _spd_distance_squared_diff(x, w)
         elif isinstance(self.manifold, Grassmannian):
             return _grassmannian_distance_squared_diff(x, w)
+        elif isinstance(self.manifold, HyperbolicPoincare):
+            return _hyperbolic_distance_squared_diff(x, w, eps=self.manifold.eps)
         else:
             return self.manifold.distance_squared(x, w)
 
@@ -450,12 +525,14 @@ class RiemannianSRNG(SupervisedPrototypeModel):
             hp['manifold_n'] = manifold.n
         if hasattr(manifold, 'k'):
             hp['manifold_k'] = manifold.k
+        if hasattr(manifold, 'd'):
+            hp['manifold_d'] = manifold.d
         return hp
 
     @classmethod
     def _reconstruct_manifold(cls, hp):
         """Reconstruct manifold from saved hyperparameters."""
-        from prosemble.core.manifolds import SO, SPD, Grassmannian
+        from prosemble.core.manifolds import SO, SPD, Grassmannian, HyperbolicPoincare
         mtype = hp.get('manifold_type', '')
         if mtype == 'SO':
             return SO(int(hp['manifold_n']))
@@ -463,6 +540,8 @@ class RiemannianSRNG(SupervisedPrototypeModel):
             return SPD(int(hp['manifold_n']))
         elif mtype == 'Grassmannian':
             return Grassmannian(int(hp['manifold_n']), int(hp['manifold_k']))
+        elif mtype == 'HyperbolicPoincare':
+            return HyperbolicPoincare(int(hp['manifold_d']))
         else:
             raise ValueError(f"Unknown manifold type: {mtype}")
 
@@ -472,5 +551,6 @@ class RiemannianSRNG(SupervisedPrototypeModel):
         hyperparams.pop('manifold_type', None)
         hyperparams.pop('manifold_n', None)
         hyperparams.pop('manifold_k', None)
+        hyperparams.pop('manifold_d', None)
         hyperparams['manifold'] = manifold
         return hyperparams

--- a/prosemble/models/wasserstein_glvq.py
+++ b/prosemble/models/wasserstein_glvq.py
@@ -1,0 +1,231 @@
+"""
+Wasserstein GLVQ (WGLVQ).
+
+Generalized LVQ with distributional (Gaussian) prototypes. Each prototype
+is a diagonal Gaussian :math:`\\mathcal{N}(\\mu_k, \\text{diag}(\\sigma_k^2))`.
+Input samples are treated as Dirac deltas. The classifier distance is the
+squared 2-Wasserstein distance:
+
+.. math::
+
+    W_2^2(x, k) = \\sum_j (x_j - \\mu_{kj})^2 + \\sum_j \\sigma_{kj}^2
+
+The variance term acts as a per-prototype "spread penalty" — prototypes with
+smaller variance attract nearby points more strongly. The variance is learned
+end-to-end via gradient descent on the GLVQ loss.
+
+References
+----------
+.. [1] Villani, C. (2009). Optimal Transport: Old and New. Springer.
+.. [2] Sato, A. & Yamada, K. (1996). Generalized Learning Vector
+       Quantization. NIPS.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel, SupervisedState
+from prosemble.core.losses import glvq_loss_with_transfer
+from prosemble.core.competitions import wtac
+from prosemble.core.distance import wasserstein2_distance_matrix
+
+
+class WGLVQ(SupervisedPrototypeModel):
+    """Wasserstein Generalized Learning Vector Quantization.
+
+    Extends GLVQ by replacing point prototypes with Gaussian prototypes.
+    Each prototype is parameterized by a mean vector :math:`\\mu_k` and
+    log-variance vector :math:`\\log(\\sigma_k^2)`. The squared 2-Wasserstein
+    distance between a sample and a prototype combines the squared
+    Euclidean distance to the mean with the total prototype variance.
+
+    The variance provides a learnable measure of prototype "uncertainty":
+
+    - Large variance: prototype is uncertain, covers a wider region
+    - Small variance: prototype is certain, tightly fits nearby samples
+
+    Parameters
+    ----------
+    beta : float
+        Transfer function steepness parameter. Default: 10.0.
+    n_prototypes_per_class : int or dict
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer
+        Optimizer name or instance. Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function for loss shaping.
+    margin : float
+        Margin for loss computation.
+    callbacks : list, optional
+        Training callbacks.
+    use_scan : bool
+        Use ``jax.lax.scan`` for training loop.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Scheduler keyword arguments.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization strategy.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters after training.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation steps.
+    ema_decay : float, optional
+        EMA decay for parameters.
+    freeze_params : list of str, optional
+        Parameter groups to freeze.
+    lookahead : dict, optional
+        Lookahead optimizer settings.
+    mixed_precision : str, optional
+        Mixed precision dtype.
+
+    Attributes
+    ----------
+    prototype_means_ : array of shape (n_prototypes, n_features)
+        Learned prototype mean vectors (after fit).
+    prototype_variances_ : array of shape (n_prototypes, n_features)
+        Learned prototype variances (after fit).
+    """
+
+    def __init__(self, beta=10.0, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=None,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.beta = beta
+        self.prototype_means_ = None
+        self.prototype_variances_ = None
+
+    def _get_resume_params(self, params):
+        return {
+            'prototypes': params['prototypes'],
+            'log_variances': self._log_variances_,
+        }
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+
+        # Initialize log-variances from per-class variance
+        n_protos = prototypes.shape[0]
+        class_vars = []
+        for i in range(n_protos):
+            mask = y == proto_labels[i]
+            class_data = X[mask]
+            var = jnp.var(class_data, axis=0)
+            class_vars.append(var)
+        class_vars = jnp.stack(class_vars)
+        log_variances = jnp.log(jnp.maximum(class_vars, 1e-6))
+
+        params = {'prototypes': prototypes, 'log_variances': log_variances}
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        means = params['prototypes']
+        log_variances = params['log_variances']
+        distances = wasserstein2_distance_matrix(X, means, log_variances)
+        return glvq_loss_with_transfer(
+            distances, y, proto_labels,
+            transfer_fn=self.transfer_fn,
+            margin=self.margin,
+            beta=self.beta,
+        )
+
+    def _compute_distances_for_rejection(self, X):
+        """W2 distances for reject option."""
+        log_vars = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+        return wasserstein2_distance_matrix(X, self.prototypes_, log_vars)
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.prototype_means_ = params['prototypes']
+        self.prototype_variances_ = jnp.exp(params['log_variances'])
+        self._log_variances_ = params['log_variances']
+
+    def predict(self, X):
+        """Predict class labels using W2 distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        log_vars = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+        distances = wasserstein2_distance_matrix(X, self.prototypes_, log_vars)
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.prototype_variances_ is not None:
+            attrs.append('prototype_variances_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.prototype_variances_ is not None:
+            arrays['prototype_variances_'] = np.asarray(self.prototype_variances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'prototype_variances_' in arrays:
+            self.prototype_variances_ = jnp.asarray(arrays['prototype_variances_'])
+            self._log_variances_ = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+            self.prototype_means_ = self.prototypes_
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['beta'] = self.beta
+        return hp

--- a/prosemble/models/wasserstein_gmlvq.py
+++ b/prosemble/models/wasserstein_gmlvq.py
@@ -1,0 +1,270 @@
+"""
+Wasserstein GMLVQ (WGMLVQ).
+
+Combines Wasserstein distributional prototypes with a global linear
+transformation :math:`\\Omega`. The squared 2-Wasserstein distance in
+the projected space is:
+
+.. math::
+
+    W_2^2(x, k) = \\|\\Omega(x - \\mu_k)\\|^2 + \\sum_j \\sigma_{kj}^2
+
+The metric adaptation matrix :math:`\\Lambda = \\Omega^T \\Omega` learns
+discriminative feature combinations, while the variance captures
+per-prototype uncertainty.
+
+References
+----------
+.. [1] Schneider, P., Biehl, M., & Hammer, B. (2009). Adaptive
+       Relevance Matrices in Learning Vector Quantization. Neural
+       Computation.
+.. [2] Villani, C. (2009). Optimal Transport: Old and New. Springer.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel, SupervisedState
+from prosemble.core.losses import glvq_loss_with_transfer
+from prosemble.core.competitions import wtac
+from prosemble.core.initializers import identity_omega_init
+from prosemble.core.distance import wasserstein2_omega_distance_matrix
+
+
+class WGMLVQ(SupervisedPrototypeModel):
+    """Wasserstein Generalized Matrix Learning Vector Quantization.
+
+    Extends WGLVQ with a learned global projection matrix :math:`\\Omega`
+    that maps data into a discriminative subspace before computing the
+    Euclidean component of the Wasserstein distance.
+
+    Parameters
+    ----------
+    latent_dim : int, optional
+        Dimension of the projected space. Default: input dimension.
+    beta : float
+        Transfer function steepness. Default: 10.0.
+    n_prototypes_per_class : int or dict
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer
+        Optimizer. Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Training callbacks.
+    use_scan : bool
+        Use ``jax.lax.scan``.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameter groups.
+    lookahead : dict, optional
+        Lookahead settings.
+    mixed_precision : str, optional
+        Mixed precision dtype.
+
+    Attributes
+    ----------
+    prototype_means_ : array of shape (n_prototypes, n_features)
+        Learned means.
+    prototype_variances_ : array of shape (n_prototypes, n_features)
+        Learned variances.
+    omega_ : array of shape (n_features, latent_dim)
+        Learned projection matrix.
+    """
+
+    def __init__(self, latent_dim=None, beta=10.0,
+                 n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=None,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.latent_dim = latent_dim
+        self.beta = beta
+        self.omega_ = None
+        self.prototype_means_ = None
+        self.prototype_variances_ = None
+
+    def _get_resume_params(self, params):
+        return {
+            'prototypes': params['prototypes'],
+            'log_variances': self._log_variances_,
+            'omega': self.omega_,
+        }
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        latent_dim = self.latent_dim or n_features
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+
+        omega = identity_omega_init(n_features, latent_dim)
+
+        # Initialize log-variances from per-class variance
+        n_protos = prototypes.shape[0]
+        class_vars = []
+        for i in range(n_protos):
+            mask = y == proto_labels[i]
+            class_data = X[mask]
+            var = jnp.var(class_data, axis=0)
+            class_vars.append(var)
+        class_vars = jnp.stack(class_vars)
+        log_variances = jnp.log(jnp.maximum(class_vars, 1e-6))
+
+        params = {
+            'prototypes': prototypes,
+            'log_variances': log_variances,
+            'omega': omega,
+        }
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        means = params['prototypes']
+        log_variances = params['log_variances']
+        omega = params['omega']
+        distances = wasserstein2_omega_distance_matrix(
+            X, means, log_variances, omega
+        )
+        return glvq_loss_with_transfer(
+            distances, y, proto_labels,
+            transfer_fn=self.transfer_fn,
+            margin=self.margin,
+            beta=self.beta,
+        )
+
+    def _compute_distances_for_rejection(self, X):
+        """Omega-projected W2 distances for reject option."""
+        log_vars = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+        return wasserstein2_omega_distance_matrix(
+            X, self.prototypes_, log_vars, self.omega_
+        )
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.omega_ = params['omega']
+        self.prototype_means_ = params['prototypes']
+        self.prototype_variances_ = jnp.exp(params['log_variances'])
+        self._log_variances_ = params['log_variances']
+
+    @property
+    def omega_matrix(self):
+        """Return the learned :math:`\\Omega` matrix."""
+        if self.omega_ is None:
+            raise ValueError("Model not fitted.")
+        return self.omega_
+
+    @property
+    def lambda_matrix(self):
+        """Return :math:`\\Lambda = \\Omega^T \\Omega` (relevance matrix)."""
+        if self.omega_ is None:
+            raise ValueError("Model not fitted.")
+        return self.omega_.T @ self.omega_
+
+    def predict(self, X):
+        """Predict class labels using omega-projected W2 distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        log_vars = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+        distances = wasserstein2_omega_distance_matrix(
+            X, self.prototypes_, log_vars, self.omega_
+        )
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.omega_ is not None:
+            attrs.append('omega_')
+        if self.prototype_variances_ is not None:
+            attrs.append('prototype_variances_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.omega_ is not None:
+            arrays['omega_'] = np.asarray(self.omega_)
+        if self.prototype_variances_ is not None:
+            arrays['prototype_variances_'] = np.asarray(self.prototype_variances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'omega_' in arrays:
+            self.omega_ = jnp.asarray(arrays['omega_'])
+        if 'prototype_variances_' in arrays:
+            self.prototype_variances_ = jnp.asarray(arrays['prototype_variances_'])
+            self._log_variances_ = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+            self.prototype_means_ = self.prototypes_
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['beta'] = self.beta
+        if self.latent_dim is not None:
+            hp['latent_dim'] = self.latent_dim
+        return hp

--- a/prosemble/models/wasserstein_grlvq.py
+++ b/prosemble/models/wasserstein_grlvq.py
@@ -1,0 +1,259 @@
+"""
+Wasserstein GRLVQ (WGRLVQ).
+
+Combines Wasserstein distributional prototypes with per-feature relevance
+weighting. The relevance-weighted squared 2-Wasserstein distance is:
+
+.. math::
+
+    W_2^2(x, k) = \\sum_j \\lambda_j (x_j - \\mu_{kj})^2 + \\sum_j \\sigma_{kj}^2
+
+where :math:`\\lambda_j = \\text{softmax}(r)_j` are learned, non-negative
+feature relevance weights that sum to 1.
+
+References
+----------
+.. [1] Hammer, B. & Villmann, T. (2002). Generalized relevance learning
+       vector quantization. Neural Networks.
+.. [2] Villani, C. (2009). Optimal Transport: Old and New. Springer.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from prosemble.models.prototype_base import SupervisedPrototypeModel, SupervisedState
+from prosemble.core.losses import glvq_loss_with_transfer
+from prosemble.core.competitions import wtac
+from prosemble.core.distance import wasserstein2_relevance_distance_matrix
+
+
+class WGRLVQ(SupervisedPrototypeModel):
+    """Wasserstein Generalized Relevance Learning Vector Quantization.
+
+    Extends WGLVQ with learned per-feature relevance weights that
+    scale the Euclidean component of the Wasserstein distance.
+
+    Parameters
+    ----------
+    beta : float
+        Transfer function steepness. Default: 10.0.
+    n_prototypes_per_class : int or dict
+        Number of prototypes per class.
+    max_iter : int
+        Maximum training iterations.
+    lr : float
+        Learning rate.
+    epsilon : float
+        Convergence threshold.
+    random_seed : int
+        Random seed.
+    optimizer : str or optax optimizer
+        Optimizer. Default: 'adam'.
+    transfer_fn : callable, optional
+        Transfer function.
+    margin : float
+        Margin for loss.
+    callbacks : list, optional
+        Training callbacks.
+    use_scan : bool
+        Use ``jax.lax.scan``.
+    batch_size : int, optional
+        Mini-batch size.
+    lr_scheduler : str or optax.Schedule, optional
+        Learning rate schedule.
+    lr_scheduler_kwargs : dict, optional
+        Scheduler kwargs.
+    prototypes_initializer : str or callable, optional
+        Prototype initialization.
+    patience : int, optional
+        Early stopping patience.
+    restore_best : bool
+        Restore best parameters.
+    class_weight : dict or 'balanced', optional
+        Class weights.
+    gradient_accumulation_steps : int, optional
+        Gradient accumulation.
+    ema_decay : float, optional
+        EMA decay.
+    freeze_params : list of str, optional
+        Frozen parameter groups.
+    lookahead : dict, optional
+        Lookahead settings.
+    mixed_precision : str, optional
+        Mixed precision dtype.
+
+    Attributes
+    ----------
+    prototype_means_ : array of shape (n_prototypes, n_features)
+        Learned means.
+    prototype_variances_ : array of shape (n_prototypes, n_features)
+        Learned variances.
+    relevances_ : array of shape (n_features,)
+        Learned relevance weights (softmax-normalized).
+    """
+
+    def __init__(self, beta=10.0, n_prototypes_per_class=1,
+                 max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
+                 optimizer='adam', transfer_fn=None, margin=0.0,
+                 callbacks=None, use_scan=True, batch_size=None,
+                 lr_scheduler=None, lr_scheduler_kwargs=None,
+                 prototypes_initializer=None, patience=None,
+                 restore_best=False, class_weight=None,
+                 gradient_accumulation_steps=None, ema_decay=None,
+                 freeze_params=None, lookahead=None,
+                 mixed_precision=None):
+        super().__init__(
+            n_prototypes_per_class=n_prototypes_per_class,
+            max_iter=max_iter, lr=lr, epsilon=epsilon,
+            random_seed=random_seed, distance_fn=None,
+            optimizer=optimizer, transfer_fn=transfer_fn, margin=margin,
+            callbacks=callbacks, use_scan=use_scan, batch_size=batch_size,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            prototypes_initializer=prototypes_initializer,
+            patience=patience, restore_best=restore_best,
+            class_weight=class_weight,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            ema_decay=ema_decay, freeze_params=freeze_params,
+            lookahead=lookahead, mixed_precision=mixed_precision,
+        )
+        self.beta = beta
+        self.relevances_ = None
+        self.prototype_means_ = None
+        self.prototype_variances_ = None
+
+    def _get_resume_params(self, params):
+        return {
+            'prototypes': params['prototypes'],
+            'log_variances': self._log_variances_,
+            'relevances': self._raw_relevances_,
+        }
+
+    def _init_state(self, X, y, key):
+        n_features = X.shape[1]
+        key1, key2 = jax.random.split(key)
+
+        prototypes, proto_labels = self._init_prototypes(
+            X, y, self.n_prototypes_per_class, key1
+        )
+
+        # Initialize uniform relevances
+        relevances = jnp.ones(n_features) / n_features
+
+        # Initialize log-variances from per-class variance
+        n_protos = prototypes.shape[0]
+        class_vars = []
+        for i in range(n_protos):
+            mask = y == proto_labels[i]
+            class_data = X[mask]
+            var = jnp.var(class_data, axis=0)
+            class_vars.append(var)
+        class_vars = jnp.stack(class_vars)
+        log_variances = jnp.log(jnp.maximum(class_vars, 1e-6))
+
+        params = {
+            'prototypes': prototypes,
+            'log_variances': log_variances,
+            'relevances': relevances,
+        }
+        opt_state = self._optimizer.init(params)
+        state = SupervisedState(
+            prototypes=prototypes,
+            opt_state=opt_state,
+            loss=jnp.array(float('inf')),
+            iteration=0,
+            converged=False,
+        )
+        return state, params, proto_labels
+
+    def _compute_loss(self, params, X, y, proto_labels):
+        means = params['prototypes']
+        log_variances = params['log_variances']
+        relevances = params['relevances']
+        distances = wasserstein2_relevance_distance_matrix(
+            X, means, log_variances, relevances
+        )
+        return glvq_loss_with_transfer(
+            distances, y, proto_labels,
+            transfer_fn=self.transfer_fn,
+            margin=self.margin,
+            beta=self.beta,
+        )
+
+    def _compute_distances_for_rejection(self, X):
+        """Relevance-weighted W2 distances for reject option."""
+        log_vars = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+        # Use raw relevances (pre-softmax) for consistency
+        relevances = self._raw_relevances_
+        return wasserstein2_relevance_distance_matrix(
+            X, self.prototypes_, log_vars, relevances
+        )
+
+    def _extract_results(self, params, proto_labels, loss_history, n_iter, **kwargs):
+        super()._extract_results(params, proto_labels, loss_history, n_iter, **kwargs)
+        self.relevances_ = jax.nn.softmax(params['relevances'])
+        self._raw_relevances_ = params['relevances']
+        self.prototype_means_ = params['prototypes']
+        self.prototype_variances_ = jnp.exp(params['log_variances'])
+        self._log_variances_ = params['log_variances']
+
+    @property
+    def relevance_profile(self):
+        """Return the learned relevance weights (normalized via softmax)."""
+        if self.relevances_ is None:
+            raise ValueError("Model not fitted. Call fit() first.")
+        return self.relevances_
+
+    def predict(self, X):
+        """Predict class labels using relevance-weighted W2 distance.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        labels : array of shape (n_samples,)
+        """
+        self._check_fitted()
+        X = jnp.asarray(X, dtype=jnp.float32)
+        log_vars = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+        distances = wasserstein2_relevance_distance_matrix(
+            X, self.prototypes_, log_vars, self._raw_relevances_
+        )
+        return wtac(distances, self.prototype_labels_)
+
+    def _get_quantizable_attrs(self):
+        attrs = super()._get_quantizable_attrs()
+        if self.relevances_ is not None:
+            attrs.append('relevances_')
+        if self.prototype_variances_ is not None:
+            attrs.append('prototype_variances_')
+        return attrs
+
+    def _get_fitted_arrays(self):
+        arrays = super()._get_fitted_arrays()
+        if self.relevances_ is not None:
+            arrays['relevances_'] = np.asarray(self.relevances_)
+        if self.prototype_variances_ is not None:
+            arrays['prototype_variances_'] = np.asarray(self.prototype_variances_)
+        if self._raw_relevances_ is not None:
+            arrays['_raw_relevances_'] = np.asarray(self._raw_relevances_)
+        return arrays
+
+    def _set_fitted_arrays(self, arrays):
+        super()._set_fitted_arrays(arrays)
+        if 'relevances_' in arrays:
+            self.relevances_ = jnp.asarray(arrays['relevances_'])
+        if 'prototype_variances_' in arrays:
+            self.prototype_variances_ = jnp.asarray(arrays['prototype_variances_'])
+            self._log_variances_ = jnp.log(jnp.maximum(self.prototype_variances_, 1e-6))
+            self.prototype_means_ = self.prototypes_
+        if '_raw_relevances_' in arrays:
+            self._raw_relevances_ = jnp.asarray(arrays['_raw_relevances_'])
+
+    def _get_hyperparams(self):
+        hp = super()._get_hyperparams()
+        hp['beta'] = self.beta
+        return hp

--- a/sphinx-docs/guides/riemannian.rst
+++ b/sphinx-docs/guides/riemannian.rst
@@ -26,15 +26,84 @@ Supported Manifolds
      - :math:`k`-dimensional subspaces of :math:`\mathbb{R}^n`
      - Hyperspectral imaging, video analysis, subspace tracking
 
-All three are available from ``prosemble.core.manifolds``:
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Manifold
+     - Points
+     - Applications
+   * - **HyperbolicPoincare(d)**
+     - Vectors in :math:`\mathbb{B}^d = \{x \in \mathbb{R}^d : \|x\| < 1\}`
+     - Hierarchical data, taxonomy embeddings, NLP trees
+
+All four are available from ``prosemble.core.manifolds``:
 
 .. code-block:: python
 
-   from prosemble.core.manifolds import SO, SPD, Grassmannian
+   from prosemble.core.manifolds import SO, SPD, Grassmannian, HyperbolicPoincare
 
    so3 = SO(3)           # 3x3 rotation matrices
    spd4 = SPD(4)         # 4x4 SPD matrices
    gr5_2 = Grassmannian(5, 2)  # 2D subspaces of R^5
+   hyp8 = HyperbolicPoincare(8)  # 8D Poincare ball
+
+HyperbolicPoincare
+~~~~~~~~~~~~~~~~~~
+
+The Poincare ball model of hyperbolic geometry.  Points live in the open
+unit ball :math:`\mathbb{B}^d = \{x \in \mathbb{R}^d : \|x\| < 1\}` with
+the Riemannian metric tensor :math:`g_x = \lambda_x^2 I` where
+:math:`\lambda_x = 2/(1 - \|x\|^2)` is the conformal factor.
+
+The geodesic distance is:
+
+.. math::
+
+   d(x, y) = \text{arcosh}\!\left(1 + \frac{2\|x - y\|^2}{(1 - \|x\|^2)(1 - \|y\|^2)}\right)
+
+Prototype updates use the exponential and logarithmic maps based on
+Mobius addition:
+
+.. math::
+
+   \text{Exp}_x(v) = x \oplus \left(\tanh\!\left(\frac{\lambda_x \|v\|}{2}\right) \cdot \frac{v}{\|v\|}\right)
+
+.. math::
+
+   \text{Log}_x(y) = \frac{2}{\lambda_x} \text{arctanh}(\|-x \oplus y\|) \cdot \frac{-x \oplus y}{\|-x \oplus y\|}
+
+Hyperbolic space is particularly suited for data with hierarchical or
+tree-like structure, as distances grow exponentially toward the boundary.
+
+.. code-block:: python
+
+   from prosemble.models import RiemannianSRNG
+   from prosemble.core.manifolds import HyperbolicPoincare
+   import jax
+   import jax.numpy as jnp
+
+   manifold = HyperbolicPoincare(4)
+
+   # Generate data inside the Poincare ball
+   key = jax.random.PRNGKey(0)
+   X = jax.random.normal(key, (40, 4)) * 0.3
+   X = jax.vmap(manifold.project)(X)  # ensure points lie in ball
+   X = X.reshape(40, -1)
+   y = jnp.array([0] * 20 + [1] * 20)
+
+   model = RiemannianSRNG(
+       manifold=manifold,
+       n_prototypes_per_class=2,
+       max_iter=50,
+       lr=0.01,
+   )
+   model.fit(X, y)
+   labels = model.predict(X)
+
+All supervised Riemannian models (RiemannianSRNG, RiemannianSMNG,
+RiemannianSLNG, RiemannianSTNG) and the unsupervised RiemannianNeuralGas
+work with ``HyperbolicPoincare`` without any code changes.
 
 RiemannianSRNG
 --------------
@@ -222,3 +291,23 @@ Choosing a Model
    * - RiemannianNeuralGas
      - Geodesic distance
      - Unsupervised manifold clustering
+
+.. list-table:: Supported Manifold Selection
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Manifold
+     - Geometry
+     - Use When
+   * - SO(n)
+     - Rotation matrices
+     - Pose estimation, robotics, structural biology
+   * - SPD(n)
+     - Positive definite matrices
+     - Covariance matrices (EEG/BCI, DTI)
+   * - Grassmannian(n, k)
+     - Subspaces of :math:`\mathbb{R}^n`
+     - Video/image subspace analysis
+   * - HyperbolicPoincare(d)
+     - Poincare ball :math:`\mathbb{B}^d`
+     - Hierarchical/tree-structured data

--- a/sphinx-docs/guides/supervised.rst
+++ b/sphinx-docs/guides/supervised.rst
@@ -150,6 +150,90 @@ distance only in directions orthogonal to the invariance subspace:
    )
    model.fit(X_train, y_train)
 
+Wasserstein Prototype LVQ
+--------------------------
+
+The Wasserstein LVQ family uses Gaussian distributional prototypes instead
+of point prototypes.  Each prototype :math:`k` is a diagonal Gaussian
+:math:`\mathcal{N}(\mu_k, \text{diag}(\sigma_k^2))`.  The distance from
+a data point :math:`x` (treated as a Dirac delta) to prototype :math:`k`
+is the squared 2-Wasserstein distance:
+
+.. math::
+
+   W_2^2(\delta_x, \mathcal{N}(\mu_k, \text{diag}(\sigma_k^2)))
+   = \|x - \mu_k\|^2 + \sum_j \sigma_{kj}^2
+
+The variance term acts as a per-prototype learned "spread" — prototypes
+with smaller variance are more specific and attract nearby points more
+strongly.
+
+**WGLVQ** — Wasserstein GLVQ (base variant):
+
+.. code-block:: python
+
+   from prosemble.models import WGLVQ
+
+   model = WGLVQ(
+       n_prototypes_per_class=2,
+       max_iter=100,
+       lr=0.01,
+   )
+   model.fit(X_train, y_train)
+
+   # Learned prototype means and variances
+   print(model.prototype_means.shape)      # (n_prototypes, n_features)
+   print(model.prototype_variances.shape)   # (n_prototypes, n_features)
+
+**WGMLVQ** — Adds a global :math:`\Omega` matrix projection:
+
+.. math::
+
+   W_2^2(x, k) = \|\Omega(x - \mu_k)\|^2 + \sum_j \sigma_{kj}^2
+
+.. code-block:: python
+
+   from prosemble.models import WGMLVQ
+
+   model = WGMLVQ(
+       n_prototypes_per_class=2,
+       latent_dim=2,          # project to 2D
+       max_iter=100,
+       lr=0.001,
+   )
+   model.fit(X_train, y_train)
+
+   print(model.omega_matrix.shape)   # (n_features, latent_dim)
+   print(model.lambda_matrix)        # Omega^T @ Omega
+
+**WGRLVQ** — Adds per-feature relevance weighting:
+
+.. math::
+
+   W_2^2(x, k) = \sum_j \lambda_j (x_j - \mu_{kj})^2 + \sum_j \sigma_{kj}^2
+
+where :math:`\lambda_j \geq 0` and :math:`\sum_j \lambda_j = 1`.
+
+.. code-block:: python
+
+   from prosemble.models import WGRLVQ
+
+   model = WGRLVQ(
+       n_prototypes_per_class=2,
+       max_iter=100,
+       lr=0.01,
+   )
+   model.fit(X_train, y_train)
+
+   # Learned relevance profile
+   print(model.relevance_profile)   # shape: (n_features,), sums to 1
+
+.. note::
+
+   Variances are parameterized internally as :math:`\log(\sigma^2)` to ensure
+   positivity during gradient optimization.  Access the actual variances via
+   ``model.prototype_variances``.
+
 CELVQ — Cross-Entropy
 ----------------------
 

--- a/tests/test_hyperbolic.py
+++ b/tests/test_hyperbolic.py
@@ -1,0 +1,292 @@
+"""Tests for Hyperbolic Poincare Ball manifold and Riemannian LVQ integration."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tempfile
+import os
+
+from prosemble.core.manifolds import HyperbolicPoincare, _mobius_add, _conformal_factor
+from prosemble.models import RiemannianSRNG, RiemannianSMNG
+
+
+# ---------------------------------------------------------------------------
+# Manifold axiom tests
+# ---------------------------------------------------------------------------
+
+class TestHyperbolicPoincareManifold:
+    """Test that HyperbolicPoincare satisfies manifold axioms."""
+
+    @pytest.fixture
+    def manifold(self):
+        return HyperbolicPoincare(4)
+
+    @pytest.fixture
+    def points(self, manifold):
+        """Generate random points on the Poincare ball."""
+        keys = jax.random.split(jax.random.PRNGKey(42), 5)
+        return jnp.stack([manifold.random_point(k) for k in keys])
+
+    def test_random_point_in_ball(self, manifold):
+        """Random points must lie strictly inside the unit ball."""
+        keys = jax.random.split(jax.random.PRNGKey(0), 20)
+        for key in keys:
+            p = manifold.random_point(key)
+            assert p.shape == (4,)
+            assert float(jnp.linalg.norm(p)) < 1.0
+
+    def test_belongs(self, manifold, points):
+        """All generated points must pass the belongs check."""
+        for i in range(points.shape[0]):
+            assert manifold.belongs(points[i])
+
+    def test_belongs_rejects_outside(self, manifold):
+        """Points outside the ball must fail belongs."""
+        outside = jnp.array([1.5, 0.0, 0.0, 0.0])
+        assert not manifold.belongs(outside)
+
+    def test_project_clamps_to_ball(self, manifold):
+        """Projection must bring points inside the ball."""
+        outside = jnp.array([2.0, 1.0, 0.5, 0.3])
+        projected = manifold.project(outside)
+        assert float(jnp.linalg.norm(projected)) < 1.0
+        assert manifold.belongs(projected)
+
+    def test_project_preserves_interior(self, manifold, points):
+        """Projection of interior points should not change them."""
+        for i in range(points.shape[0]):
+            projected = manifold.project(points[i])
+            np.testing.assert_allclose(
+                np.asarray(projected), np.asarray(points[i]), atol=1e-6
+            )
+
+    def test_distance_non_negative(self, manifold, points):
+        """Geodesic distance must be non-negative."""
+        for i in range(points.shape[0]):
+            for j in range(points.shape[0]):
+                d = manifold.distance(points[i], points[j])
+                assert float(d) >= 0.0
+
+    def test_distance_self_zero(self, manifold, points):
+        """Distance from a point to itself must be approximately zero."""
+        for i in range(points.shape[0]):
+            d = manifold.distance(points[i], points[i])
+            # Limited by arcosh clamp (1e-6) for gradient stability
+            assert float(d) < 2e-3
+
+    def test_distance_symmetric(self, manifold, points):
+        """Geodesic distance must be symmetric."""
+        for i in range(points.shape[0]):
+            for j in range(i + 1, points.shape[0]):
+                d_ij = manifold.distance(points[i], points[j])
+                d_ji = manifold.distance(points[j], points[i])
+                np.testing.assert_allclose(float(d_ij), float(d_ji), atol=1e-5)
+
+    def test_triangle_inequality(self, manifold, points):
+        """Geodesic distance must satisfy the triangle inequality."""
+        for i in range(3):
+            for j in range(i + 1, 4):
+                for k in range(j + 1, 5):
+                    d_ij = float(manifold.distance(points[i], points[j]))
+                    d_jk = float(manifold.distance(points[j], points[k]))
+                    d_ik = float(manifold.distance(points[i], points[k]))
+                    assert d_ik <= d_ij + d_jk + 1e-5
+
+    def test_exp_log_roundtrip(self, manifold, points):
+        """exp_x(log_x(y)) should approximately recover y."""
+        for i in range(points.shape[0]):
+            for j in range(points.shape[0]):
+                if i == j:
+                    continue
+                x, y = points[i], points[j]
+                v = manifold.log_map(x, y)
+                y_recovered = manifold.exp_map(x, v)
+                # Float32 precision limits roundtrip accuracy for distant points
+                np.testing.assert_allclose(
+                    np.asarray(y_recovered), np.asarray(y), atol=5e-3
+                )
+
+    def test_log_exp_roundtrip(self, manifold, points):
+        """log_x(exp_x(v)) should approximately recover v for small v."""
+        x = points[0]
+        # Use a small tangent vector
+        v = jnp.array([0.05, -0.03, 0.02, -0.01])
+        y = manifold.exp_map(x, v)
+        v_recovered = manifold.log_map(x, y)
+        np.testing.assert_allclose(
+            np.asarray(v_recovered), np.asarray(v), atol=1e-3
+        )
+
+    def test_distance_squared_consistent(self, manifold, points):
+        """distance_squared should equal distance^2."""
+        for i in range(3):
+            for j in range(i + 1, 4):
+                d = manifold.distance(points[i], points[j])
+                d2 = manifold.distance_squared(points[i], points[j])
+                np.testing.assert_allclose(float(d2), float(d) ** 2, atol=1e-5)
+
+    def test_injectivity_radius(self, manifold):
+        """Poincare ball has infinite injectivity radius."""
+        x = jnp.zeros(4)
+        assert float(manifold.injectivity_radius(x)) == float('inf')
+
+
+# ---------------------------------------------------------------------------
+# Mobius addition tests
+# ---------------------------------------------------------------------------
+
+class TestMobiusAddition:
+
+    def test_identity_element(self):
+        """Mobius addition with origin should be identity."""
+        x = jnp.array([0.3, -0.2, 0.1])
+        zero = jnp.zeros(3)
+        result = _mobius_add(zero, x)
+        np.testing.assert_allclose(np.asarray(result), np.asarray(x), atol=1e-6)
+
+    def test_inverse(self):
+        """x + (-x) should give (approximately) the origin."""
+        x = jnp.array([0.3, -0.2, 0.1])
+        result = _mobius_add(x, -x)
+        np.testing.assert_allclose(np.asarray(result), np.zeros(3), atol=1e-5)
+
+    def test_conformal_factor_at_origin(self):
+        """Conformal factor at origin should be 2."""
+        origin = jnp.zeros(4)
+        lam = _conformal_factor(origin)
+        np.testing.assert_allclose(float(lam), 2.0, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Supervised Riemannian model integration tests
+# ---------------------------------------------------------------------------
+
+def _make_hyperbolic_data(d=4, n_per_class=15, seed=0):
+    """Create two classes of points in the Poincare ball.
+
+    Class 0 points cluster near one region, class 1 near another.
+    """
+    manifold = HyperbolicPoincare(d)
+    key = jax.random.PRNGKey(seed)
+    k1, k2 = jax.random.split(key)
+
+    # Class 0: points near a center
+    center0 = jnp.zeros(d).at[0].set(0.3)
+    noise0 = jax.random.normal(k1, (n_per_class, d)) * 0.05
+    class0 = jax.vmap(manifold.project)(center0 + noise0)
+
+    # Class 1: points near a different center
+    center1 = jnp.zeros(d).at[0].set(-0.3)
+    noise1 = jax.random.normal(k2, (n_per_class, d)) * 0.05
+    class1 = jax.vmap(manifold.project)(center1 + noise1)
+
+    X = jnp.concatenate([class0, class1], axis=0)
+    y = jnp.array([0] * n_per_class + [1] * n_per_class)
+    return manifold, X, y
+
+
+class TestRiemannianSRNGHyperbolic:
+
+    def test_fit_loss_decreases(self):
+        manifold, X, y = _make_hyperbolic_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=20, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    def test_prototypes_on_manifold(self):
+        manifold, X, y = _make_hyperbolic_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        n_protos = model.prototypes_.shape[0]
+        protos = model.prototypes_.reshape(n_protos, *manifold.point_shape)
+        for i in range(n_protos):
+            assert manifold.belongs(protos[i]), f"Prototype {i} not on manifold"
+
+    def test_predict_returns_valid_labels(self):
+        manifold, X, y = _make_hyperbolic_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        unique_preds = set(np.asarray(preds).tolist())
+        assert unique_preds.issubset({0, 1})
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_hyperbolic_data()
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = RiemannianSRNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+    def test_classification_accuracy(self):
+        """With well-separated classes, accuracy should be reasonable."""
+        manifold, X, y = _make_hyperbolic_data(d=4, n_per_class=20, seed=1)
+        model = RiemannianSRNG(
+            manifold=manifold, n_prototypes_per_class=2,
+            max_iter=50, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        accuracy = float(jnp.mean(preds == y))
+        assert accuracy > 0.7, f"Accuracy too low: {accuracy}"
+
+
+class TestRiemannianSMNGHyperbolic:
+
+    def test_fit_loss_decreases(self):
+        manifold, X, y = _make_hyperbolic_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.001, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    def test_predict_returns_valid_labels(self):
+        manifold, X, y = _make_hyperbolic_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.001, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+        unique_preds = set(np.asarray(preds).tolist())
+        assert unique_preds.issubset({0, 1})
+
+    def test_save_load_roundtrip(self):
+        manifold, X, y = _make_hyperbolic_data()
+        model = RiemannianSMNG(
+            manifold=manifold, n_prototypes_per_class=1,
+            max_iter=10, lr=0.001, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = RiemannianSMNG.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)

--- a/tests/test_wasserstein.py
+++ b/tests/test_wasserstein.py
@@ -1,0 +1,302 @@
+"""Tests for Wasserstein LVQ models and distance functions."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tempfile
+import os
+
+from prosemble.core.distance import (
+    wasserstein2_distance_matrix,
+    wasserstein2_omega_distance_matrix,
+    wasserstein2_relevance_distance_matrix,
+    squared_euclidean_distance_matrix,
+)
+from prosemble.models.wasserstein_glvq import WGLVQ
+from prosemble.models.wasserstein_gmlvq import WGMLVQ
+from prosemble.models.wasserstein_grlvq import WGRLVQ
+
+
+# ---------------------------------------------------------------------------
+# Distance function tests
+# ---------------------------------------------------------------------------
+
+class TestWasserstein2Distance:
+
+    def test_analytical_correctness(self):
+        """Hand-computed W2 distance."""
+        # x = [1, 2], mu = [0, 0], sigma^2 = [1, 1]
+        # W2^2 = (1-0)^2 + (2-0)^2 + 1 + 1 = 1 + 4 + 2 = 7
+        X = jnp.array([[1.0, 2.0]])
+        means = jnp.array([[0.0, 0.0]])
+        log_vars = jnp.array([[0.0, 0.0]])  # exp(0) = 1
+        D = wasserstein2_distance_matrix(X, means, log_vars)
+        np.testing.assert_allclose(float(D[0, 0]), 7.0, atol=1e-5)
+
+    def test_zero_variance_equals_euclidean(self):
+        """When variance is zero, W2 should equal squared Euclidean."""
+        key = jax.random.PRNGKey(42)
+        X = jax.random.normal(key, (10, 4))
+        means = jax.random.normal(jax.random.PRNGKey(1), (3, 4))
+        # log_var = -inf => var = 0, but use very small for numerical stability
+        log_vars = jnp.full((3, 4), -30.0)  # exp(-30) ≈ 0
+        w2 = wasserstein2_distance_matrix(X, means, log_vars)
+        eucl = squared_euclidean_distance_matrix(X, means)
+        np.testing.assert_allclose(np.asarray(w2), np.asarray(eucl), atol=1e-4)
+
+    def test_variance_increases_distance(self):
+        """Higher variance should increase W2 distance."""
+        X = jnp.array([[0.0, 0.0]])
+        means = jnp.array([[0.0, 0.0]])
+        log_vars_small = jnp.array([[-2.0, -2.0]])
+        log_vars_large = jnp.array([[2.0, 2.0]])
+        d_small = wasserstein2_distance_matrix(X, means, log_vars_small)
+        d_large = wasserstein2_distance_matrix(X, means, log_vars_large)
+        assert float(d_large[0, 0]) > float(d_small[0, 0])
+
+    def test_output_shape(self):
+        """Output shape should be (n, p)."""
+        X = jnp.ones((10, 5))
+        means = jnp.ones((3, 5))
+        log_vars = jnp.zeros((3, 5))
+        D = wasserstein2_distance_matrix(X, means, log_vars)
+        assert D.shape == (10, 3)
+
+    def test_non_negative(self):
+        """W2 distances must be non-negative."""
+        key = jax.random.PRNGKey(0)
+        X = jax.random.normal(key, (20, 4))
+        means = jax.random.normal(jax.random.PRNGKey(1), (5, 4))
+        log_vars = jax.random.normal(jax.random.PRNGKey(2), (5, 4)) * 0.5
+        D = wasserstein2_distance_matrix(X, means, log_vars)
+        assert jnp.all(D >= 0.0)
+
+
+class TestWasserstein2OmegaDistance:
+
+    def test_identity_omega_matches_base(self):
+        """With identity omega, should match base W2 distance."""
+        X = jax.random.normal(jax.random.PRNGKey(0), (10, 4))
+        means = jax.random.normal(jax.random.PRNGKey(1), (3, 4))
+        log_vars = jnp.zeros((3, 4))
+        omega = jnp.eye(4)
+        d_omega = wasserstein2_omega_distance_matrix(X, means, log_vars, omega)
+        d_base = wasserstein2_distance_matrix(X, means, log_vars)
+        np.testing.assert_allclose(
+            np.asarray(d_omega), np.asarray(d_base), atol=1e-4
+        )
+
+    def test_output_shape(self):
+        """Output shape should be (n, p)."""
+        X = jnp.ones((10, 5))
+        means = jnp.ones((3, 5))
+        log_vars = jnp.zeros((3, 5))
+        omega = jnp.eye(5, 3)  # Project to 3D
+        D = wasserstein2_omega_distance_matrix(X, means, log_vars, omega)
+        assert D.shape == (10, 3)
+
+
+class TestWasserstein2RelevanceDistance:
+
+    def test_uniform_relevance_matches_scaled_euclidean(self):
+        """With uniform relevances, should match scaled squared Euclidean + spread."""
+        X = jax.random.normal(jax.random.PRNGKey(0), (10, 4))
+        means = jax.random.normal(jax.random.PRNGKey(1), (3, 4))
+        log_vars = jnp.zeros((3, 4))
+        # Uniform relevances: softmax of equal values = 1/d each
+        relevances = jnp.zeros(4)
+        D = wasserstein2_relevance_distance_matrix(X, means, log_vars, relevances)
+        assert D.shape == (10, 3)
+        # Each component weighted by 0.25 + variance spread
+        eucl = squared_euclidean_distance_matrix(X, means) * 0.25
+        spread = jnp.sum(jnp.exp(log_vars), axis=1)
+        expected = eucl + spread[None, :]
+        np.testing.assert_allclose(np.asarray(D), np.asarray(expected), atol=1e-4)
+
+    def test_output_shape(self):
+        X = jnp.ones((10, 5))
+        means = jnp.ones((3, 5))
+        log_vars = jnp.zeros((3, 5))
+        relevances = jnp.ones(5)
+        D = wasserstein2_relevance_distance_matrix(X, means, log_vars, relevances)
+        assert D.shape == (10, 3)
+
+
+# ---------------------------------------------------------------------------
+# WGLVQ model tests
+# ---------------------------------------------------------------------------
+
+def _make_iris_data():
+    """Simple 3-class data for testing."""
+    from prosemble.datasets import load_iris_jax
+    dataset = load_iris_jax()
+    return dataset.input_data, dataset.labels
+
+
+class TestWGLVQ:
+
+    def test_fit_loss_decreases(self):
+        X, y = _make_iris_data()
+        model = WGLVQ(
+            n_prototypes_per_class=1, max_iter=30,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    def test_predict_shape(self):
+        X, y = _make_iris_data()
+        model = WGLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds = model.predict(X)
+        assert preds.shape == y.shape
+
+    def test_variance_positivity(self):
+        X, y = _make_iris_data()
+        model = WGLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.prototype_variances_ > 0.0)
+
+    def test_prototype_means_match_prototypes(self):
+        X, y = _make_iris_data()
+        model = WGLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        np.testing.assert_array_equal(
+            np.asarray(model.prototype_means_),
+            np.asarray(model.prototypes_),
+        )
+
+    def test_save_load_roundtrip(self):
+        X, y = _make_iris_data()
+        model = WGLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = WGLVQ.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+
+# ---------------------------------------------------------------------------
+# WGMLVQ model tests
+# ---------------------------------------------------------------------------
+
+class TestWGMLVQ:
+
+    def test_fit_loss_decreases(self):
+        X, y = _make_iris_data()
+        model = WGMLVQ(
+            n_prototypes_per_class=1, max_iter=30,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    def test_omega_shape(self):
+        X, y = _make_iris_data()
+        model = WGMLVQ(
+            latent_dim=2, n_prototypes_per_class=1,
+            max_iter=10, lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.omega_matrix.shape == (4, 2)
+
+    def test_lambda_matrix(self):
+        X, y = _make_iris_data()
+        model = WGMLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        lam = model.lambda_matrix
+        assert lam.shape == (4, 4)
+        # Lambda should be symmetric
+        np.testing.assert_allclose(
+            np.asarray(lam), np.asarray(lam.T), atol=1e-5
+        )
+
+    def test_save_load_roundtrip(self):
+        X, y = _make_iris_data()
+        model = WGMLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = WGMLVQ.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)
+
+
+# ---------------------------------------------------------------------------
+# WGRLVQ model tests
+# ---------------------------------------------------------------------------
+
+class TestWGRLVQ:
+
+    def test_fit_loss_decreases(self):
+        X, y = _make_iris_data()
+        model = WGRLVQ(
+            n_prototypes_per_class=1, max_iter=30,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert model.loss_history_[0] > model.loss_history_[-1]
+
+    def test_relevance_profile_sums_to_one(self):
+        X, y = _make_iris_data()
+        model = WGRLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        rel = model.relevance_profile
+        np.testing.assert_allclose(float(jnp.sum(rel)), 1.0, atol=1e-5)
+
+    def test_relevance_non_negative(self):
+        X, y = _make_iris_data()
+        model = WGRLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        assert jnp.all(model.relevance_profile >= 0.0)
+
+    def test_save_load_roundtrip(self):
+        X, y = _make_iris_data()
+        model = WGRLVQ(
+            n_prototypes_per_class=1, max_iter=10,
+            lr=0.01, use_scan=False,
+        )
+        model.fit(X, y)
+        preds_before = model.predict(X)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.npz')
+            model.save(path)
+            loaded = WGRLVQ.load(path)
+
+        preds_after = loaded.predict(X)
+        np.testing.assert_array_equal(preds_before, preds_after)


### PR DESCRIPTION
## Summary
- **Wasserstein Prototype LVQ** (novel): WGLVQ, WGMLVQ, WGRLVQ — Gaussian distributional prototypes with 2-Wasserstein distance replacing point prototypes
- **HyperbolicPoincare manifold**: Poincare ball model enabling all Riemannian models (SRNG, SMNG, SLNG, STNG + DK variants) on hyperbolic data
- Gradient-safe implementations fixing norm singularity at coincident points
- Sphinx documentation and tests for both model families

## Test plan
- [x] `pytest tests/test_hyperbolic.py -v` — manifold axioms + Riemannian model integration
- [x] `pytest tests/test_wasserstein.py -v` — distance correctness + model fit/predict/save/load
- [x] `pytest tests/ -x` — full suite, no regressions