### PR TITLE
feat: Add separate learning rates for Neural Gas models

### DIFF
--- a/prosemble/models/dk_glvq_ng.py
+++ b/prosemble/models/dk_glvq_ng.py
@@ -140,7 +140,7 @@ class DKGLVQ_NG(SupervisedPrototypeModel):
 
     def __init__(self, sigma_init='median', sigma_min=1e-3, beta=10.0,
                  gamma_init=None, gamma_final=0.01, gamma_decay=None,
-                 n_prototypes_per_class=1, max_iter=100,
+                 lr_ratio=0.5, n_prototypes_per_class=1, max_iter=100,
                  lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=True, batch_size=None,
@@ -171,6 +171,7 @@ class DKGLVQ_NG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
         self.gamma_ = None
 
@@ -274,6 +275,11 @@ class DKGLVQ_NG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: ε⁻ = lr_ratio × ε⁺)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         # GLVQ mu for each (sample, prototype) pair
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
@@ -353,4 +359,5 @@ class DKGLVQ_NG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/dk_matrix_lvq_ng.py
+++ b/prosemble/models/dk_matrix_lvq_ng.py
@@ -136,7 +136,7 @@ class DKGMLVQ_NG(SupervisedPrototypeModel):
 
     def __init__(self, latent_dim=None, omega_hat_scale=0.1, beta=10.0,
                  gamma_init=None, gamma_final=0.01, gamma_decay=None,
-                 n_prototypes_per_class=1, max_iter=100,
+                 lr_ratio=0.5, n_prototypes_per_class=1, max_iter=100,
                  lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=True, batch_size=None,
@@ -167,6 +167,7 @@ class DKGMLVQ_NG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.omega_hat_ = None
         self.gamma_ = None
 
@@ -255,6 +256,11 @@ class DKGMLVQ_NG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: ε⁻ = lr_ratio × ε⁺)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         from prosemble.core.activations import sigmoid_beta
@@ -331,6 +337,7 @@ class DKGMLVQ_NG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         if self.latent_dim is not None:
             hp['latent_dim'] = self.latent_dim
         return hp

--- a/prosemble/models/dk_relevance_lvq_ng.py
+++ b/prosemble/models/dk_relevance_lvq_ng.py
@@ -144,7 +144,7 @@ class DKGRLVQ_NG(SupervisedPrototypeModel):
 
     def __init__(self, sigma_init='median', sigma_min=1e-3, beta=10.0,
                  gamma_init=None, gamma_final=0.01, gamma_decay=None,
-                 n_prototypes_per_class=1, max_iter=100,
+                 lr_ratio=0.5, n_prototypes_per_class=1, max_iter=100,
                  lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=True, batch_size=None,
@@ -175,6 +175,7 @@ class DKGRLVQ_NG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
         self.relevances_ = None
         self.gamma_ = None
@@ -282,6 +283,11 @@ class DKGRLVQ_NG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: ε⁻ = lr_ratio × ε⁺)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         from prosemble.core.activations import sigmoid_beta
@@ -373,4 +379,5 @@ class DKGRLVQ_NG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_glvq.py
+++ b/prosemble/models/riemannian_dk_glvq.py
@@ -120,7 +120,8 @@ class RiemannianDKGLVQ(RiemannianSRNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  beta=10.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 gamma_decay=None, tau=0.95, lr_ratio=0.5,
+                 n_prototypes_per_class=1,
                  max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=False, batch_size=None,
@@ -133,7 +134,7 @@ class RiemannianDKGLVQ(RiemannianSRNG):
         super().__init__(
             manifold=manifold, beta=beta,
             gamma_init=gamma_init, gamma_final=gamma_final,
-            gamma_decay=gamma_decay, tau=tau,
+            gamma_decay=gamma_decay, tau=tau, lr_ratio=lr_ratio,
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
             random_seed=random_seed, optimizer=optimizer,

--- a/prosemble/models/riemannian_dk_m_slng.py
+++ b/prosemble/models/riemannian_dk_m_slng.py
@@ -126,7 +126,8 @@ class RiemannianDKMSLNG(RiemannianSLNG):
 
     def __init__(self, manifold, latent_dim=None, kernel_latent_dim=None,
                  omega_hat_scale=0.1, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -156,6 +157,7 @@ class RiemannianDKMSLNG(RiemannianSLNG):
         )
         self.kernel_latent_dim = kernel_latent_dim
         self.omega_hat_scale = omega_hat_scale
+        self.lr_ratio = lr_ratio
         self.omega_hat_ = None
 
     def _get_resume_params(self, params):
@@ -222,6 +224,11 @@ class RiemannianDKMSLNG(RiemannianSLNG):
 
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
+
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
 
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
@@ -300,4 +307,5 @@ class RiemannianDKMSLNG(RiemannianSLNG):
         hp['omega_hat_scale'] = self.omega_hat_scale
         if self.kernel_latent_dim is not None:
             hp['kernel_latent_dim'] = self.kernel_latent_dim
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_m_smng.py
+++ b/prosemble/models/riemannian_dk_m_smng.py
@@ -127,7 +127,8 @@ class RiemannianDKMSMNG(RiemannianSMNG):
 
     def __init__(self, manifold, latent_dim=None, kernel_latent_dim=None,
                  omega_hat_scale=0.1, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -157,6 +158,7 @@ class RiemannianDKMSMNG(RiemannianSMNG):
         )
         self.kernel_latent_dim = kernel_latent_dim
         self.omega_hat_scale = omega_hat_scale
+        self.lr_ratio = lr_ratio
         self.omega_hat_ = None
 
     def _get_resume_params(self, params):
@@ -222,6 +224,11 @@ class RiemannianDKMSMNG(RiemannianSMNG):
 
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
+
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
 
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
@@ -300,4 +307,5 @@ class RiemannianDKMSMNG(RiemannianSMNG):
         hp['omega_hat_scale'] = self.omega_hat_scale
         if self.kernel_latent_dim is not None:
             hp['kernel_latent_dim'] = self.kernel_latent_dim
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_m_stng.py
+++ b/prosemble/models/riemannian_dk_m_stng.py
@@ -126,7 +126,8 @@ class RiemannianDKMSTNG(RiemannianSTNG):
 
     def __init__(self, manifold, kernel_latent_dim=None, omega_hat_scale=0.1,
                  subspace_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -156,6 +157,7 @@ class RiemannianDKMSTNG(RiemannianSTNG):
         )
         self.kernel_latent_dim = kernel_latent_dim
         self.omega_hat_scale = omega_hat_scale
+        self.lr_ratio = lr_ratio
         self.omega_hat_ = None
 
     def _get_resume_params(self, params):
@@ -223,6 +225,11 @@ class RiemannianDKMSTNG(RiemannianSTNG):
 
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
+
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
 
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
@@ -304,4 +311,5 @@ class RiemannianDKMSTNG(RiemannianSTNG):
         hp['omega_hat_scale'] = self.omega_hat_scale
         if self.kernel_latent_dim is not None:
             hp['kernel_latent_dim'] = self.kernel_latent_dim
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_matrix_lvq.py
+++ b/prosemble/models/riemannian_dk_matrix_lvq.py
@@ -133,7 +133,8 @@ class RiemannianDKGMLVQ(RiemannianSRNG):
 
     def __init__(self, manifold, latent_dim=None, omega_hat_scale=0.1,
                  beta=10.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 gamma_decay=None, tau=0.95, lr_ratio=0.5,
+                 n_prototypes_per_class=1,
                  max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=False, batch_size=None,
@@ -146,7 +147,7 @@ class RiemannianDKGMLVQ(RiemannianSRNG):
         super().__init__(
             manifold=manifold, beta=beta,
             gamma_init=gamma_init, gamma_final=gamma_final,
-            gamma_decay=gamma_decay, tau=tau,
+            gamma_decay=gamma_decay, tau=tau, lr_ratio=lr_ratio,
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
             random_seed=random_seed, optimizer=optimizer,

--- a/prosemble/models/riemannian_dk_r_slng.py
+++ b/prosemble/models/riemannian_dk_r_slng.py
@@ -130,7 +130,8 @@ class RiemannianDKRSLNG(RiemannianSLNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -160,6 +161,7 @@ class RiemannianDKRSLNG(RiemannianSLNG):
         )
         self.sigma_init = sigma_init
         self.sigma_min = sigma_min
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
         self.relevances_ = None
 
@@ -260,6 +262,11 @@ class RiemannianDKRSLNG(RiemannianSLNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         transfer = self.transfer_fn or sigmoid_beta
@@ -349,4 +356,5 @@ class RiemannianDKRSLNG(RiemannianSLNG):
         hp = super()._get_hyperparams()
         hp['sigma_init'] = self.sigma_init
         hp['sigma_min'] = self.sigma_min
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_r_smng.py
+++ b/prosemble/models/riemannian_dk_r_smng.py
@@ -130,7 +130,8 @@ class RiemannianDKRSMNG(RiemannianSMNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -160,6 +161,7 @@ class RiemannianDKRSMNG(RiemannianSMNG):
         )
         self.sigma_init = sigma_init
         self.sigma_min = sigma_min
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
         self.relevances_ = None
 
@@ -261,6 +263,11 @@ class RiemannianDKRSMNG(RiemannianSMNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         transfer = self.transfer_fn or sigmoid_beta
@@ -350,4 +357,5 @@ class RiemannianDKRSMNG(RiemannianSMNG):
         hp = super()._get_hyperparams()
         hp['sigma_init'] = self.sigma_init
         hp['sigma_min'] = self.sigma_min
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_r_stng.py
+++ b/prosemble/models/riemannian_dk_r_stng.py
@@ -129,7 +129,8 @@ class RiemannianDKRSTNG(RiemannianSTNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  subspace_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -159,6 +160,7 @@ class RiemannianDKRSTNG(RiemannianSTNG):
         )
         self.sigma_init = sigma_init
         self.sigma_min = sigma_min
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
         self.relevances_ = None
 
@@ -264,6 +266,11 @@ class RiemannianDKRSTNG(RiemannianSTNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         transfer = self.transfer_fn or sigmoid_beta
@@ -356,4 +363,5 @@ class RiemannianDKRSTNG(RiemannianSTNG):
         hp = super()._get_hyperparams()
         hp['sigma_init'] = self.sigma_init
         hp['sigma_min'] = self.sigma_min
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_relevance_lvq.py
+++ b/prosemble/models/riemannian_dk_relevance_lvq.py
@@ -130,7 +130,8 @@ class RiemannianDKGRLVQ(RiemannianSRNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  beta=10.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 gamma_decay=None, tau=0.95, lr_ratio=0.5,
+                 n_prototypes_per_class=1,
                  max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=False, batch_size=None,
@@ -143,7 +144,7 @@ class RiemannianDKGRLVQ(RiemannianSRNG):
         super().__init__(
             manifold=manifold, beta=beta,
             gamma_init=gamma_init, gamma_final=gamma_final,
-            gamma_decay=gamma_decay, tau=tau,
+            gamma_decay=gamma_decay, tau=tau, lr_ratio=lr_ratio,
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
             random_seed=random_seed, optimizer=optimizer,

--- a/prosemble/models/riemannian_dk_slng.py
+++ b/prosemble/models/riemannian_dk_slng.py
@@ -124,7 +124,8 @@ class RiemannianDKSLNG(RiemannianSLNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -154,6 +155,7 @@ class RiemannianDKSLNG(RiemannianSLNG):
         )
         self.sigma_init = sigma_init
         self.sigma_min = sigma_min
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
 
     def _estimate_sigmas(self, X, y, params, proto_labels):
@@ -242,6 +244,11 @@ class RiemannianDKSLNG(RiemannianSLNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         transfer = self.transfer_fn or sigmoid_beta
@@ -316,4 +323,5 @@ class RiemannianDKSLNG(RiemannianSLNG):
         hp = super()._get_hyperparams()
         hp['sigma_init'] = self.sigma_init
         hp['sigma_min'] = self.sigma_min
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_smng.py
+++ b/prosemble/models/riemannian_dk_smng.py
@@ -124,7 +124,8 @@ class RiemannianDKSMNG(RiemannianSMNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -154,6 +155,7 @@ class RiemannianDKSMNG(RiemannianSMNG):
         )
         self.sigma_init = sigma_init
         self.sigma_min = sigma_min
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
 
     def _estimate_sigmas(self, X, y, params, proto_labels):
@@ -242,6 +244,11 @@ class RiemannianDKSMNG(RiemannianSMNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         transfer = self.transfer_fn or sigmoid_beta
@@ -316,4 +323,5 @@ class RiemannianDKSMNG(RiemannianSMNG):
         hp = super()._get_hyperparams()
         hp['sigma_init'] = self.sigma_init
         hp['sigma_min'] = self.sigma_min
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_dk_stng.py
+++ b/prosemble/models/riemannian_dk_stng.py
@@ -127,7 +127,8 @@ class RiemannianDKSTNG(RiemannianSTNG):
 
     def __init__(self, manifold, sigma_init='median', sigma_min=1e-3,
                  subspace_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None, tau=0.95,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
+                 tau=0.95,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, optimizer='adam',
                  transfer_fn=None, margin=0.0, callbacks=None,
@@ -157,6 +158,7 @@ class RiemannianDKSTNG(RiemannianSTNG):
         )
         self.sigma_init = sigma_init
         self.sigma_min = sigma_min
+        self.lr_ratio = lr_ratio
         self.sigmas_ = None
 
     def _estimate_sigmas(self, X, y, params, proto_labels):
@@ -249,6 +251,11 @@ class RiemannianDKSTNG(RiemannianSTNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         transfer = self.transfer_fn or sigmoid_beta
@@ -325,4 +332,5 @@ class RiemannianDKSTNG(RiemannianSTNG):
         hp = super()._get_hyperparams()
         hp['sigma_init'] = self.sigma_init
         hp['sigma_min'] = self.sigma_min
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_slng.py
+++ b/prosemble/models/riemannian_slng.py
@@ -95,7 +95,7 @@ class RiemannianSLNG(RiemannianSMNG):
 
     def __init__(self, manifold, latent_dim=None, beta=10.0,
                  gamma_init=None, gamma_final=0.01, gamma_decay=None,
-                 tau=0.95, n_prototypes_per_class=1, max_iter=100,
+                 lr_ratio=0.5, tau=0.95, n_prototypes_per_class=1, max_iter=100,
                  lr=0.01, epsilon=1e-6, random_seed=42,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=False, batch_size=None,
@@ -108,7 +108,7 @@ class RiemannianSLNG(RiemannianSMNG):
         super().__init__(
             manifold=manifold, latent_dim=latent_dim, beta=beta,
             gamma_init=gamma_init, gamma_final=gamma_final,
-            gamma_decay=gamma_decay, tau=tau,
+            gamma_decay=gamma_decay, lr_ratio=lr_ratio, tau=tau,
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
             random_seed=random_seed, optimizer=optimizer,
@@ -186,6 +186,11 @@ class RiemannianSLNG(RiemannianSMNG):
 
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
+
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
 
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 

--- a/prosemble/models/riemannian_smng.py
+++ b/prosemble/models/riemannian_smng.py
@@ -97,7 +97,7 @@ class RiemannianSMNG(RiemannianSRNG):
 
     def __init__(self, manifold, latent_dim=None, beta=10.0,
                  gamma_init=None, gamma_final=0.01, gamma_decay=None,
-                 tau=0.95, n_prototypes_per_class=1, max_iter=100,
+                 lr_ratio=0.5, tau=0.95, n_prototypes_per_class=1, max_iter=100,
                  lr=0.01, epsilon=1e-6, random_seed=42,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=False, batch_size=None,
@@ -110,7 +110,7 @@ class RiemannianSMNG(RiemannianSRNG):
         super().__init__(
             manifold=manifold, beta=beta,
             gamma_init=gamma_init, gamma_final=gamma_final,
-            gamma_decay=gamma_decay, tau=tau,
+            gamma_decay=gamma_decay, lr_ratio=lr_ratio, tau=tau,
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
             random_seed=random_seed, optimizer=optimizer,
@@ -237,6 +237,11 @@ class RiemannianSMNG(RiemannianSRNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         # 6. GLVQ mu
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
@@ -303,4 +308,5 @@ class RiemannianSMNG(RiemannianSRNG):
     def _get_hyperparams(self):
         hp = super()._get_hyperparams()
         hp['latent_dim'] = self.latent_dim
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/riemannian_srng.py
+++ b/prosemble/models/riemannian_srng.py
@@ -288,7 +288,7 @@ class RiemannianSRNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, manifold: Manifold, beta=10.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, tau=0.95, n_prototypes_per_class=1,
+                 gamma_decay=None, lr_ratio=0.5, tau=0.95, n_prototypes_per_class=1,
                  max_iter=100, lr=0.01, epsilon=1e-6, random_seed=42,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=False, batch_size=None,
@@ -318,6 +318,7 @@ class RiemannianSRNG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.tau = tau
         self.gamma_ = None
 
@@ -458,6 +459,11 @@ class RiemannianSRNG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         # 6. GLVQ mu
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
@@ -517,6 +523,7 @@ class RiemannianSRNG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         hp['tau'] = self.tau
         # Store manifold type and params for reconstruction
         manifold = self.manifold

--- a/prosemble/models/riemannian_stng.py
+++ b/prosemble/models/riemannian_stng.py
@@ -95,7 +95,7 @@ class RiemannianSTNG(RiemannianSMNG):
 
     def __init__(self, manifold, subspace_dim=None, beta=10.0,
                  gamma_init=None, gamma_final=0.01, gamma_decay=None,
-                 tau=0.95, n_prototypes_per_class=1, max_iter=100,
+                 lr_ratio=0.5, tau=0.95, n_prototypes_per_class=1, max_iter=100,
                  lr=0.01, epsilon=1e-6, random_seed=42,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=False, batch_size=None,
@@ -109,7 +109,7 @@ class RiemannianSTNG(RiemannianSMNG):
         super().__init__(
             manifold=manifold, latent_dim=None, beta=beta,
             gamma_init=gamma_init, gamma_final=gamma_final,
-            gamma_decay=gamma_decay, tau=tau,
+            gamma_decay=gamma_decay, lr_ratio=lr_ratio, tau=tau,
             n_prototypes_per_class=n_prototypes_per_class,
             max_iter=max_iter, lr=lr, epsilon=epsilon,
             random_seed=random_seed, optimizer=optimizer,
@@ -193,6 +193,11 @@ class RiemannianSTNG(RiemannianSMNG):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)
 
+        # Separate learning rates (Hammer et al. 2003: epsilon^- = lr_ratio * epsilon^+)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)
 
         transfer = self.transfer_fn or sigmoid_beta
@@ -259,4 +264,5 @@ class RiemannianSTNG(RiemannianSMNG):
         # Call RiemannianSRNG._get_hyperparams (skip SMNG's latent_dim)
         hp = RiemannianSMNG.__bases__[0]._get_hyperparams(self)
         hp['subspace_dim'] = self.subspace_dim
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/slng.py
+++ b/prosemble/models/slng.py
@@ -167,7 +167,7 @@ class SLNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, distance_fn=None,
                  optimizer='adam', transfer_fn=None, margin=0.0,
@@ -198,6 +198,7 @@ class SLNG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.omegas_ = None
         self.gamma_ = None
 
@@ -292,6 +293,11 @@ class SLNG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)  # (n,)
 
+        # 5b. Separate learning rates (Hammer et al. 2003: ε⁻ = lr_ratio × ε⁺)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         # 6. GLVQ mu for each (sample, same-class prototype) pair
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)  # (n, p)
 
@@ -350,6 +356,7 @@ class SLNG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         if self.latent_dim is not None:
             hp['latent_dim'] = self.latent_dim
         return hp

--- a/prosemble/models/smng.py
+++ b/prosemble/models/smng.py
@@ -168,7 +168,7 @@ class SMNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, latent_dim=None, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, distance_fn=None,
                  optimizer='adam', transfer_fn=None, margin=0.0,
@@ -199,6 +199,7 @@ class SMNG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.omega_ = None
         self.gamma_ = None
 
@@ -290,6 +291,11 @@ class SMNG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)  # (n,)
 
+        # 5b. Separate learning rates (Hammer et al. 2003: ε⁻ = lr_ratio × ε⁺)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         # 6. GLVQ mu for each (sample, same-class prototype) pair
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)  # (n, p)
 
@@ -362,6 +368,7 @@ class SMNG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         if self.latent_dim is not None:
             hp['latent_dim'] = self.latent_dim
         return hp

--- a/prosemble/models/srng.py
+++ b/prosemble/models/srng.py
@@ -128,7 +128,8 @@ class SRNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, beta=10.0, gamma_init=None, gamma_final=0.01,
-                 gamma_decay=None, n_prototypes_per_class=1, max_iter=100,
+                 gamma_decay=None, lr_ratio=0.5,
+                 n_prototypes_per_class=1, max_iter=100,
                  lr=0.01, epsilon=1e-6, random_seed=42, distance_fn=None,
                  optimizer='adam', transfer_fn=None, margin=0.0,
                  callbacks=None, use_scan=True, batch_size=None,
@@ -157,6 +158,7 @@ class SRNG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.relevances_ = None
         self.gamma_ = None
 
@@ -246,6 +248,11 @@ class SRNG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)  # (n,)
 
+        # 5b. Separate learning rates (Hammer et al. 2003: ε⁻ = lr_ratio × ε⁺)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         # 6. GLVQ mu for each (sample, same-class prototype) pair
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)  # (n, p)
 
@@ -303,4 +310,5 @@ class SRNG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         return hp

--- a/prosemble/models/stng.py
+++ b/prosemble/models/stng.py
@@ -172,7 +172,7 @@ class STNG(SupervisedPrototypeModel):
     """
 
     def __init__(self, subspace_dim=2, beta=10.0, gamma_init=None,
-                 gamma_final=0.01, gamma_decay=None,
+                 gamma_final=0.01, gamma_decay=None, lr_ratio=0.5,
                  n_prototypes_per_class=1, max_iter=100, lr=0.01,
                  epsilon=1e-6, random_seed=42, distance_fn=None,
                  optimizer='adam', transfer_fn=None, margin=0.0,
@@ -203,6 +203,7 @@ class STNG(SupervisedPrototypeModel):
         self.gamma_init = gamma_init
         self.gamma_final = gamma_final
         self.gamma_decay = gamma_decay
+        self.lr_ratio = lr_ratio
         self.omegas_ = None
         self.gamma_ = None
 
@@ -301,6 +302,11 @@ class STNG(SupervisedPrototypeModel):
         d_diff = jnp.where(~same_class, distances, INF)
         dm = jnp.min(d_diff, axis=1)  # (n,)
 
+        # 5b. Separate learning rates (Hammer et al. 2003: ε⁻ = lr_ratio × ε⁺)
+        # Scale gradient through dm by lr_ratio; forward pass unchanged.
+        dm = jax.lax.stop_gradient(dm) + self.lr_ratio * (
+            dm - jax.lax.stop_gradient(dm))
+
         # 6. GLVQ mu for each (sample, same-class prototype) pair
         mu = (distances - dm[:, None]) / (distances + dm[:, None] + 1e-10)  # (n, p)
 
@@ -361,4 +367,5 @@ class STNG(SupervisedPrototypeModel):
         hp['gamma_init'] = self.gamma_init
         hp['gamma_final'] = self.gamma_final
         hp['gamma_decay'] = self.gamma_decay
+        hp['lr_ratio'] = self.lr_ratio
         return hp


### PR DESCRIPTION
## Summary

- Adds `lr_ratio` parameter to all 20 Supervised Neural Gas model variants
- Implements Hammer et al. (2003) separate update rates: ε⁻ = lr_ratio × ε⁺ for correct vs wrong-class prototypes
- Uses JAX `stop_gradient` trick to scale gradients without changing the forward loss value
- Default `lr_ratio=0.5` matches the paper's recommendation
- Also updates 3 non-NG models (RiemannianDKGLVQ, RiemannianDKGMLVQ, RiemannianDKGRLVQ) that inherit from RiemannianSRNG for serialization compatibility

## Test plan

- [x] All 1783 tests pass (0 failures)
- [x] Verified lr_ratio=1.0 reproduces old behavior (backward compatible)
- [x] Verified lr_ratio=0.5 improves SLNG over baseline LGMLVQ on Pendigits